### PR TITLE
feat: Phase 1 — Skeleton, Protocol, and Snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["crates/tauri-plugin-pilot", "crates/tauri-pilot-cli"]
+
+[workspace.package]
+edition = "2024"
+license = "MIT"
+rust-version = "1.94.0"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1" }
+tracing = "0.1"
+
+[workspace.lints.clippy]
+unwrap_used = "deny"
+pedantic = { level = "warn", priority = -1 }

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,6 +40,7 @@
 | `value` | Get input value | `tauri-pilot value @e2` |
 | `attrs` | Get attributes | `tauri-pilot attrs @e1` |
 | `eval` | Run arbitrary JS | `tauri-pilot eval "document.title"` |
+| `ipc` | Invoke Tauri IPC command | `tauri-pilot ipc greet '{"name":"World"}'` |
 | `wait` | Wait for element | `tauri-pilot wait --selector ".loaded"` |
 | `navigate` | Go to URL | `tauri-pilot navigate "https://..."` |
 | `url` | Get current URL | `tauri-pilot url` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,96 @@
+# tauri-pilot — Skill for Claude Code
+
+## Overview
+
+`tauri-pilot` lets you inspect, interact with, and test a running Tauri v2 app via CLI. It communicates over a Unix socket using JSON-RPC 2.0.
+
+## Standard Workflow
+
+```
+1. ping          — verify connectivity
+2. snapshot -i   — get interactive elements with refs
+3. read refs     — inspect specific elements (text, value, attrs)
+4. act on refs   — click, fill, type, select, check
+5. snapshot -i   — verify result
+```
+
+## Rules
+
+1. **Always snapshot before interacting.** Refs reset on each snapshot call.
+2. **Prefer `snapshot -i`** (interactive only) to minimize output tokens.
+3. **Use `wait` after async actions** (navigation, data loading, animations).
+4. **Use `@ref` notation** (e.g., `@e3`) to target elements from the snapshot.
+5. **One action at a time**, then re-snapshot to verify.
+
+## Commands Reference
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `ping` | Check connectivity | `tauri-pilot ping` |
+| `snapshot` | Accessibility tree | `tauri-pilot snapshot -i` |
+| `click` | Click element | `tauri-pilot click @e3` |
+| `fill` | Set input value | `tauri-pilot fill @e2 "hello"` |
+| `type` | Type characters | `tauri-pilot type @e2 "abc"` |
+| `press` | Press key | `tauri-pilot press Enter` |
+| `select` | Select option | `tauri-pilot select @e5 "opt1"` |
+| `check` | Toggle checkbox | `tauri-pilot check @e6` |
+| `scroll` | Scroll page/element | `tauri-pilot scroll down 500` |
+| `text` | Get text content | `tauri-pilot text @e1` |
+| `html` | Get innerHTML | `tauri-pilot html @e1` |
+| `value` | Get input value | `tauri-pilot value @e2` |
+| `attrs` | Get attributes | `tauri-pilot attrs @e1` |
+| `eval` | Run arbitrary JS | `tauri-pilot eval "document.title"` |
+| `wait` | Wait for element | `tauri-pilot wait --selector ".loaded"` |
+| `navigate` | Go to URL | `tauri-pilot navigate "https://..."` |
+| `url` | Get current URL | `tauri-pilot url` |
+| `title` | Get page title | `tauri-pilot title` |
+| `state` | Get app state | `tauri-pilot state` |
+| `screenshot` | Capture PNG | `tauri-pilot screenshot ./out.png` |
+
+## Example Workflows
+
+### Test a login form
+
+```bash
+tauri-pilot ping
+tauri-pilot snapshot -i
+# Output: textbox "Email" [ref=e1], textbox "Password" [ref=e2], button "Login" [ref=e3]
+tauri-pilot fill @e1 "user@example.com"
+tauri-pilot fill @e2 "password123"
+tauri-pilot click @e3
+tauri-pilot wait --selector ".dashboard"
+tauri-pilot snapshot -i
+```
+
+### Verify page content
+
+```bash
+tauri-pilot snapshot
+# Full tree — look for specific text
+tauri-pilot text @e5
+tauri-pilot attrs @e5
+tauri-pilot html @e5
+```
+
+### Test navigation
+
+```bash
+tauri-pilot url
+tauri-pilot navigate "/settings"
+tauri-pilot wait --selector "#settings-page"
+tauri-pilot snapshot -i
+```
+
+## Flags
+
+- `--socket <path>` — Explicit socket path (auto-detected by default)
+- `--json` — Output raw JSON instead of compact text
+- `-i` / `--interactive` — Snapshot interactive elements only
+- `-s` / `--selector` — Scope snapshot to CSS selector
+- `-d` / `--depth` — Limit snapshot depth
+
+## Socket Auto-Detection
+
+If `--socket` is not provided, the CLI looks for:
+1. `$TAURI_PILOT_SOCKET` env var
+2. Most recent `/tmp/tauri-pilot-*.sock` file

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -20,6 +20,7 @@ tracing.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+base64 = "0.22.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "io-util"] }
 tracing.workspace = true
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tauri-pilot-cli"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "tauri-pilot"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "io-util"] }
+tracing.workspace = true
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+assert_cmd = "2"

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -1,0 +1,23 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "tauri-pilot", about = "Interactive testing CLI for Tauri apps")]
+pub(crate) struct Cli {
+    /// Socket path (auto-detected if omitted).
+    #[arg(long, env = "TAURI_PILOT_SOCKET")]
+    pub socket: Option<PathBuf>,
+
+    /// Output JSON instead of text.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    /// Check connectivity with a running Tauri app.
+    Ping,
+}

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -20,4 +20,132 @@ pub(crate) struct Cli {
 pub(crate) enum Command {
     /// Check connectivity with a running Tauri app.
     Ping,
+    /// Get app state (url, title, ready).
+    State,
+    /// Capture an accessibility snapshot of the UI.
+    Snapshot {
+        #[arg(short, long)]
+        interactive: bool,
+        #[arg(short, long)]
+        selector: Option<String>,
+        #[arg(short, long)]
+        depth: Option<u8>,
+    },
+    /// Click an element.
+    Click { target: String },
+    /// Clear and fill an input with a value.
+    Fill { target: String, value: String },
+    /// Type text character by character.
+    Type { target: String, text: String },
+    /// Press a keyboard key.
+    Press { key: String },
+    /// Select an option in a <select>.
+    Select { target: String, value: String },
+    /// Toggle a checkbox.
+    Check { target: String },
+    /// Scroll the page or an element.
+    Scroll {
+        direction: String,
+        amount: Option<i32>,
+        #[arg(long)]
+        r#ref: Option<String>,
+    },
+    /// Get text content of an element.
+    Text { target: String },
+    /// Get inner HTML (of an element, or full page).
+    Html { target: Option<String> },
+    /// Get the value of an input/select/textarea.
+    Value { target: String },
+    /// Get all attributes of an element.
+    Attrs { target: String },
+    /// Evaluate arbitrary JavaScript.
+    Eval { script: String },
+    /// Invoke a Tauri IPC command.
+    Ipc {
+        command: String,
+        #[arg(long)]
+        args: Option<String>,
+    },
+    /// Capture a screenshot (PNG).
+    Screenshot {
+        path: Option<PathBuf>,
+        #[arg(long)]
+        selector: Option<String>,
+    },
+    /// Navigate to a URL.
+    Navigate { url: String },
+    /// Get current URL.
+    Url,
+    /// Get page title.
+    Title,
+    /// Wait for an element or condition.
+    Wait {
+        target: Option<String>,
+        #[arg(long)]
+        selector: Option<String>,
+        #[arg(long)]
+        gone: bool,
+        #[arg(long, default_value = "10000")]
+        timeout: u64,
+    },
+}
+
+/// Parsed target for element-targeting commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Target {
+    Ref(String),
+    Selector(String),
+    Coords(i32, i32),
+}
+
+/// Parse a target string into a `Target` variant.
+pub(crate) fn parse_target(s: &str) -> Target {
+    if let Some(r) = s.strip_prefix('@') {
+        return Target::Ref(r.to_owned());
+    }
+
+    if let Some((x_str, y_str)) = s.split_once(',')
+        && let (Ok(x), Ok(y)) = (x_str.trim().parse::<i32>(), y_str.trim().parse::<i32>())
+    {
+        return Target::Coords(x, y);
+    }
+
+    Target::Selector(s.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_target_ref() {
+        assert_eq!(parse_target("@e1"), Target::Ref("e1".to_owned()));
+        assert_eq!(parse_target("@e42"), Target::Ref("e42".to_owned()));
+    }
+
+    #[test]
+    fn test_parse_target_selector() {
+        assert_eq!(
+            parse_target("#submit-btn"),
+            Target::Selector("#submit-btn".to_owned())
+        );
+        assert_eq!(
+            parse_target(".class"),
+            Target::Selector(".class".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_target_coords() {
+        assert_eq!(parse_target("100,200"), Target::Coords(100, 200));
+        assert_eq!(parse_target("0, 0"), Target::Coords(0, 0));
+    }
+
+    #[test]
+    fn test_parse_target_invalid_coords_as_selector() {
+        assert_eq!(
+            parse_target("abc,def"),
+            Target::Selector("abc,def".to_owned())
+        );
+    }
 }

--- a/crates/tauri-pilot-cli/src/client.rs
+++ b/crates/tauri-pilot-cli/src/client.rs
@@ -57,6 +57,10 @@ impl Client {
 
         let response: Response = serde_json::from_str(line.trim())?;
 
+        if response.id != id {
+            bail!("Response ID mismatch: expected {id}, got {}", response.id);
+        }
+
         if let Some(err) = response.error {
             bail!("RPC error ({}): {}", err.code, err.message);
         }
@@ -99,13 +103,25 @@ mod tests {
         })
     }
 
+    /// Connect with retry to avoid race with server bind.
+    async fn connect_with_retry(path: &Path) -> Client {
+        for _ in 0..20 {
+            match Client::connect(path).await {
+                Ok(c) => return c,
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+        Client::connect(path)
+            .await
+            .expect("Failed to connect after retries")
+    }
+
     #[tokio::test]
     async fn test_client_ping_returns_ok() {
         let socket = PathBuf::from("/tmp/tauri-pilot-test-t05a.sock");
         let handle = mock_server(&socket).await;
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut client = Client::connect(&socket).await.unwrap();
+        let mut client = connect_with_retry(&socket).await;
         let result = client.call("ping", None).await.unwrap();
         assert_eq!(result, serde_json::json!({"status": "ok"}));
 
@@ -117,9 +133,8 @@ mod tests {
     async fn test_client_unknown_method_returns_error() {
         let socket = PathBuf::from("/tmp/tauri-pilot-test-t05b.sock");
         let handle = mock_server(&socket).await;
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut client = Client::connect(&socket).await.unwrap();
+        let mut client = connect_with_retry(&socket).await;
         let result = client.call("nonexistent", None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("-32601"));

--- a/crates/tauri-pilot-cli/src/client.rs
+++ b/crates/tauri-pilot-cli/src/client.rs
@@ -1,0 +1,139 @@
+use crate::protocol::{Request, Response};
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+
+/// JSON-RPC client over a Unix socket.
+pub(crate) struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+    next_id: u64,
+}
+
+impl Client {
+    /// Connect to the tauri-pilot socket.
+    pub async fn connect(path: &Path) -> Result<Self> {
+        let stream = UnixStream::connect(path)
+            .await
+            .with_context(|| format!("Cannot connect to socket: {}", path.display()))?;
+
+        let (reader, writer) = stream.into_split();
+        Ok(Self {
+            reader: BufReader::new(reader),
+            writer,
+            next_id: 1,
+        })
+    }
+
+    /// Send a JSON-RPC request and return the result value.
+    pub async fn call(
+        &mut self,
+        method: &str,
+        params: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let request = Request {
+            jsonrpc: "2.0".to_owned(),
+            id,
+            method: method.to_owned(),
+            params,
+        };
+
+        let mut bytes = serde_json::to_vec(&request)?;
+        bytes.push(b'\n');
+        self.writer.write_all(&bytes).await?;
+        self.writer.flush().await?;
+
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).await?;
+        if n == 0 {
+            bail!("Server closed the connection");
+        }
+
+        let response: Response = serde_json::from_str(line.trim())?;
+
+        if let Some(err) = response.error {
+            bail!("RPC error ({}): {}", err.code, err.message);
+        }
+
+        response
+            .result
+            .context("Server returned empty result without error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixListener;
+
+    async fn mock_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
+        let _ = std::fs::remove_file(path);
+        let listener = UnixListener::bind(path).unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            while reader.read_line(&mut line).await.unwrap() > 0 {
+                let req: Request = serde_json::from_str(line.trim()).unwrap();
+                let resp = if req.method == "ping" {
+                    Response::success(req.id, serde_json::json!({"status": "ok"}))
+                } else {
+                    Response::error(req.id, -32601, "Method not found")
+                };
+                let mut bytes = serde_json::to_vec(&resp).unwrap();
+                bytes.push(b'\n');
+                writer.write_all(&bytes).await.unwrap();
+                writer.flush().await.unwrap();
+                line.clear();
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_client_ping_returns_ok() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05a.sock");
+        let handle = mock_server(&socket).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = Client::connect(&socket).await.unwrap();
+        let result = client.call("ping", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({"status": "ok"}));
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_client_unknown_method_returns_error() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05b.sock");
+        let handle = mock_server(&socket).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut client = Client::connect(&socket).await.unwrap();
+        let result = client.call("nonexistent", None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("-32601"));
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_client_connect_failure() {
+        let err = Client::connect(Path::new("/tmp/tauri-pilot-nonexistent.sock"))
+            .await
+            .map(|_| ())
+            .expect_err("should fail to connect");
+        assert!(err.to_string().contains("Cannot connect"));
+    }
+}

--- a/crates/tauri-pilot-cli/src/error.rs
+++ b/crates/tauri-pilot-cli/src/error.rs
@@ -1,2 +1,2 @@
-/// Re-export anyhow types for convenience.
-pub use anyhow::Result;
+// Error types for the CLI crate.
+// Using anyhow directly in each module — no shared re-exports needed yet.

--- a/crates/tauri-pilot-cli/src/error.rs
+++ b/crates/tauri-pilot-cli/src/error.rs
@@ -1,0 +1,2 @@
+/// Re-export anyhow types for convenience.
+pub use anyhow::Result;

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1,0 +1,15 @@
+mod error;
+
+use error::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    Ok(())
+}

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -187,8 +187,7 @@ fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
 
     // Auto-detect: find the most recent tauri-pilot-*.sock in /tmp
     let mut candidates: Vec<PathBuf> = std::fs::read_dir("/tmp")
-        .into_iter()
-        .flatten()
+        .map_err(|e| anyhow::anyhow!("Failed to read /tmp: {e}"))?
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -5,6 +5,7 @@ mod output;
 mod protocol;
 
 use anyhow::Result;
+use base64::Engine;
 use clap::Parser;
 use serde_json::json;
 use std::path::PathBuf;
@@ -26,7 +27,19 @@ async fn main() -> Result<()> {
     let mut client = Client::connect(&socket).await?;
 
     let is_snapshot = matches!(args.command, Command::Snapshot { .. });
+    let screenshot_path = if let Command::Screenshot { ref path, .. } = args.command {
+        path.clone()
+    } else {
+        None
+    };
     let result = run_command(&mut client, args.command).await?;
+
+    // Screenshot save-to-file: decode base64 data URL and write PNG
+    if let Some(path) = screenshot_path {
+        save_screenshot(&result, &path)?;
+        println!("Saved to {}", path.display());
+        return Ok(());
+    }
 
     if args.json {
         output::format_json(&result)?;
@@ -146,6 +159,24 @@ fn target_params(raw: &str) -> serde_json::Value {
         Target::Selector(s) => json!({"selector": s}),
         Target::Coords(x, y) => json!({"x": x, "y": y}),
     }
+}
+
+/// Decode a base64 data URL and write the PNG file.
+fn save_screenshot(result: &serde_json::Value, path: &std::path::Path) -> Result<()> {
+    let data_url = result
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Screenshot result is not a string"))?;
+
+    let base64_data = data_url
+        .strip_prefix("data:image/png;base64,")
+        .unwrap_or(data_url);
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64_data)
+        .map_err(|e| anyhow::anyhow!("Failed to decode base64: {e}"))?;
+
+    std::fs::write(path, bytes)?;
+    Ok(())
 }
 
 /// Resolve the socket path from explicit arg, env var, or auto-detection.

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1,4 +1,6 @@
 mod error;
+#[allow(dead_code)]
+mod protocol;
 
 use error::Result;
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -25,10 +25,13 @@ async fn main() -> Result<()> {
     let socket = resolve_socket(args.socket)?;
     let mut client = Client::connect(&socket).await?;
 
+    let is_snapshot = matches!(args.command, Command::Snapshot { .. });
     let result = run_command(&mut client, args.command).await?;
 
     if args.json {
         output::format_json(&result)?;
+    } else if is_snapshot {
+        output::format_snapshot(&result);
     } else {
         output::format_text(&result);
     }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1,8 +1,14 @@
-mod error;
+mod cli;
+mod client;
 #[allow(dead_code)]
 mod protocol;
 
-use error::Result;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+use cli::{Cli, Command};
+use client::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -13,5 +19,53 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    let args = Cli::parse();
+    let socket = resolve_socket(args.socket)?;
+    let mut client = Client::connect(&socket).await?;
+
+    match args.command {
+        Command::Ping => {
+            let result = client.call("ping", None).await?;
+            if args.json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            } else {
+                println!("ok");
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Resolve the socket path from explicit arg, env var, or auto-detection.
+fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(path) = explicit {
+        return Ok(path);
+    }
+
+    // Auto-detect: find the most recent tauri-pilot-*.sock in /tmp
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir("/tmp")
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                n.starts_with("tauri-pilot-")
+                    && std::path::Path::new(n)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("sock"))
+            })
+        })
+        .collect();
+
+    candidates.sort_by_key(|p| {
+        std::fs::metadata(p)
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+
+    candidates
+        .pop()
+        .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1,13 +1,15 @@
 mod cli;
 mod client;
+mod output;
 #[allow(dead_code)]
 mod protocol;
 
 use anyhow::Result;
 use clap::Parser;
+use serde_json::json;
 use std::path::PathBuf;
 
-use cli::{Cli, Command};
+use cli::{Cli, Command, Target, parse_target};
 use client::Client;
 
 #[tokio::main]
@@ -23,18 +25,124 @@ async fn main() -> Result<()> {
     let socket = resolve_socket(args.socket)?;
     let mut client = Client::connect(&socket).await?;
 
-    match args.command {
-        Command::Ping => {
-            let result = client.call("ping", None).await?;
-            if args.json {
-                println!("{}", serde_json::to_string_pretty(&result)?);
-            } else {
-                println!("ok");
-            }
-        }
+    let result = run_command(&mut client, args.command).await?;
+
+    if args.json {
+        output::format_json(&result)?;
+    } else {
+        output::format_text(&result);
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+async fn run_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {
+    match command {
+        Command::Ping => client.call("ping", None).await,
+        Command::State => client.call("state", None).await,
+        Command::Snapshot {
+            interactive,
+            selector,
+            depth,
+        } => {
+            client
+                .call(
+                    "snapshot",
+                    Some(json!({
+                        "interactive": interactive,
+                        "selector": selector,
+                        "depth": depth,
+                    })),
+                )
+                .await
+        }
+        Command::Click { target } => client.call("click", Some(target_params(&target))).await,
+        Command::Fill { target, value } => {
+            let mut p = target_params(&target);
+            p["value"] = json!(value);
+            client.call("fill", Some(p)).await
+        }
+        Command::Type { target, text } => {
+            let mut p = target_params(&target);
+            p["text"] = json!(text);
+            client.call("type", Some(p)).await
+        }
+        Command::Press { key } => client.call("press", Some(json!({"key": key}))).await,
+        Command::Select { target, value } => {
+            let mut p = target_params(&target);
+            p["value"] = json!(value);
+            client.call("select", Some(p)).await
+        }
+        Command::Check { target } => client.call("check", Some(target_params(&target))).await,
+        Command::Scroll {
+            direction,
+            amount,
+            r#ref,
+        } => {
+            client
+                .call(
+                    "scroll",
+                    Some(json!({"direction": direction, "amount": amount, "ref": r#ref})),
+                )
+                .await
+        }
+        Command::Text { target } => client.call("text", Some(target_params(&target))).await,
+        Command::Html { target } => {
+            let params = target.map(|t| target_params(&t));
+            client.call("html", params).await
+        }
+        Command::Value { target } => client.call("value", Some(target_params(&target))).await,
+        Command::Attrs { target } => client.call("attrs", Some(target_params(&target))).await,
+        Command::Eval { script } => client.call("eval", Some(json!({"script": script}))).await,
+        Command::Ipc { command, args } => {
+            let parsed_args: Option<serde_json::Value> =
+                args.as_deref().map(serde_json::from_str).transpose()?;
+            client
+                .call(
+                    "ipc",
+                    Some(json!({"command": command, "args": parsed_args})),
+                )
+                .await
+        }
+        Command::Screenshot { path, selector } => {
+            client
+                .call(
+                    "screenshot",
+                    Some(json!({"path": path, "selector": selector})),
+                )
+                .await
+        }
+        Command::Navigate { url } => client.call("navigate", Some(json!({"url": url}))).await,
+        Command::Url => client.call("url", None).await,
+        Command::Title => client.call("title", None).await,
+        Command::Wait {
+            target,
+            selector,
+            gone,
+            timeout,
+        } => {
+            client
+                .call(
+                    "wait",
+                    Some(json!({
+                        "target": target,
+                        "selector": selector,
+                        "gone": gone,
+                        "timeout": timeout,
+                    })),
+                )
+                .await
+        }
+    }
+}
+
+fn target_params(raw: &str) -> serde_json::Value {
+    match parse_target(raw) {
+        Target::Ref(r) => json!({"ref": r}),
+        Target::Selector(s) => json!({"selector": s}),
+        Target::Coords(x, y) => json!({"x": x, "y": y}),
+    }
 }
 
 /// Resolve the socket path from explicit arg, env var, or auto-detection.

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -10,6 +10,16 @@ pub(crate) fn format_json(value: &serde_json::Value) -> Result<()> {
 
 /// Print a value as compact text for human consumption.
 pub(crate) fn format_text(value: &serde_json::Value) {
+    // {ok: true} → "ok"
+    if value.get("ok").and_then(serde_json::Value::as_bool) == Some(true) {
+        println!("ok");
+        return;
+    }
+    // {status: "ok"} → "ok"
+    if let Some(status) = value.get("status").and_then(serde_json::Value::as_str) {
+        println!("{status}");
+        return;
+    }
     match value {
         serde_json::Value::String(s) => println!("{s}"),
         serde_json::Value::Null => {}

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use anyhow::Result;
 
 /// Print a value as pretty JSON.
@@ -15,6 +17,52 @@ pub(crate) fn format_text(value: &serde_json::Value) {
     }
 }
 
+/// Format a snapshot result as an indented accessibility tree.
+pub(crate) fn format_snapshot(value: &serde_json::Value) {
+    let Some(elements) = value.get("elements").and_then(|e| e.as_array()) else {
+        println!("(empty snapshot)");
+        return;
+    };
+
+    for el in elements {
+        let depth = usize::try_from(
+            el.get("depth")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+        )
+        .unwrap_or(0);
+        let indent = "  ".repeat(depth);
+        let role = el
+            .get("role")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+        let r#ref = el
+            .get("ref")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("?");
+
+        let mut line = format!("{indent}- {role}");
+
+        if let Some(name) = el.get("name").and_then(serde_json::Value::as_str) {
+            let _ = write!(line, " \"{name}\"");
+        }
+
+        let _ = write!(line, " [ref={ref}]");
+
+        if let Some(val) = el.get("value").and_then(serde_json::Value::as_str) {
+            let _ = write!(line, " value=\"{val}\"");
+        }
+        if el.get("checked").and_then(serde_json::Value::as_bool) == Some(true) {
+            line.push_str(" checked");
+        }
+        if el.get("disabled").and_then(serde_json::Value::as_bool) == Some(true) {
+            line.push_str(" disabled");
+        }
+
+        println!("{line}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,9 +74,24 @@ mod tests {
     }
 
     #[test]
-    fn test_format_text_does_not_panic() {
-        format_text(&json!("hello"));
-        format_text(&json!(42));
-        format_text(&json!(null));
+    fn test_format_snapshot_with_elements() {
+        let snapshot = json!({
+            "elements": [
+                {"ref": "e1", "role": "heading", "name": "Title", "depth": 0},
+                {"ref": "e2", "role": "textbox", "name": "Search", "depth": 1, "value": ""},
+                {"ref": "e3", "role": "button", "name": "Submit", "depth": 1},
+                {"ref": "e4", "role": "checkbox", "name": "Agree", "depth": 1, "checked": true},
+                {"ref": "e5", "role": "button", "name": "Disabled", "depth": 2, "disabled": true},
+            ]
+        });
+        // Just verify it doesn't panic — output goes to stdout
+        format_snapshot(&snapshot);
+    }
+
+    #[test]
+    fn test_format_snapshot_empty() {
+        format_snapshot(&json!({"elements": []}));
+        format_snapshot(&json!({}));
+        format_snapshot(&json!(null));
     }
 }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+
+/// Print a value as pretty JSON.
+pub(crate) fn format_json(value: &serde_json::Value) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+/// Print a value as compact text for human consumption.
+pub(crate) fn format_text(value: &serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => println!("{s}"),
+        serde_json::Value::Null => {}
+        other => println!("{other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_format_json_does_not_panic() {
+        format_json(&json!({"status": "ok"})).unwrap();
+    }
+
+    #[test]
+    fn test_format_text_does_not_panic() {
+        format_text(&json!("hello"));
+        format_text(&json!(42));
+        format_text(&json!(null));
+    }
+}

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -36,6 +36,11 @@ pub(crate) fn format_snapshot(value: &serde_json::Value) {
         return;
     };
 
+    if elements.is_empty() {
+        println!("(empty snapshot)");
+        return;
+    }
+
     for el in elements {
         let depth = usize::try_from(
             el.get("depth")

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -10,10 +10,12 @@ pub(crate) fn format_json(value: &serde_json::Value) -> Result<()> {
 
 /// Print a value as compact text for human consumption.
 pub(crate) fn format_text(value: &serde_json::Value) {
-    // {ok: true} → "ok"
-    if value.get("ok").and_then(serde_json::Value::as_bool) == Some(true) {
-        println!("ok");
-        return;
+    // {ok: true} → "ok", {found: true} → "found"
+    for key in ["ok", "found"] {
+        if value.get(key).and_then(serde_json::Value::as_bool) == Some(true) {
+            println!("{key}");
+            return;
+        }
     }
     // {status: "ok"} → "ok"
     if let Some(status) = value.get("status").and_then(serde_json::Value::as_str) {

--- a/crates/tauri-pilot-cli/src/protocol.rs
+++ b/crates/tauri-pilot-cli/src/protocol.rs
@@ -1,4 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize params, normalizing `null` to `None`.
+fn deserialize_params<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    match val {
+        Some(serde_json::Value::Null) => Ok(None),
+        other => Ok(other),
+    }
+}
 
 /// A JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -6,7 +18,7 @@ pub struct Request {
     pub jsonrpc: String,
     pub id: u64,
     pub method: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_params")]
     pub params: Option<serde_json::Value>,
 }
 
@@ -70,7 +82,7 @@ mod tests {
         assert_eq!(req.jsonrpc, "2.0");
         assert_eq!(req.id, 1);
         assert_eq!(req.method, "ping");
-        assert!(req.params.is_none() || req.params == Some(serde_json::Value::Null));
+        assert!(req.params.is_none(), "null params should normalize to None");
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/protocol.rs
+++ b/crates/tauri-pilot-cli/src/protocol.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+
+/// A JSON-RPC 2.0 request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub id: u64,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    pub jsonrpc: String,
+    pub id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl Response {
+    /// Create a success response.
+    #[must_use]
+    pub fn success(id: u64, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_owned(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// Create an error response.
+    #[must_use]
+    pub fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_owned(),
+            id,
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_deserialize_request_with_params() {
+        let raw = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":null}"#;
+        let req: Request = serde_json::from_str(raw).expect("deserialize");
+        assert_eq!(req.jsonrpc, "2.0");
+        assert_eq!(req.id, 1);
+        assert_eq!(req.method, "ping");
+        assert!(req.params.is_none() || req.params == Some(serde_json::Value::Null));
+    }
+
+    #[test]
+    fn test_deserialize_request_without_params() {
+        let raw = r#"{"jsonrpc":"2.0","id":2,"method":"snapshot"}"#;
+        let req: Request = serde_json::from_str(raw).expect("deserialize");
+        assert_eq!(req.method, "snapshot");
+        assert!(req.params.is_none());
+    }
+
+    #[test]
+    fn test_serialize_success_response() {
+        let resp = Response::success(1, json!({"status": "ok"}));
+        let v: serde_json::Value = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(v["result"]["status"], "ok");
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn test_serialize_error_response() {
+        let resp = Response::error(1, -32601, "Method not found");
+        let s = serde_json::to_string(&resp).expect("serialize");
+        assert!(s.contains(r#""error""#));
+        assert!(!s.contains(r#""result""#));
+        assert!(s.contains("-32601"));
+    }
+
+    #[test]
+    fn test_roundtrip_request() {
+        let req = Request {
+            jsonrpc: "2.0".to_owned(),
+            id: 42,
+            method: "click".to_owned(),
+            params: Some(json!({"ref": "e1"})),
+        };
+        let serialized = serde_json::to_string(&req).expect("serialize");
+        let deserialized: Request = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(deserialized.id, 42);
+        assert_eq!(deserialized.method, "click");
+    }
+
+    #[test]
+    fn test_roundtrip_response() {
+        let resp = Response::success(7, json!([1, 2, 3]));
+        let serialized = serde_json::to_string(&resp).expect("serialize");
+        let deserialized: Response = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(deserialized.id, 7);
+        assert_eq!(deserialized.result, Some(json!([1, 2, 3])));
+        assert!(deserialized.error.is_none());
+    }
+}

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util"] 
 tracing.workspace = true
 thiserror = "2"
 tauri = { version = "2", features = ["unstable"] }
+libc = "0.2.184"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+links = "tauri-plugin-pilot"
 
 [lints]
 workspace = true
@@ -19,3 +20,6 @@ libc = "0.2.184"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
+
+[build-dependencies]
+tauri-plugin = { version = "2.5.4", features = ["build"] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tauri-plugin-pilot"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util"] }
+tracing.workspace = true
+thiserror = "2"
+tauri = { version = "2", features = ["unstable"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/build.rs
+++ b/crates/tauri-plugin-pilot/build.rs
@@ -1,0 +1,5 @@
+const COMMANDS: &[&str] = &["__callback"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+}

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -193,8 +193,23 @@
     return el;
   }
 
+  function resolveTarget(params) {
+    if (params.ref) return requireEl(params.ref);
+    if (params.selector) {
+      var el = document.querySelector(params.selector);
+      if (!el) throw new Error("No element matches selector: " + params.selector);
+      return el;
+    }
+    if (params.x != null && params.y != null) {
+      var el = document.elementFromPoint(params.x, params.y);
+      if (!el) throw new Error("No element at (" + params.x + "," + params.y + ")");
+      return el;
+    }
+    throw new Error("No ref, selector, or coordinates provided");
+  }
+
   function click(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     el.focus();
     el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
@@ -203,7 +218,7 @@
   }
 
   function fill(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     el.focus();
     const setter =
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
@@ -219,7 +234,7 @@
   }
 
   function typeText(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     el.focus();
     const setter =
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
@@ -246,7 +261,7 @@
   }
 
   function select(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
     if (setter && setter.set) {
       setter.set.call(el, params.value);
@@ -258,7 +273,7 @@
   }
 
   function check(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     el.checked = !el.checked;
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
@@ -276,21 +291,22 @@
   }
 
   function text(params) {
-    return requireEl(params.ref || params.selector).textContent || "";
+    return resolveTarget(params).textContent || "";
   }
 
   function html(params) {
-    var ref = params && params.ref;
-    const el = ref ? requireEl(ref) : document.documentElement;
-    return el.innerHTML;
+    if (params && (params.ref || params.selector)) {
+      return resolveTarget(params).innerHTML;
+    }
+    return document.documentElement.innerHTML;
   }
 
   function value(params) {
-    return requireEl(params.ref || params.selector).value || "";
+    return resolveTarget(params).value || "";
   }
 
   function attrs(params) {
-    const el = requireEl(params.ref || params.selector);
+    const el = resolveTarget(params);
     const result = {};
     for (const attr of el.attributes) {
       result[attr.name] = attr.value;

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -193,8 +193,8 @@
     return el;
   }
 
-  function click(ref) {
-    const el = requireEl(ref);
+  function click(params) {
+    const el = requireEl(params.ref || params.selector);
     el.focus();
     el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
@@ -202,29 +202,29 @@
     return { ok: true };
   }
 
-  function fill(ref, value) {
-    const el = requireEl(ref);
+  function fill(params) {
+    const el = requireEl(params.ref || params.selector);
     el.focus();
     const setter =
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
       Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
     if (setter && setter.set) {
-      setter.set.call(el, value);
+      setter.set.call(el, params.value);
     } else {
-      el.value = value;
+      el.value = params.value;
     }
     el.dispatchEvent(new Event("input", { bubbles: true }));
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
   }
 
-  function typeText(ref, text) {
-    const el = requireEl(ref);
+  function typeText(params) {
+    const el = requireEl(params.ref || params.selector);
     el.focus();
     const setter =
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
       Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
-    for (const ch of text) {
+    for (const ch of params.text) {
       el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
       if (setter && setter.set) {
         setter.set.call(el, el.value + ch);
@@ -237,27 +237,28 @@
     return { ok: true };
   }
 
-  function press(key) {
+  function press(params) {
+    var key = params.key || params;
     const target = document.activeElement || document.body;
     target.dispatchEvent(new KeyboardEvent("keydown", { key: key, bubbles: true }));
     target.dispatchEvent(new KeyboardEvent("keyup", { key: key, bubbles: true }));
     return { ok: true };
   }
 
-  function select(ref, value) {
-    const el = requireEl(ref);
+  function select(params) {
+    const el = requireEl(params.ref || params.selector);
     const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
     if (setter && setter.set) {
-      setter.set.call(el, value);
+      setter.set.call(el, params.value);
     } else {
-      el.value = value;
+      el.value = params.value;
     }
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
   }
 
-  function check(ref) {
-    const el = requireEl(ref);
+  function check(params) {
+    const el = requireEl(params.ref || params.selector);
     el.checked = !el.checked;
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
@@ -274,22 +275,22 @@
     return { ok: true };
   }
 
-  function text(ref) {
-    return requireEl(ref).textContent || "";
+  function text(params) {
+    return requireEl(params.ref || params.selector).textContent || "";
   }
 
-  function html(options) {
-    const ref = options && options.ref;
+  function html(params) {
+    var ref = params && params.ref;
     const el = ref ? requireEl(ref) : document.documentElement;
     return el.innerHTML;
   }
 
-  function value(ref) {
-    return requireEl(ref).value || "";
+  function value(params) {
+    return requireEl(params.ref || params.selector).value || "";
   }
 
-  function attrs(ref) {
-    const el = requireEl(ref);
+  function attrs(params) {
+    const el = requireEl(params.ref || params.selector);
     const result = {};
     for (const attr of el.attributes) {
       result[attr.name] = attr.value;

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -242,6 +242,59 @@
     return { ok: true };
   }
 
+  function text(ref) {
+    return requireEl(ref).textContent || "";
+  }
+
+  function html(options) {
+    const ref = options && options.ref;
+    const el = ref ? requireEl(ref) : document.documentElement;
+    return el.innerHTML;
+  }
+
+  function value(ref) {
+    return requireEl(ref).value || "";
+  }
+
+  function attrs(ref) {
+    const el = requireEl(ref);
+    const result = {};
+    for (const attr of el.attributes) {
+      result[attr.name] = attr.value;
+    }
+    return result;
+  }
+
+  function navigate(options) {
+    const url = options && options.url;
+    if (url) window.location.href = url;
+    return { ok: true };
+  }
+
+  function url() {
+    return window.location.href;
+  }
+
+  function title() {
+    return document.title;
+  }
+
+  function state() {
+    return {
+      url: window.location.href,
+      title: document.title,
+      readyState: document.readyState,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      scroll: { x: window.scrollX, y: window.scrollY },
+    };
+  }
+
+  function evalScript(options) {
+    var script = options && options.script;
+    if (!script) throw new Error("No script provided");
+    return new Function("return (" + script + ")")();
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
@@ -252,5 +305,14 @@
     select: select,
     check: check,
     scroll: scroll,
+    text: text,
+    html: html,
+    value: value,
+    attrs: attrs,
+    navigate: navigate,
+    url: url,
+    title: title,
+    state: state,
+    eval: evalScript,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -45,6 +45,8 @@
   function inputRole(el) {
     const t = (el.getAttribute("type") || "text").toLowerCase();
     switch (t) {
+      case "hidden":
+        return null;
       case "checkbox":
         return "checkbox";
       case "radio":
@@ -100,8 +102,11 @@
 
   function isInteractiveElement(el) {
     const tag = el.tagName;
+    if (tag === "INPUT") {
+      const t = (el.getAttribute("type") || "text").toLowerCase();
+      return t !== "hidden";
+    }
     if (
-      tag === "INPUT" ||
       tag === "BUTTON" ||
       tag === "SELECT" ||
       tag === "TEXTAREA" ||
@@ -122,7 +127,16 @@
     refCounter = 0;
     idMap.clear();
 
-    const root = selector ? document.querySelector(selector) : document.body;
+    var root;
+    if (selector) {
+      try {
+        root = document.querySelector(selector);
+      } catch (e) {
+        throw new Error("Invalid selector: " + selector);
+      }
+    } else {
+      root = document.body;
+    }
     if (!root) return { elements: [] };
 
     const elements = [];
@@ -136,7 +150,7 @@
 
       if (interactive && !isInteractive) {
         for (const child of node.children) {
-          walk(child, currentDepth);
+          walk(child, currentDepth + 1);
         }
         return;
       }
@@ -150,7 +164,12 @@
         const name = getName(node);
         if (name) entry.name = name;
         if (node.value !== undefined && node.value !== "") entry.value = node.value;
-        if (node.checked !== undefined) entry.checked = node.checked;
+        if (node.tagName === "INPUT") {
+          var inputType = (node.getAttribute("type") || "text").toLowerCase();
+          if (inputType === "checkbox" || inputType === "radio") {
+            entry.checked = node.checked;
+          }
+        }
         if (node.disabled) entry.disabled = true;
         elements.push(entry);
       }
@@ -202,8 +221,16 @@
   function typeText(ref, text) {
     const el = requireEl(ref);
     el.focus();
+    const setter =
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
     for (const ch of text) {
       el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
+      if (setter && setter.set) {
+        setter.set.call(el, el.value + ch);
+      } else {
+        el.value += ch;
+      }
       el.dispatchEvent(new InputEvent("input", { data: ch, inputType: "insertText", bubbles: true }));
       el.dispatchEvent(new KeyboardEvent("keyup", { key: ch, bubbles: true }));
     }
@@ -219,7 +246,12 @@
 
   function select(ref, value) {
     const el = requireEl(ref);
-    el.value = value;
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
+    if (setter && setter.set) {
+      setter.set.call(el, value);
+    } else {
+      el.value = value;
+    }
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
   }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -338,6 +338,17 @@
     });
   }
 
+  async function screenshot(options) {
+    var selector = options && options.selector;
+    var el = selector ? document.querySelector(selector) : document.documentElement;
+    if (!el) throw new Error("Element not found: " + selector);
+    if (typeof htmlToImage === "undefined" || !htmlToImage.toPng) {
+      throw new Error("html-to-image library not loaded. Bundle it into bridge.js for screenshot support.");
+    }
+    var dataUrl = await htmlToImage.toPng(el);
+    return dataUrl;
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
@@ -358,5 +369,6 @@
     state: state,
     eval: evalScript,
     wait: waitFor,
+    screenshot: screenshot,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -295,6 +295,49 @@
     return new Function("return (" + script + ")")();
   }
 
+  function waitFor(options) {
+    var selector = options && options.selector;
+    var ref = options && options.target;
+    var gone = (options && options.gone) || false;
+    var timeout = (options && options.timeout) || 10000;
+
+    return new Promise(function (res, rej) {
+      function check() {
+        if (selector) return document.querySelector(selector);
+        if (ref) return idMap.get(ref) || null;
+        return null;
+      }
+
+      var el = check();
+      if (!gone && el) return res({ found: true });
+      if (gone && !el) return res({ found: true });
+
+      var timer = setTimeout(function () {
+        observer.disconnect();
+        rej(new Error("Timeout waiting for " + (selector || ref)));
+      }, timeout);
+
+      var observer = new MutationObserver(function () {
+        var found = check();
+        if (!gone && found) {
+          observer.disconnect();
+          clearTimeout(timer);
+          res({ found: true });
+        } else if (gone && !found) {
+          observer.disconnect();
+          clearTimeout(timer);
+          res({ found: true });
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+    });
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
@@ -314,5 +357,6 @@
     title: title,
     state: state,
     eval: evalScript,
+    wait: waitFor,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -168,8 +168,89 @@
     return idMap.get(ref) || null;
   }
 
+  function requireEl(ref) {
+    const el = idMap.get(ref);
+    if (!el) throw new Error("Unknown ref: " + ref);
+    return el;
+  }
+
+  function click(ref) {
+    const el = requireEl(ref);
+    el.focus();
+    el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return { ok: true };
+  }
+
+  function fill(ref, value) {
+    const el = requireEl(ref);
+    el.focus();
+    const setter =
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
+    if (setter && setter.set) {
+      setter.set.call(el, value);
+    } else {
+      el.value = value;
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true };
+  }
+
+  function typeText(ref, text) {
+    const el = requireEl(ref);
+    el.focus();
+    for (const ch of text) {
+      el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
+      el.dispatchEvent(new InputEvent("input", { data: ch, inputType: "insertText", bubbles: true }));
+      el.dispatchEvent(new KeyboardEvent("keyup", { key: ch, bubbles: true }));
+    }
+    return { ok: true };
+  }
+
+  function press(key) {
+    const target = document.activeElement || document.body;
+    target.dispatchEvent(new KeyboardEvent("keydown", { key: key, bubbles: true }));
+    target.dispatchEvent(new KeyboardEvent("keyup", { key: key, bubbles: true }));
+    return { ok: true };
+  }
+
+  function select(ref, value) {
+    const el = requireEl(ref);
+    el.value = value;
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true };
+  }
+
+  function check(ref) {
+    const el = requireEl(ref);
+    el.checked = !el.checked;
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true };
+  }
+
+  function scroll(options) {
+    const dir = (options && options.direction) || "down";
+    const amount = (options && options.amount) || 300;
+    const ref = options && options.ref;
+    const target = ref ? requireEl(ref) : window;
+    const dx = (dir === "left" ? -amount : dir === "right" ? amount : 0);
+    const dy = (dir === "up" ? -amount : dir === "down" ? amount : 0);
+    target.scrollBy(dx, dy);
+    return { ok: true };
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
+    click: click,
+    fill: fill,
+    type: typeText,
+    press: press,
+    select: select,
+    check: check,
+    scroll: scroll,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1,0 +1,175 @@
+(() => {
+  "use strict";
+
+  const idMap = new Map();
+  let refCounter = 0;
+
+  const ROLE_MAP = {
+    A: "link",
+    BUTTON: "button",
+    SELECT: "combobox",
+    TEXTAREA: "textbox",
+    IMG: "img",
+    H1: "heading",
+    H2: "heading",
+    H3: "heading",
+    H4: "heading",
+    H5: "heading",
+    H6: "heading",
+    UL: "list",
+    OL: "list",
+    LI: "listitem",
+    TABLE: "table",
+    TR: "row",
+    TH: "columnheader",
+    TD: "cell",
+    NAV: "navigation",
+    MAIN: "main",
+    ASIDE: "complementary",
+    FORM: "form",
+    DIALOG: "dialog",
+    DETAILS: "group",
+  };
+
+  const INTERACTIVE_ROLES = new Set([
+    "button",
+    "link",
+    "checkbox",
+    "radio",
+    "switch",
+    "slider",
+    "textbox",
+    "combobox",
+  ]);
+
+  function inputRole(el) {
+    const t = (el.getAttribute("type") || "text").toLowerCase();
+    switch (t) {
+      case "checkbox":
+        return "checkbox";
+      case "radio":
+        return "radio";
+      case "range":
+        return "slider";
+      case "submit":
+      case "reset":
+      case "button":
+        return "button";
+      default:
+        return "textbox";
+    }
+  }
+
+  function getRole(el) {
+    const explicit = el.getAttribute("role");
+    if (explicit) return explicit;
+    if (el.tagName === "INPUT") return inputRole(el);
+    return ROLE_MAP[el.tagName] || null;
+  }
+
+  function getName(el) {
+    const label = el.getAttribute("aria-label");
+    if (label) return label.trim().slice(0, 50);
+
+    const labelledBy = el.getAttribute("aria-labelledby");
+    if (labelledBy) {
+      const parts = labelledBy
+        .split(/\s+/)
+        .map((id) => {
+          const ref = document.getElementById(id);
+          return ref ? ref.textContent : "";
+        })
+        .filter(Boolean);
+      if (parts.length > 0) return parts.join(" ").trim().slice(0, 50);
+    }
+
+    if (el.tagName === "IMG") {
+      const alt = el.getAttribute("alt");
+      if (alt) return alt.trim().slice(0, 50);
+    }
+
+    if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT") {
+      const placeholder = el.getAttribute("placeholder");
+      if (placeholder) return placeholder.trim().slice(0, 50);
+    }
+
+    const text = el.textContent || "";
+    const trimmed = text.replace(/\s+/g, " ").trim();
+    return trimmed.slice(0, 50) || null;
+  }
+
+  function isInteractiveElement(el) {
+    const tag = el.tagName;
+    if (
+      tag === "INPUT" ||
+      tag === "BUTTON" ||
+      tag === "SELECT" ||
+      tag === "TEXTAREA" ||
+      tag === "A"
+    ) {
+      return true;
+    }
+    if (el.hasAttribute("tabindex")) return true;
+    const role = el.getAttribute("role");
+    return role ? INTERACTIVE_ROLES.has(role) : false;
+  }
+
+  function snapshot(options) {
+    const interactive = (options && options.interactive) || false;
+    const selector = (options && options.selector) || null;
+    const maxDepth = (options && options.depth != null) ? options.depth : 255;
+
+    refCounter = 0;
+    idMap.clear();
+
+    const root = selector ? document.querySelector(selector) : document.body;
+    if (!root) return { elements: [] };
+
+    const elements = [];
+
+    function walk(node, currentDepth) {
+      if (currentDepth > maxDepth) return;
+      if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+      const role = getRole(node);
+      const isInteractive = isInteractiveElement(node);
+
+      if (interactive && !isInteractive) {
+        for (const child of node.children) {
+          walk(child, currentDepth);
+        }
+        return;
+      }
+
+      if (role) {
+        refCounter++;
+        const ref = "e" + refCounter;
+        idMap.set(ref, node);
+
+        const entry = { ref: ref, role: role, depth: currentDepth };
+        const name = getName(node);
+        if (name) entry.name = name;
+        if (node.value !== undefined && node.value !== "") entry.value = node.value;
+        if (node.checked !== undefined) entry.checked = node.checked;
+        if (node.disabled) entry.disabled = true;
+        elements.push(entry);
+      }
+
+      for (const child of node.children) {
+        walk(child, currentDepth + 1);
+      }
+    }
+
+    walk(root, 0);
+    return { elements: elements };
+  }
+
+  function resolve(ref) {
+    return idMap.get(ref) || null;
+  }
+
+  window.__PILOT__ = {
+    snapshot: snapshot,
+    resolve: resolve,
+  };
+})();

--- a/crates/tauri-plugin-pilot/permissions/autogenerated/commands/__callback.toml
+++ b/crates/tauri-plugin-pilot/permissions/autogenerated/commands/__callback.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow---callback"
+description = "Enables the __callback command without any pre-configured scope."
+commands.allow = ["__callback"]
+
+[[permission]]
+identifier = "deny---callback"
+description = "Denies the __callback command without any pre-configured scope."
+commands.deny = ["__callback"]

--- a/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
@@ -1,0 +1,56 @@
+## Default Permission
+
+Default permissions for tauri-plugin-pilot (allows eval callback)
+
+#### This default permission set includes the following:
+
+- `allow-callback`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`pilot:allow---callback`
+
+</td>
+<td>
+
+Enables the __callback command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`pilot:deny---callback`
+
+</td>
+<td>
+
+Denies the __callback command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`pilot:allow-callback`
+
+</td>
+<td>
+
+Allow the internal __callback IPC command used by the eval engine
+
+</td>
+</tr>
+</table>

--- a/crates/tauri-plugin-pilot/permissions/default.toml
+++ b/crates/tauri-plugin-pilot/permissions/default.toml
@@ -1,0 +1,12 @@
+"$schema" = "schemas/schema.json"
+
+[[permission]]
+identifier = "allow-callback"
+description = "Allow the internal __callback IPC command used by the eval engine"
+
+[permission.commands]
+allow = ["__callback"]
+
+[default]
+description = "Default permissions for tauri-plugin-pilot (allows eval callback)"
+permissions = ["allow-callback"]

--- a/crates/tauri-plugin-pilot/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-pilot/permissions/schemas/schema.json
@@ -1,0 +1,324 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the __callback command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow---callback",
+          "markdownDescription": "Enables the __callback command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the __callback command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny---callback",
+          "markdownDescription": "Denies the __callback command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`"
+        },
+        {
+          "description": "Allow the internal __callback IPC command used by the eval engine",
+          "type": "string",
+          "const": "allow-callback",
+          "markdownDescription": "Allow the internal __callback IPC command used by the eval engine"
+        }
+      ]
+    }
+  }
+}

--- a/crates/tauri-plugin-pilot/src/error.rs
+++ b/crates/tauri-plugin-pilot/src/error.rs
@@ -1,0 +1,11 @@
+/// Plugin-level errors for tauri-pilot.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An I/O error occurred (socket, file, etc.).
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A JSON serialization/deserialization error occurred.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
+/// Error types for eval operations.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EvalError {
+    #[error("eval timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("JavaScript error: {0}")]
+    JsError(String),
+    #[error("eval channel closed unexpectedly")]
+    ChannelClosed,
+}
+
+type PendingMap = HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>>>;
+
+/// Engine for executing JS in a `WebView` and getting results via callback.
+///
+/// The core ADR-001 pattern: wrap script in try/catch + invoke callback,
+/// await the result on a oneshot channel with timeout.
+#[derive(Clone)]
+pub(crate) struct EvalEngine {
+    pending: Arc<Mutex<PendingMap>>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl EvalEngine {
+    pub fn new() -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    /// Register a pending eval request. Returns the ID and a receiver.
+    pub fn register(&self) -> (u64, oneshot::Receiver<Result<serde_json::Value, String>>) {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .expect("pending lock poisoned")
+            .insert(id, tx);
+        (id, rx)
+    }
+
+    /// Resolve a pending eval by ID. Called from the IPC __callback handler.
+    pub fn resolve(&self, id: u64, result: Result<serde_json::Value, String>) {
+        let sender = self
+            .pending
+            .lock()
+            .expect("pending lock poisoned")
+            .remove(&id);
+
+        match sender {
+            Some(tx) => {
+                let _ = tx.send(result);
+            }
+            None => {
+                tracing::warn!(id, "resolve called for unknown eval ID");
+            }
+        }
+    }
+
+    /// Wrap a user script in the ADR-001 callback pattern.
+    #[must_use]
+    pub fn wrap_script(id: u64, script: &str) -> String {
+        format!(
+            "(async()=>{{try{{let __r={script};\
+             window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+             {{id:{id},result:JSON.stringify(__r)}});\
+             }}catch(__e){{window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+             {{id:{id},error:__e.message}});}}}})();"
+        )
+    }
+
+    /// Wait for a pending eval result with timeout.
+    pub async fn wait(
+        &self,
+        rx: oneshot::Receiver<Result<serde_json::Value, String>>,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, EvalError> {
+        let result = tokio::time::timeout(timeout, rx)
+            .await
+            .map_err(|_| EvalError::Timeout(timeout))?
+            .map_err(|_| EvalError::ChannelClosed)?;
+
+        result.map_err(EvalError::JsError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_new_starts_at_id_1() {
+        let engine = EvalEngine::new();
+        let (id, _rx) = engine.register();
+        assert_eq!(id, 1);
+    }
+
+    #[test]
+    fn test_ids_increment() {
+        let engine = EvalEngine::new();
+        let (id1, _) = engine.register();
+        let (id2, _) = engine.register();
+        assert_eq!(id2, id1 + 1);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_success() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        engine.resolve(id, Ok(json!(42)));
+        let result = rx.await.unwrap();
+        assert_eq!(result, Ok(json!(42)));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_js_error() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        engine.resolve(id, Err("ReferenceError: x is not defined".to_owned()));
+        let result = rx.await.unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_unknown_id_no_panic() {
+        let engine = EvalEngine::new();
+        engine.resolve(999, Ok(json!(null)));
+    }
+
+    #[tokio::test]
+    async fn test_wait_timeout() {
+        tokio::time::pause();
+        let engine = EvalEngine::new();
+        let (_id, rx) = engine.register();
+        let result = engine.wait(rx, Duration::from_secs(1)).await;
+        assert!(matches!(result, Err(EvalError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn test_wait_success() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        engine.resolve(id, Ok(json!({"title": "hello"})));
+        let result = engine.wait(rx, Duration::from_secs(10)).await;
+        assert_eq!(result.unwrap(), json!({"title": "hello"}));
+    }
+
+    #[tokio::test]
+    async fn test_wait_js_error() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        engine.resolve(id, Err("boom".to_owned()));
+        let result = engine.wait(rx, Duration::from_secs(10)).await;
+        assert!(matches!(result, Err(EvalError::JsError(ref m)) if m == "boom"));
+    }
+
+    #[test]
+    fn test_wrap_script_contains_id_and_code() {
+        let script = EvalEngine::wrap_script(42, "document.title");
+        assert!(script.contains("42"));
+        assert!(script.contains("document.title"));
+        assert!(script.contains("__callback"));
+        assert!(script.contains("try"));
+        assert!(script.contains("catch"));
+    }
+}

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -66,15 +66,16 @@ impl EvalEngine {
     }
 
     /// Wrap a user script in the ADR-001 callback pattern.
-    /// The expression is `await`-ed so async results (Promises) resolve before
-    /// being serialized. Errors are stringified to handle non-Error rejections.
+    /// Uses `__TAURI_INTERNALS__.invoke` which is always available (even without
+    /// `withGlobalTauri`). The expression is `await`-ed so async results resolve
+    /// before serialization.
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
             "(async()=>{{try{{let __r=await({script});\
-             await window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+             await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
              {{id:{id},result:JSON.stringify(__r)}});\
-             }}catch(__e){{await window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+             }}catch(__e){{await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
              {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
         )
     }

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -89,7 +89,14 @@ impl EvalEngine {
 
         match result {
             Ok(Ok(inner)) => inner.map_err(EvalError::JsError),
-            Ok(Err(_)) => Err(EvalError::ChannelClosed),
+            Ok(Err(_)) => {
+                // Defensive cleanup — sender dropped without sending
+                self.pending
+                    .lock()
+                    .expect("pending lock poisoned")
+                    .remove(&id);
+                Err(EvalError::ChannelClosed)
+            }
             Err(_) => {
                 // Remove stale entry from pending map on timeout
                 self.pending

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -78,17 +78,27 @@ impl EvalEngine {
     }
 
     /// Wait for a pending eval result with timeout.
+    /// Cleans up the pending entry on timeout to prevent memory leaks.
     pub async fn wait(
         &self,
+        id: u64,
         rx: oneshot::Receiver<Result<serde_json::Value, String>>,
         timeout: Duration,
     ) -> Result<serde_json::Value, EvalError> {
-        let result = tokio::time::timeout(timeout, rx)
-            .await
-            .map_err(|_| EvalError::Timeout(timeout))?
-            .map_err(|_| EvalError::ChannelClosed)?;
+        let result = tokio::time::timeout(timeout, rx).await;
 
-        result.map_err(EvalError::JsError)
+        match result {
+            Ok(Ok(inner)) => inner.map_err(EvalError::JsError),
+            Ok(Err(_)) => Err(EvalError::ChannelClosed),
+            Err(_) => {
+                // Remove stale entry from pending map on timeout
+                self.pending
+                    .lock()
+                    .expect("pending lock poisoned")
+                    .remove(&id);
+                Err(EvalError::Timeout(timeout))
+            }
+        }
     }
 }
 
@@ -137,12 +147,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_timeout() {
+    async fn test_wait_timeout_cleans_pending() {
         tokio::time::pause();
         let engine = EvalEngine::new();
-        let (_id, rx) = engine.register();
-        let result = engine.wait(rx, Duration::from_secs(1)).await;
+        let (id, rx) = engine.register();
+        let result = engine.wait(id, rx, Duration::from_secs(1)).await;
         assert!(matches!(result, Err(EvalError::Timeout(_))));
+        // Verify pending entry was cleaned up
+        assert!(!engine.pending.lock().expect("lock").contains_key(&id));
     }
 
     #[tokio::test]
@@ -150,7 +162,7 @@ mod tests {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
         engine.resolve(id, Ok(json!({"title": "hello"})));
-        let result = engine.wait(rx, Duration::from_secs(10)).await;
+        let result = engine.wait(id, rx, Duration::from_secs(10)).await;
         assert_eq!(result.unwrap(), json!({"title": "hello"}));
     }
 
@@ -159,7 +171,7 @@ mod tests {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
         engine.resolve(id, Err("boom".to_owned()));
-        let result = engine.wait(rx, Duration::from_secs(10)).await;
+        let result = engine.wait(id, rx, Duration::from_secs(10)).await;
         assert!(matches!(result, Err(EvalError::JsError(ref m)) if m == "boom"));
     }
 

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -66,14 +66,16 @@ impl EvalEngine {
     }
 
     /// Wrap a user script in the ADR-001 callback pattern.
+    /// The expression is `await`-ed so async results (Promises) resolve before
+    /// being serialized. Errors are stringified to handle non-Error rejections.
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
-            "(async()=>{{try{{let __r={script};\
-             window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+            "(async()=>{{try{{let __r=await({script});\
+             await window.__TAURI__.core.invoke('plugin:pilot|__callback',\
              {{id:{id},result:JSON.stringify(__r)}});\
-             }}catch(__e){{window.__TAURI__.core.invoke('plugin:pilot|__callback',\
-             {{id:{id},error:__e.message}});}}}})();"
+             }}catch(__e){{await window.__TAURI__.core.invoke('plugin:pilot|__callback',\
+             {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
         )
     }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -45,14 +45,18 @@ async fn handle_eval_method(
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
-    eval_fn(wrapped).map_err(|e| RpcError {
-        code: -32603,
-        message: format!("Eval failed: {e}"),
-        data: None,
-    })?;
+    if let Err(e) = eval_fn(wrapped) {
+        // Clean up pending entry on eval_fn failure
+        engine.resolve(id, Err(format!("Eval failed: {e}")));
+        return Err(RpcError {
+            code: -32603,
+            message: format!("Eval failed: {e}"),
+            data: None,
+        });
+    }
 
     engine
-        .wait(rx, DEFAULT_TIMEOUT)
+        .wait(id, rx, DEFAULT_TIMEOUT)
         .await
         .map_err(|e| RpcError {
             code: -32603,
@@ -70,14 +74,16 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String
 
     if method == "ipc" {
         // ipc calls Tauri's backend invoke directly
+        // Use JSON.parse for safe interpolation — no string escaping needed
         let command = params
             .and_then(|p| p.get("command"))
             .and_then(serde_json::Value::as_str)
             .unwrap_or("");
+        let command_json = serde_json::to_string(command).unwrap_or_else(|_| "\"\"".to_owned());
         let ipc_args = params
             .and_then(|p| p.get("args"))
             .map_or("{}".to_owned(), ToString::to_string);
-        return format!("window.__TAURI__.core.invoke('{command}', {ipc_args})");
+        return format!("window.__TAURI__.core.invoke(JSON.parse({command_json}), {ipc_args})");
     }
 
     format!("window.__PILOT__.{method}({args})")
@@ -97,6 +103,9 @@ pub(crate) fn handle_callback(
             Ok(val) => engine.resolve(id, Ok(val)),
             Err(_) => engine.resolve(id, Ok(serde_json::Value::String(res))),
         }
+    } else {
+        tracing::warn!(id, "callback received with neither result nor error");
+        engine.resolve(id, Ok(serde_json::Value::Null));
     }
 }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,3 +1,4 @@
+use crate::eval::EvalEngine;
 use crate::protocol::RpcError;
 
 /// Dispatch a JSON-RPC method call to the appropriate handler.
@@ -15,15 +16,45 @@ pub(crate) fn dispatch(
     }
 }
 
+/// Process the IPC callback from the JS bridge (ADR-001).
+pub(crate) fn handle_callback(
+    engine: &EvalEngine,
+    id: u64,
+    result: Option<String>,
+    error: Option<String>,
+) {
+    if let Some(err) = error {
+        engine.resolve(id, Err(err));
+    } else if let Some(res) = result {
+        match serde_json::from_str(&res) {
+            Ok(val) => engine.resolve(id, Ok(val)),
+            Err(_) => engine.resolve(id, Ok(serde_json::Value::String(res))),
+        }
+    }
+}
+
+/// Tauri IPC command for the `__callback` handler.
+#[tauri::command]
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn __callback(
+    eval_engine: tauri::State<'_, EvalEngine>,
+    id: u64,
+    result: Option<String>,
+    error: Option<String>,
+) {
+    handle_callback(&eval_engine, id, result, error);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_dispatch_ping_returns_ok() {
         let result = dispatch("ping", None);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), serde_json::json!({"status": "ok"}));
+        assert_eq!(result.unwrap(), json!({"status": "ok"}));
     }
 
     #[test]
@@ -33,5 +64,38 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, -32601);
         assert!(err.message.contains("nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn test_callback_with_json_result() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        handle_callback(&engine, id, Some(r#"{"title":"hello"}"#.to_owned()), None);
+        let val = rx.await.unwrap().unwrap();
+        assert_eq!(val, json!({"title": "hello"}));
+    }
+
+    #[tokio::test]
+    async fn test_callback_with_plain_string_result() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        handle_callback(&engine, id, Some("not json".to_owned()), None);
+        let val = rx.await.unwrap().unwrap();
+        assert_eq!(val, json!("not json"));
+    }
+
+    #[tokio::test]
+    async fn test_callback_with_error() {
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        handle_callback(&engine, id, None, Some("TypeError: x".to_owned()));
+        let result = rx.await.unwrap();
+        assert_eq!(result, Err("TypeError: x".to_owned()));
+    }
+
+    #[test]
+    fn test_callback_unknown_id_no_panic() {
+        let engine = EvalEngine::new();
+        handle_callback(&engine, 999, Some("{}".to_owned()), None);
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -17,7 +17,9 @@ pub(crate) async fn dispatch(
         "ping" => Ok(serde_json::json!({"status": "ok"})),
         "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll"
         | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
-        | "state" | "wait" => handle_eval_method(method, params, engine, eval_fn).await,
+        | "state" | "wait" | "screenshot" => {
+            handle_eval_method(method, params, engine, eval_fn).await
+        }
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,0 +1,37 @@
+use crate::protocol::RpcError;
+
+/// Dispatch a JSON-RPC method call to the appropriate handler.
+pub(crate) fn dispatch(
+    method: &str,
+    _params: Option<&serde_json::Value>,
+) -> Result<serde_json::Value, RpcError> {
+    match method {
+        "ping" => Ok(serde_json::json!({"status": "ok"})),
+        _ => Err(RpcError {
+            code: -32601,
+            message: format!("Method not found: {method}"),
+            data: None,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dispatch_ping_returns_ok() {
+        let result = dispatch("ping", None);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), serde_json::json!({"status": "ok"}));
+    }
+
+    #[test]
+    fn test_dispatch_unknown_method_returns_error() {
+        let result = dispatch("nonexistent", None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32601);
+        assert!(err.message.contains("nonexistent"));
+    }
+}

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,19 +1,69 @@
 use crate::eval::EvalEngine;
 use crate::protocol::RpcError;
+use crate::server::EvalFn;
+
+use std::time::Duration;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Dispatch a JSON-RPC method call to the appropriate handler.
-pub(crate) fn dispatch(
+pub(crate) async fn dispatch(
     method: &str,
-    _params: Option<&serde_json::Value>,
+    params: Option<&serde_json::Value>,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
 ) -> Result<serde_json::Value, RpcError> {
     match method {
         "ping" => Ok(serde_json::json!({"status": "ok"})),
+        "snapshot" => handle_eval_method("snapshot", params, engine, eval_fn).await,
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
             data: None,
         }),
     }
+}
+
+/// Handle a method that requires JS evaluation via the bridge.
+async fn handle_eval_method(
+    method: &str,
+    params: Option<&serde_json::Value>,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+) -> Result<serde_json::Value, RpcError> {
+    let eval_fn = eval_fn.ok_or_else(|| RpcError {
+        code: -32603,
+        message: "No webview available for eval".to_owned(),
+        data: None,
+    })?;
+
+    let script = build_bridge_call(method, params);
+    let (id, rx) = engine.register();
+    let wrapped = EvalEngine::wrap_script(id, &script);
+
+    eval_fn(wrapped).map_err(|e| RpcError {
+        code: -32603,
+        message: format!("Eval failed: {e}"),
+        data: None,
+    })?;
+
+    engine
+        .wait(rx, DEFAULT_TIMEOUT)
+        .await
+        .map_err(|e| RpcError {
+            code: -32603,
+            message: format!("Eval error: {e}"),
+            data: None,
+        })
+}
+
+/// Build a `window.__PILOT__.<method>(params)` JS call string.
+fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String {
+    let args = match params {
+        Some(v) if !v.is_null() => v.to_string(),
+        _ => "{}".to_owned(),
+    };
+    format!("window.__PILOT__.{method}({args})")
 }
 
 /// Process the IPC callback from the JS bridge (ADR-001).
@@ -50,20 +100,42 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn test_dispatch_ping_returns_ok() {
-        let result = dispatch("ping", None);
-        assert!(result.is_ok());
+    #[tokio::test]
+    async fn test_dispatch_ping_returns_ok() {
+        let engine = EvalEngine::new();
+        let result = dispatch("ping", None, &engine, None).await;
         assert_eq!(result.unwrap(), json!({"status": "ok"}));
     }
 
-    #[test]
-    fn test_dispatch_unknown_method_returns_error() {
-        let result = dispatch("nonexistent", None);
-        assert!(result.is_err());
+    #[tokio::test]
+    async fn test_dispatch_unknown_method_returns_error() {
+        let engine = EvalEngine::new();
+        let result = dispatch("nonexistent", None, &engine, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32601);
-        assert!(err.message.contains("nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_snapshot_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("snapshot", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_snapshot() {
+        let params = json!({"interactive": true, "selector": null, "depth": 3});
+        let script = build_bridge_call("snapshot", Some(&params));
+        assert!(script.starts_with("window.__PILOT__.snapshot("));
+        assert!(script.contains("\"interactive\":true"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_no_params() {
+        let script = build_bridge_call("snapshot", None);
+        assert_eq!(script, "window.__PILOT__.snapshot({})");
     }
 
     #[tokio::test]
@@ -76,26 +148,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_callback_with_plain_string_result() {
-        let engine = EvalEngine::new();
-        let (id, rx) = engine.register();
-        handle_callback(&engine, id, Some("not json".to_owned()), None);
-        let val = rx.await.unwrap().unwrap();
-        assert_eq!(val, json!("not json"));
-    }
-
-    #[tokio::test]
     async fn test_callback_with_error() {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
         handle_callback(&engine, id, None, Some("TypeError: x".to_owned()));
         let result = rx.await.unwrap();
         assert_eq!(result, Err("TypeError: x".to_owned()));
-    }
-
-    #[test]
-    fn test_callback_unknown_id_no_panic() {
-        let engine = EvalEngine::new();
-        handle_callback(&engine, 999, Some("{}".to_owned()), None);
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -90,7 +90,7 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> Result
             .and_then(|p| p.get("args"))
             .map_or("{}".to_owned(), ToString::to_string);
         return Ok(format!(
-            "window.__TAURI__.core.invoke({command_js}, {ipc_args})"
+            "window.__TAURI_INTERNALS__.invoke({command_js}, {ipc_args})"
         ));
     }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -17,7 +17,7 @@ pub(crate) async fn dispatch(
         "ping" => Ok(serde_json::json!({"status": "ok"})),
         "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll"
         | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
-        | "state" => handle_eval_method(method, params, engine, eval_fn).await,
+        | "state" | "wait" => handle_eval_method(method, params, engine, eval_fn).await,
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -15,9 +15,9 @@ pub(crate) async fn dispatch(
 ) -> Result<serde_json::Value, RpcError> {
     match method {
         "ping" => Ok(serde_json::json!({"status": "ok"})),
-        "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" => {
-            handle_eval_method(method, params, engine, eval_fn).await
-        }
+        "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll"
+        | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
+        | "state" => handle_eval_method(method, params, engine, eval_fn).await,
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
@@ -65,6 +65,19 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String
         Some(v) if !v.is_null() => v.to_string(),
         _ => "{}".to_owned(),
     };
+
+    if method == "ipc" {
+        // ipc calls Tauri's backend invoke directly
+        let command = params
+            .and_then(|p| p.get("command"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let ipc_args = params
+            .and_then(|p| p.get("args"))
+            .map_or("{}".to_owned(), ToString::to_string);
+        return format!("window.__TAURI__.core.invoke('{command}', {ipc_args})");
+    }
+
     format!("window.__PILOT__.{method}({args})")
 }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -74,16 +74,16 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String
 
     if method == "ipc" {
         // ipc calls Tauri's backend invoke directly
-        // Use JSON.parse for safe interpolation — no string escaping needed
+        // serde_json::to_string produces a valid JS string literal (escaped quotes, backslashes, etc.)
         let command = params
             .and_then(|p| p.get("command"))
             .and_then(serde_json::Value::as_str)
             .unwrap_or("");
-        let command_json = serde_json::to_string(command).unwrap_or_else(|_| "\"\"".to_owned());
+        let command_js = serde_json::to_string(command).unwrap_or_else(|_| "\"\"".to_owned());
         let ipc_args = params
             .and_then(|p| p.get("args"))
             .map_or("{}".to_owned(), ToString::to_string);
-        return format!("window.__TAURI__.core.invoke(JSON.parse({command_json}), {ipc_args})");
+        return format!("window.__TAURI__.core.invoke({command_js}, {ipc_args})");
     }
 
     format!("window.__PILOT__.{method}({args})")

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -41,7 +41,11 @@ async fn handle_eval_method(
         data: None,
     })?;
 
-    let script = build_bridge_call(method, params);
+    let script = build_bridge_call(method, params).map_err(|msg| RpcError {
+        code: -32602,
+        message: msg,
+        data: None,
+    })?;
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
@@ -66,7 +70,8 @@ async fn handle_eval_method(
 }
 
 /// Build a `window.__PILOT__.<method>(params)` JS call string.
-fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String {
+/// Returns `Err` with a message for invalid params (e.g. missing ipc command).
+fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> Result<String, String> {
     let args = match params {
         Some(v) if !v.is_null() => v.to_string(),
         _ => "{}".to_owned(),
@@ -78,15 +83,18 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> String
         let command = params
             .and_then(|p| p.get("command"))
             .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| "ipc requires a non-empty \"command\" string param".to_owned())?;
         let command_js = serde_json::to_string(command).unwrap_or_else(|_| "\"\"".to_owned());
         let ipc_args = params
             .and_then(|p| p.get("args"))
             .map_or("{}".to_owned(), ToString::to_string);
-        return format!("window.__TAURI__.core.invoke({command_js}, {ipc_args})");
+        return Ok(format!(
+            "window.__TAURI__.core.invoke({command_js}, {ipc_args})"
+        ));
     }
 
-    format!("window.__PILOT__.{method}({args})")
+    Ok(format!("window.__PILOT__.{method}({args})"))
 }
 
 /// Process the IPC callback from the JS bridge (ADR-001).
@@ -153,15 +161,22 @@ mod tests {
     #[test]
     fn test_build_bridge_call_snapshot() {
         let params = json!({"interactive": true, "selector": null, "depth": 3});
-        let script = build_bridge_call("snapshot", Some(&params));
+        let script = build_bridge_call("snapshot", Some(&params)).unwrap();
         assert!(script.starts_with("window.__PILOT__.snapshot("));
         assert!(script.contains("\"interactive\":true"));
     }
 
     #[test]
     fn test_build_bridge_call_no_params() {
-        let script = build_bridge_call("snapshot", None);
+        let script = build_bridge_call("snapshot", None).unwrap();
         assert_eq!(script, "window.__PILOT__.snapshot({})");
+    }
+
+    #[test]
+    fn test_build_bridge_call_ipc_missing_command() {
+        let result = build_bridge_call("ipc", None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("command"));
     }
 
     #[tokio::test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -15,7 +15,9 @@ pub(crate) async fn dispatch(
 ) -> Result<serde_json::Value, RpcError> {
     match method {
         "ping" => Ok(serde_json::json!({"status": "ok"})),
-        "snapshot" => handle_eval_method("snapshot", params, engine, eval_fn).await,
+        "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" => {
+            handle_eval_method(method, params, engine, eval_fn).await
+        }
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -3,37 +3,56 @@ mod error;
 pub(crate) mod eval;
 mod handler;
 pub(crate) mod protocol;
-mod server;
+pub(crate) mod server;
 
 pub use error::Error;
 
 use eval::EvalEngine;
+use server::EvalFn;
+use std::sync::Arc;
 use tauri::Manager;
+
+const BRIDGE_JS: &str = include_str!("../js/bridge.js");
 
 /// Initialize the tauri-pilot plugin.
 ///
-/// Stores an `EvalEngine` in app state and starts a Unix socket server
-/// at `/tmp/tauri-pilot-{identifier}.sock`. Registers the `__callback`
-/// IPC handler for the eval+callback pattern (ADR-001).
+/// Injects the JS bridge, stores an `EvalEngine` in app state,
+/// and starts a Unix socket server at `/tmp/tauri-pilot-{identifier}.sock`.
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new("pilot")
+        .js_init_script(BRIDGE_JS.to_owned())
         .setup(|app, _api| {
-            app.manage(EvalEngine::new());
+            let engine = EvalEngine::new();
+            app.manage(engine.clone());
 
             let identifier = app.config().identifier.clone();
             let socket_path =
                 std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
-            // Remove stale socket from a previous run
             let _ = std::fs::remove_file(&socket_path);
 
             tracing::info!(path = %socket_path.display(), "starting tauri-pilot socket server");
 
-            tauri::async_runtime::spawn(server::start(socket_path));
+            let eval_fn = make_eval_fn(app);
+
+            tauri::async_runtime::spawn(server::start(socket_path, engine, Some(eval_fn)));
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![handler::__callback])
         .build()
+}
+
+/// Create an eval function from the app handle that evaluates JS in the first webview.
+fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
+    let handle = app.clone();
+    Arc::new(move |script| {
+        let windows = handle.webview_windows();
+        let window = windows
+            .values()
+            .next()
+            .ok_or_else(|| "No webview window available".to_owned())?;
+        window.eval(&script).map_err(|e| e.to_string())
+    })
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -40,7 +40,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 let engine = EvalEngine::new();
                 app.manage(engine.clone());
 
-                let identifier = app.config().identifier.clone();
+                let identifier = sanitize_identifier(&app.config().identifier);
                 let socket_path =
                     std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
@@ -57,6 +57,27 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             })
             .invoke_handler(tauri::generate_handler![handler::__callback])
             .build()
+    }
+}
+
+/// Strip path separators and unsafe characters from the app identifier
+/// so it can be safely used in a socket filename.
+#[cfg(all(unix, debug_assertions))]
+fn sanitize_identifier(raw: &str) -> String {
+    let sanitized: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "default".to_owned()
+    } else {
+        sanitized
     }
 }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -3,52 +3,68 @@ mod error;
 pub(crate) mod eval;
 mod handler;
 pub(crate) mod protocol;
+#[cfg(unix)]
 pub(crate) mod server;
 
 pub use error::Error;
 
+#[cfg(unix)]
 use eval::EvalEngine;
+#[cfg(unix)]
 use server::EvalFn;
+#[cfg(unix)]
 use std::sync::Arc;
+#[cfg(unix)]
 use tauri::Manager;
 
+#[cfg(unix)]
 const BRIDGE_JS: &str = include_str!("../js/bridge.js");
 
 /// Initialize the tauri-pilot plugin.
 ///
-/// Injects the JS bridge, stores an `EvalEngine` in app state,
+/// On non-Unix platforms or in release builds, returns a no-op plugin.
+/// In debug builds on Unix, injects the JS bridge, stores an `EvalEngine`,
 /// and starts a Unix socket server at `/tmp/tauri-pilot-{identifier}.sock`.
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
-    tauri::plugin::Builder::new("pilot")
-        .js_init_script(BRIDGE_JS.to_owned())
-        .setup(|app, _api| {
-            let engine = EvalEngine::new();
-            app.manage(engine.clone());
+    #[cfg(not(all(unix, debug_assertions)))]
+    {
+        return tauri::plugin::Builder::new("pilot").build();
+    }
 
-            let identifier = app.config().identifier.clone();
-            let socket_path =
-                std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
+    #[cfg(all(unix, debug_assertions))]
+    {
+        tauri::plugin::Builder::new("pilot")
+            .js_init_script(BRIDGE_JS.to_owned())
+            .setup(|app, _api| {
+                let engine = EvalEngine::new();
+                app.manage(engine.clone());
 
-            let eval_fn = make_eval_fn(app);
+                let identifier = app.config().identifier.clone();
+                let socket_path =
+                    std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
-            let listener = server::bind(&socket_path).map_err(|e| {
-                tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
-                e
-            })?;
+                let eval_fn = make_eval_fn(app);
 
-            tauri::async_runtime::spawn(server::run(listener, engine, Some(eval_fn)));
+                let (listener, guard) = server::bind(&socket_path).map_err(|e| {
+                    tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
+                    e
+                })?;
 
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![handler::__callback])
-        .build()
+                tauri::async_runtime::spawn(server::run(listener, guard, engine, Some(eval_fn)));
+
+                Ok(())
+            })
+            .invoke_handler(tauri::generate_handler![handler::__callback])
+            .build()
+    }
 }
 
 /// Create an eval function from the app handle that evaluates JS in a webview.
 ///
 /// Tries the "main" window label first for deterministic targeting,
 /// falls back to the first available window if "main" doesn't exist.
+#[cfg(all(unix, debug_assertions))]
 fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
     let handle = app.clone();
     Arc::new(move |script| {

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -30,11 +30,14 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             let socket_path =
                 std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
-            tracing::info!(path = %socket_path.display(), "starting tauri-pilot socket server");
-
             let eval_fn = make_eval_fn(app);
 
-            tauri::async_runtime::spawn(server::start(socket_path, engine, Some(eval_fn)));
+            let listener = server::bind(&socket_path).map_err(|e| {
+                tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
+                e
+            })?;
+
+            tauri::async_runtime::spawn(server::run(listener, engine, Some(eval_fn)));
 
             Ok(())
         })

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -7,15 +7,20 @@ mod server;
 
 pub use error::Error;
 
+use eval::EvalEngine;
+use tauri::Manager;
+
 /// Initialize the tauri-pilot plugin.
 ///
-/// Starts a Unix socket server at `/tmp/tauri-pilot-{identifier}.sock`
-/// during the plugin setup phase. The server listens for JSON-RPC 2.0
-/// requests from the CLI.
+/// Stores an `EvalEngine` in app state and starts a Unix socket server
+/// at `/tmp/tauri-pilot-{identifier}.sock`. Registers the `__callback`
+/// IPC handler for the eval+callback pattern (ADR-001).
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new("pilot")
         .setup(|app, _api| {
+            app.manage(EvalEngine::new());
+
             let identifier = app.config().identifier.clone();
             let socket_path =
                 std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
@@ -29,5 +34,6 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
             Ok(())
         })
+        .invoke_handler(tauri::generate_handler![handler::__callback])
         .build()
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,15 +1,30 @@
 mod error;
-#[allow(dead_code)]
 pub(crate) mod protocol;
+mod server;
 
 pub use error::Error;
 
 /// Initialize the tauri-pilot plugin.
 ///
-/// # Panics
-///
-/// This function does not panic.
+/// Starts a Unix socket server at `/tmp/tauri-pilot-{identifier}.sock`
+/// during the plugin setup phase. The server listens for JSON-RPC 2.0
+/// requests from the CLI.
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
-    tauri::plugin::Builder::new("pilot").build()
+    tauri::plugin::Builder::new("pilot")
+        .setup(|app, _api| {
+            let identifier = app.config().identifier.clone();
+            let socket_path =
+                std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
+
+            // Remove stale socket from a previous run
+            let _ = std::fs::remove_file(&socket_path);
+
+            tracing::info!(path = %socket_path.display(), "starting tauri-pilot socket server");
+
+            tauri::async_runtime::spawn(server::start(socket_path));
+
+            Ok(())
+        })
+        .build()
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,4 +1,6 @@
 mod error;
+#[allow(dead_code)]
+pub(crate) mod eval;
 mod handler;
 pub(crate) mod protocol;
 mod server;

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod handler;
 pub(crate) mod protocol;
 mod server;
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -30,8 +30,6 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             let socket_path =
                 std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
-            let _ = std::fs::remove_file(&socket_path);
-
             tracing::info!(path = %socket_path.display(), "starting tauri-pilot socket server");
 
             let eval_fn = make_eval_fn(app);
@@ -44,10 +42,16 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
         .build()
 }
 
-/// Create an eval function from the app handle that evaluates JS in the first webview.
+/// Create an eval function from the app handle that evaluates JS in a webview.
+///
+/// Tries the "main" window label first for deterministic targeting,
+/// falls back to the first available window if "main" doesn't exist.
 fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
     let handle = app.clone();
     Arc::new(move |script| {
+        if let Some(w) = handle.get_webview_window("main") {
+            return w.eval(&script).map_err(|e| e.to_string());
+        }
         let windows = handle.webview_windows();
         let window = windows
             .values()

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,0 +1,13 @@
+mod error;
+
+pub use error::Error;
+
+/// Initialize the tauri-pilot plugin.
+///
+/// # Panics
+///
+/// This function does not panic.
+#[must_use]
+pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    tauri::plugin::Builder::new("pilot").build()
+}

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,4 +1,6 @@
 mod error;
+#[allow(dead_code)]
+pub(crate) mod protocol;
 
 pub use error::Error;
 

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -1,4 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize params, normalizing `null` to `None`.
+fn deserialize_params<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    match val {
+        Some(serde_json::Value::Null) => Ok(None),
+        other => Ok(other),
+    }
+}
 
 /// A JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -6,7 +18,7 @@ pub(crate) struct Request {
     pub jsonrpc: String,
     pub id: u64,
     pub method: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_params")]
     pub params: Option<serde_json::Value>,
 }
 
@@ -70,7 +82,7 @@ mod tests {
         assert_eq!(req.jsonrpc, "2.0");
         assert_eq!(req.id, 1);
         assert_eq!(req.method, "ping");
-        assert!(req.params.is_none() || req.params == Some(serde_json::Value::Null));
+        assert!(req.params.is_none(), "null params should normalize to None");
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -33,7 +33,8 @@ pub(crate) struct RpcError {
 impl Response {
     /// Create a success response.
     #[must_use]
-    pub fn success(id: u64, result: serde_json::Value) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn success(id: u64, result: serde_json::Value) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
             id,
@@ -44,7 +45,7 @@ impl Response {
 
     /// Create an error response.
     #[must_use]
-    pub fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+    pub(crate) fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
             id,

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+
+/// A JSON-RPC 2.0 request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Request {
+    pub jsonrpc: String,
+    pub id: u64,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Response {
+    pub jsonrpc: String,
+    pub id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl Response {
+    /// Create a success response.
+    #[must_use]
+    pub fn success(id: u64, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_owned(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// Create an error response.
+    #[must_use]
+    pub fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_owned(),
+            id,
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_deserialize_request_with_params() {
+        let raw = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":null}"#;
+        let req: Request = serde_json::from_str(raw).expect("deserialize");
+        assert_eq!(req.jsonrpc, "2.0");
+        assert_eq!(req.id, 1);
+        assert_eq!(req.method, "ping");
+        assert!(req.params.is_none() || req.params == Some(serde_json::Value::Null));
+    }
+
+    #[test]
+    fn test_deserialize_request_without_params() {
+        let raw = r#"{"jsonrpc":"2.0","id":2,"method":"snapshot"}"#;
+        let req: Request = serde_json::from_str(raw).expect("deserialize");
+        assert_eq!(req.method, "snapshot");
+        assert!(req.params.is_none());
+    }
+
+    #[test]
+    fn test_serialize_success_response() {
+        let resp = Response::success(1, json!({"status": "ok"}));
+        let v: serde_json::Value = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(v["result"]["status"], "ok");
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn test_serialize_error_response() {
+        let resp = Response::error(1, -32601, "Method not found");
+        let s = serde_json::to_string(&resp).expect("serialize");
+        assert!(s.contains(r#""error""#));
+        assert!(!s.contains(r#""result""#));
+        assert!(s.contains("-32601"));
+    }
+
+    #[test]
+    fn test_roundtrip_request() {
+        let req = Request {
+            jsonrpc: "2.0".to_owned(),
+            id: 42,
+            method: "click".to_owned(),
+            params: Some(json!({"ref": "e1"})),
+        };
+        let serialized = serde_json::to_string(&req).expect("serialize");
+        let deserialized: Request = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(deserialized.id, 42);
+        assert_eq!(deserialized.method, "click");
+    }
+
+    #[test]
+    fn test_roundtrip_response() {
+        let resp = Response::success(7, json!([1, 2, 3]));
+        let serialized = serde_json::to_string(&resp).expect("serialize");
+        let deserialized: Response = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(deserialized.id, 7);
+        assert_eq!(deserialized.result, Some(json!([1, 2, 3])));
+        assert!(deserialized.error.is_none());
+    }
+}

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -33,7 +33,6 @@ pub(crate) struct RpcError {
 impl Response {
     /// Create a success response.
     #[must_use]
-    #[allow(dead_code)]
     pub(crate) fn success(id: u64, result: serde_json::Value) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -3,7 +3,6 @@ use crate::eval::EvalEngine;
 use crate::handler;
 use crate::protocol::{Request, Response};
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -11,25 +10,29 @@ use tokio::net::{UnixListener, UnixStream};
 /// A function that evaluates JS in the webview. `None` if no webview is available.
 pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
-/// Start the socket server. Logs errors internally.
-pub(crate) async fn start(socket_path: PathBuf, engine: EvalEngine, eval_fn: Option<EvalFn>) {
-    if let Err(e) = run(&socket_path, engine, eval_fn).await {
-        tracing::error!(path = %socket_path.display(), "socket server error: {e}");
-    }
-}
-
-async fn run(
-    socket_path: &PathBuf,
-    engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-) -> Result<(), Error> {
-    // Remove stale socket from a previous run that didn't clean up
+/// Bind the socket, removing any stale file from a previous run.
+/// Called from plugin setup so bind failures propagate immediately.
+pub(crate) fn bind(socket_path: &std::path::Path) -> Result<UnixListener, Error> {
     if socket_path.exists() {
         let _ = std::fs::remove_file(socket_path);
     }
-
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
+    Ok(listener)
+}
+
+/// Run the accept loop on a pre-bound listener. Logs errors internally.
+pub(crate) async fn run(listener: UnixListener, engine: EvalEngine, eval_fn: Option<EvalFn>) {
+    if let Err(e) = accept_loop(listener, engine, eval_fn).await {
+        tracing::error!("socket server error: {e}");
+    }
+}
+
+async fn accept_loop(
+    listener: UnixListener,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+) -> Result<(), Error> {
     let ctx = Arc::new((engine, eval_fn));
 
     loop {
@@ -71,6 +74,11 @@ async fn handle_connection(
         }
 
         let response = match serde_json::from_str::<Request>(trimmed) {
+            Ok(req) if req.jsonrpc != "2.0" => Response::error(
+                req.id,
+                -32600,
+                "Invalid JSON-RPC version (expected \"2.0\")",
+            ),
             Ok(req) => dispatch(&req, engine, eval_fn).await,
             Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
         };
@@ -99,13 +107,13 @@ async fn dispatch(req: &Request, engine: &EvalEngine, eval_fn: Option<&EvalFn>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::time::Duration;
 
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
-        let _ = std::fs::remove_file(path);
-        let p = path.clone();
+        let listener = bind(path).expect("bind test socket");
         let engine = EvalEngine::new();
-        let handle = tokio::spawn(async move { start(p, engine, None).await });
+        let handle = tokio::spawn(async move { run(listener, engine, None).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
     }

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -55,15 +55,24 @@ pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, Socke
         Ok(l) => l,
         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
             // Probe: if a live server answers, the socket is truly in use.
-            if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
-                return Err(Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::AddrInUse,
-                    format!("socket already in use: {}", socket_path.display()),
-                )));
+            // Only treat ConnectionRefused as "stale" — other errors (e.g.
+            // PermissionDenied) should propagate rather than blindly unlinking.
+            match std::os::unix::net::UnixStream::connect(socket_path) {
+                Ok(_) => {
+                    return Err(Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::AddrInUse,
+                        format!("socket already in use: {}", socket_path.display()),
+                    )));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                    // Stale socket from a crashed process — safe to remove and retry.
+                    let _ = std::fs::remove_file(socket_path);
+                    UnixListener::bind(socket_path)?
+                }
+                Err(e) => {
+                    return Err(Error::Io(e));
+                }
             }
-            // Stale socket from a crashed process — safe to remove and retry.
-            let _ = std::fs::remove_file(socket_path);
-            UnixListener::bind(socket_path)?
         }
         Err(e) => return Err(Error::Io(e)),
     };

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -1,33 +1,52 @@
 use crate::error::Error;
+use crate::eval::EvalEngine;
 use crate::handler;
 use crate::protocol::{Request, Response};
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-/// Start the socket server. Logs errors internally — never returns `Err` to callers.
-pub(crate) async fn start(socket_path: PathBuf) {
-    if let Err(e) = run(&socket_path).await {
+/// A function that evaluates JS in the webview. `None` if no webview is available.
+pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
+
+/// Start the socket server. Logs errors internally.
+pub(crate) async fn start(
+    socket_path: PathBuf,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+) {
+    if let Err(e) = run(&socket_path, engine, eval_fn).await {
         tracing::error!(path = %socket_path.display(), "socket server error: {e}");
     }
 }
 
-async fn run(socket_path: &PathBuf) -> Result<(), Error> {
+async fn run(
+    socket_path: &PathBuf,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+) -> Result<(), Error> {
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
+    let ctx = Arc::new((engine, eval_fn));
 
     loop {
         let (stream, _addr) = listener.accept().await?;
+        let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream).await {
+            if let Err(e) = handle_connection(stream, &ctx.0, ctx.1.as_ref()).await {
                 tracing::warn!("connection error: {e}");
             }
         });
     }
 }
 
-async fn handle_connection(stream: UnixStream) -> Result<(), Error> {
+async fn handle_connection(
+    stream: UnixStream,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+) -> Result<(), Error> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
@@ -45,7 +64,7 @@ async fn handle_connection(stream: UnixStream) -> Result<(), Error> {
         }
 
         let response = match serde_json::from_str::<Request>(trimmed) {
-            Ok(req) => dispatch(&req),
+            Ok(req) => dispatch(&req, engine, eval_fn).await,
             Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
         };
 
@@ -58,8 +77,12 @@ async fn handle_connection(stream: UnixStream) -> Result<(), Error> {
     Ok(())
 }
 
-fn dispatch(req: &Request) -> Response {
-    match handler::dispatch(&req.method, req.params.as_ref()) {
+async fn dispatch(
+    req: &Request,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+) -> Response {
+    match handler::dispatch(&req.method, req.params.as_ref(), engine, eval_fn).await {
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {
             jsonrpc: "2.0".to_owned(),
@@ -78,7 +101,8 @@ mod tests {
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let _ = std::fs::remove_file(path);
         let p = path.clone();
-        let handle = tokio::spawn(async move { start(p).await });
+        let engine = EvalEngine::new();
+        let handle = tokio::spawn(async move { start(p, engine, None).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
     }

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -3,6 +3,7 @@ use crate::eval::EvalEngine;
 use crate::handler;
 use crate::protocol::{Request, Response};
 
+use std::os::unix::fs::MetadataExt;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -11,13 +12,20 @@ use tokio::net::{UnixListener, UnixStream};
 pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
 /// RAII guard that removes the socket file on drop (normal shutdown or panic).
-pub(crate) struct SocketGuard(std::path::PathBuf);
+/// Stores the inode at bind time so it only unlinks its own socket, not one
+/// created by an overlapping instance.
+pub(crate) struct SocketGuard {
+    path: std::path::PathBuf,
+    inode: u64,
+}
 
 impl Drop for SocketGuard {
     fn drop(&mut self) {
-        if self.0.exists() {
-            let _ = std::fs::remove_file(&self.0);
-            tracing::info!(path = %self.0.display(), "socket removed");
+        if let Ok(meta) = std::fs::metadata(&self.path)
+            && meta.ino() == self.inode
+        {
+            let _ = std::fs::remove_file(&self.path);
+            tracing::info!(path = %self.path.display(), "socket removed");
         }
     }
 }
@@ -30,7 +38,16 @@ pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, Socke
     }
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
-    Ok((listener, SocketGuard(socket_path.to_path_buf())))
+
+    let inode = std::fs::metadata(socket_path).map(|m| m.ino()).unwrap_or(0);
+
+    Ok((
+        listener,
+        SocketGuard {
+            path: socket_path.to_path_buf(),
+            inode,
+        },
+    ))
 }
 
 /// Run the accept loop on a pre-bound listener. Logs errors internally.
@@ -126,7 +143,18 @@ async fn dispatch(req: &Request, engine: &EvalEngine, eval_fn: Option<&EvalFn>) 
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_socket_path() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(format!(
+            "/tmp/tauri-pilot-test-{}-{n}.sock",
+            std::process::id()
+        ))
+    }
 
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let (listener, guard) = bind(path).expect("bind test socket");
@@ -138,7 +166,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_responds_ping_ok() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t04a.sock");
+        let socket = unique_socket_path();
         let handle = start_test_server(&socket).await;
 
         let stream = UnixStream::connect(&socket).await.unwrap();
@@ -165,7 +193,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_handles_invalid_json() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03b.sock");
+        let socket = unique_socket_path();
         let handle = start_test_server(&socket).await;
 
         let stream = UnixStream::connect(&socket).await.unwrap();
@@ -189,7 +217,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_handles_multiple_requests() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03c.sock");
+        let socket = unique_socket_path();
         let handle = start_test_server(&socket).await;
 
         let stream = UnixStream::connect(&socket).await.unwrap();

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -1,0 +1,156 @@
+use crate::error::Error;
+use crate::protocol::{Request, Response};
+
+use std::path::PathBuf;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+/// Start the socket server. Logs errors internally — never returns `Err` to callers.
+pub(crate) async fn start(socket_path: PathBuf) {
+    if let Err(e) = run(&socket_path).await {
+        tracing::error!(path = %socket_path.display(), "socket server error: {e}");
+    }
+}
+
+async fn run(socket_path: &PathBuf) -> Result<(), Error> {
+    let listener = UnixListener::bind(socket_path)?;
+    tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
+
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream).await {
+                tracing::warn!("connection error: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_connection(stream: UnixStream) -> Result<(), Error> {
+    let (reader, mut writer) = stream.into_split();
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<Request>(trimmed) {
+            Ok(req) => dispatch(&req),
+            Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
+        };
+
+        let mut resp_bytes = serde_json::to_vec(&response)?;
+        resp_bytes.push(b'\n');
+        writer.write_all(&resp_bytes).await?;
+        writer.flush().await?;
+    }
+
+    Ok(())
+}
+
+fn dispatch(req: &Request) -> Response {
+    Response::error(
+        req.id,
+        -32601,
+        format!("Method not found: {}", req.method),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
+        let _ = std::fs::remove_file(path);
+        let p = path.clone();
+        let handle = tokio::spawn(async move { start(p).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle
+    }
+
+    #[tokio::test]
+    async fn test_server_responds_method_not_found() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03a.sock");
+        let handle = start_test_server(&socket).await;
+
+        let stream = UnixStream::connect(&socket).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        let resp: Response = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(resp.id, 1);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32601);
+        assert!(err.message.contains("ping"));
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_server_handles_invalid_json() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03b.sock");
+        let handle = start_test_server(&socket).await;
+
+        let stream = UnixStream::connect(&socket).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer.write_all(b"not json\n").await.unwrap();
+        writer.flush().await.unwrap();
+
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        let resp: Response = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(resp.id, 0);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32700);
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_server_handles_multiple_requests() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03c.sock");
+        let handle = start_test_server(&socket).await;
+
+        let stream = UnixStream::connect(&socket).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        for i in 1..=3 {
+            let req = format!("{{\"jsonrpc\":\"2.0\",\"id\":{i},\"method\":\"test\"}}\n");
+            writer.write_all(req.as_bytes()).await.unwrap();
+            writer.flush().await.unwrap();
+
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let resp: Response = serde_json::from_str(&line).unwrap();
+            assert_eq!(resp.id, i);
+        }
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+}

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -32,10 +32,9 @@ impl Drop for SocketGuard {
     }
 }
 
-/// Get inode from a listener's file descriptor via `fstat`.
+/// Get inode from a raw file descriptor via `fstat`.
 /// This is race-free: it queries the kernel FD, not the filesystem path.
-fn inode_from_fd(listener: &UnixListener) -> u64 {
-    let fd = listener.as_raw_fd();
+fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
     // SAFETY: fstat only reads from a valid fd and writes to our stack buffer.
     unsafe {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
@@ -47,11 +46,16 @@ fn inode_from_fd(listener: &UnixListener) -> u64 {
     }
 }
 
-/// Bind the socket. Tries bind first; only removes stale files on `AddrInUse`
-/// after verifying no live server is listening.
-/// Returns the listener and a [`SocketGuard`] that cleans up on drop.
-pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, SocketGuard), Error> {
-    let listener = match UnixListener::bind(socket_path) {
+/// Bind the socket using the **std** (sync) listener so this can be called
+/// outside a tokio runtime (e.g. from Tauri plugin `setup`).
+///
+/// Tries bind first; only removes stale files on `AddrInUse` after verifying
+/// no live server is listening.
+/// Returns a std listener and a [`SocketGuard`] that cleans up on drop.
+pub(crate) fn bind(
+    socket_path: &std::path::Path,
+) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
+    let listener = match std::os::unix::net::UnixListener::bind(socket_path) {
         Ok(l) => l,
         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
             // Probe: if a live server answers, the socket is truly in use.
@@ -67,7 +71,7 @@ pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, Socke
                 Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
                     // Stale socket from a crashed process — safe to remove and retry.
                     let _ = std::fs::remove_file(socket_path);
-                    UnixListener::bind(socket_path)?
+                    std::os::unix::net::UnixListener::bind(socket_path)?
                 }
                 Err(e) => {
                     return Err(Error::Io(e));
@@ -77,8 +81,13 @@ pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, Socke
         Err(e) => return Err(Error::Io(e)),
     };
 
+    // Must be non-blocking for tokio conversion
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking on unix listener");
+
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
-    let inode = inode_from_fd(&listener);
+    let inode = inode_from_raw_fd(listener.as_raw_fd());
 
     Ok((
         listener,
@@ -89,14 +98,21 @@ pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, Socke
     ))
 }
 
-/// Run the accept loop on a pre-bound listener. Logs errors internally.
+/// Run the accept loop on a pre-bound std listener. Converts to tokio internally.
 /// The `_guard` is held for its `Drop` cleanup.
 pub(crate) async fn run(
-    listener: UnixListener,
+    std_listener: std::os::unix::net::UnixListener,
     _guard: SocketGuard,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
 ) {
+    let listener = match UnixListener::from_std(std_listener) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("failed to convert listener to tokio: {e}");
+            return;
+        }
+    };
     if let Err(e) = accept_loop(listener, engine, eval_fn).await {
         tracing::error!("socket server error: {e}");
     }

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -82,9 +82,7 @@ pub(crate) fn bind(
     };
 
     // Must be non-blocking for tokio conversion
-    listener
-        .set_nonblocking(true)
-        .expect("set_nonblocking on unix listener");
+    listener.set_nonblocking(true)?;
 
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
     let inode = inode_from_raw_fd(listener.as_raw_fd());

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -23,12 +23,23 @@ async fn run(
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
 ) -> Result<(), Error> {
+    // Remove stale socket from a previous run that didn't clean up
+    if socket_path.exists() {
+        let _ = std::fs::remove_file(socket_path);
+    }
+
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
     let ctx = Arc::new((engine, eval_fn));
 
     loop {
-        let (stream, _addr) = listener.accept().await?;
+        let (stream, _addr) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::warn!("accept error: {e}");
+                continue;
+            }
+        };
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
             if let Err(e) = handle_connection(stream, &ctx.0, ctx.1.as_ref()).await {

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -3,7 +3,7 @@ use crate::eval::EvalEngine;
 use crate::handler;
 use crate::protocol::{Request, Response};
 
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -21,6 +21,8 @@ pub(crate) struct SocketGuard {
 
 impl Drop for SocketGuard {
     fn drop(&mut self) {
+        use std::os::unix::fs::MetadataExt;
+        // Only unlink if the on-disk inode still matches ours
         if let Ok(meta) = std::fs::metadata(&self.path)
             && meta.ino() == self.inode
         {
@@ -30,16 +32,44 @@ impl Drop for SocketGuard {
     }
 }
 
-/// Bind the socket, removing any stale file from a previous run.
+/// Get inode from a listener's file descriptor via `fstat`.
+/// This is race-free: it queries the kernel FD, not the filesystem path.
+fn inode_from_fd(listener: &UnixListener) -> u64 {
+    let fd = listener.as_raw_fd();
+    // SAFETY: fstat only reads from a valid fd and writes to our stack buffer.
+    unsafe {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        if libc::fstat(fd, stat.as_mut_ptr()) == 0 {
+            stat.assume_init().st_ino
+        } else {
+            0
+        }
+    }
+}
+
+/// Bind the socket. Tries bind first; only removes stale files on `AddrInUse`
+/// after verifying no live server is listening.
 /// Returns the listener and a [`SocketGuard`] that cleans up on drop.
 pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, SocketGuard), Error> {
-    if socket_path.exists() {
-        let _ = std::fs::remove_file(socket_path);
-    }
-    let listener = UnixListener::bind(socket_path)?;
-    tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
+    let listener = match UnixListener::bind(socket_path) {
+        Ok(l) => l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            // Probe: if a live server answers, the socket is truly in use.
+            if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    format!("socket already in use: {}", socket_path.display()),
+                )));
+            }
+            // Stale socket from a crashed process — safe to remove and retry.
+            let _ = std::fs::remove_file(socket_path);
+            UnixListener::bind(socket_path)?
+        }
+        Err(e) => return Err(Error::Io(e)),
+    };
 
-    let inode = std::fs::metadata(socket_path).map(|m| m.ino()).unwrap_or(0);
+    tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
+    let inode = inode_from_fd(&listener);
 
     Ok((
         listener,

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -12,11 +12,7 @@ use tokio::net::{UnixListener, UnixStream};
 pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
 /// Start the socket server. Logs errors internally.
-pub(crate) async fn start(
-    socket_path: PathBuf,
-    engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-) {
+pub(crate) async fn start(socket_path: PathBuf, engine: EvalEngine, eval_fn: Option<EvalFn>) {
     if let Err(e) = run(&socket_path, engine, eval_fn).await {
         tracing::error!(path = %socket_path.display(), "socket server error: {e}");
     }
@@ -77,11 +73,7 @@ async fn handle_connection(
     Ok(())
 }
 
-async fn dispatch(
-    req: &Request,
-    engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-) -> Response {
+async fn dispatch(req: &Request, engine: &EvalEngine, eval_fn: Option<&EvalFn>) -> Response {
     match handler::dispatch(&req.method, req.params.as_ref(), engine, eval_fn).await {
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::handler;
 use crate::protocol::{Request, Response};
 
 use std::path::PathBuf;
@@ -58,11 +59,15 @@ async fn handle_connection(stream: UnixStream) -> Result<(), Error> {
 }
 
 fn dispatch(req: &Request) -> Response {
-    Response::error(
-        req.id,
-        -32601,
-        format!("Method not found: {}", req.method),
-    )
+    match handler::dispatch(&req.method, req.params.as_ref()) {
+        Ok(result) => Response::success(req.id, result),
+        Err(rpc_err) => Response {
+            jsonrpc: "2.0".to_owned(),
+            id: req.id,
+            result: None,
+            error: Some(rpc_err),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -79,8 +84,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_server_responds_method_not_found() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t03a.sock");
+    async fn test_server_responds_ping_ok() {
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t04a.sock");
         let handle = start_test_server(&socket).await;
 
         let stream = UnixStream::connect(&socket).await.unwrap();
@@ -98,9 +103,8 @@ mod tests {
         let resp: Response = serde_json::from_str(&line).unwrap();
 
         assert_eq!(resp.id, 1);
-        let err = resp.error.unwrap();
-        assert_eq!(err.code, -32601);
-        assert!(err.message.contains("ping"));
+        assert!(resp.error.is_none());
+        assert_eq!(resp.result, Some(serde_json::json!({"status": "ok"})));
 
         handle.abort();
         let _ = std::fs::remove_file(&socket);

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -10,19 +10,37 @@ use tokio::net::{UnixListener, UnixStream};
 /// A function that evaluates JS in the webview. `None` if no webview is available.
 pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
 
+/// RAII guard that removes the socket file on drop (normal shutdown or panic).
+pub(crate) struct SocketGuard(std::path::PathBuf);
+
+impl Drop for SocketGuard {
+    fn drop(&mut self) {
+        if self.0.exists() {
+            let _ = std::fs::remove_file(&self.0);
+            tracing::info!(path = %self.0.display(), "socket removed");
+        }
+    }
+}
+
 /// Bind the socket, removing any stale file from a previous run.
-/// Called from plugin setup so bind failures propagate immediately.
-pub(crate) fn bind(socket_path: &std::path::Path) -> Result<UnixListener, Error> {
+/// Returns the listener and a [`SocketGuard`] that cleans up on drop.
+pub(crate) fn bind(socket_path: &std::path::Path) -> Result<(UnixListener, SocketGuard), Error> {
     if socket_path.exists() {
         let _ = std::fs::remove_file(socket_path);
     }
     let listener = UnixListener::bind(socket_path)?;
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
-    Ok(listener)
+    Ok((listener, SocketGuard(socket_path.to_path_buf())))
 }
 
 /// Run the accept loop on a pre-bound listener. Logs errors internally.
-pub(crate) async fn run(listener: UnixListener, engine: EvalEngine, eval_fn: Option<EvalFn>) {
+/// The `_guard` is held for its `Drop` cleanup.
+pub(crate) async fn run(
+    listener: UnixListener,
+    _guard: SocketGuard,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+) {
     if let Err(e) = accept_loop(listener, engine, eval_fn).await {
         tracing::error!("socket server error: {e}");
     }
@@ -111,9 +129,9 @@ mod tests {
     use std::time::Duration;
 
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
-        let listener = bind(path).expect("bind test socket");
+        let (listener, guard) = bind(path).expect("bind test socket");
         let engine = EvalEngine::new();
-        let handle = tokio::spawn(async move { run(listener, engine, None).await });
+        let handle = tokio::spawn(async move { run(listener, guard, engine, None).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
     }

--- a/scripts/integrate-prism.sh
+++ b/scripts/integrate-prism.sh
@@ -11,9 +11,11 @@ if [ ! -f "$PRISM_DIR/src-tauri/Cargo.toml" ]; then
   exit 1
 fi
 
+PILOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
 echo "Adding tauri-plugin-pilot dependency to Prism..."
 cd "$PRISM_DIR/src-tauri"
-cargo add tauri-plugin-pilot --path "../../tauri-pilot/crates/tauri-plugin-pilot"
+cargo add tauri-plugin-pilot --path "$PILOT_DIR/crates/tauri-plugin-pilot"
 
 echo "Done! Now add this to $PRISM_DIR/src-tauri/src/lib.rs after .plugin(tauri_plugin_opener::init()):"
 echo ""

--- a/scripts/integrate-prism.sh
+++ b/scripts/integrate-prism.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Integrate tauri-pilot plugin into Prism for development testing.
+# Run from the tauri-pilot project root.
+set -euo pipefail
+
+PRISM_DIR="${1:-../prism}"
+
+if [ ! -f "$PRISM_DIR/src-tauri/Cargo.toml" ]; then
+  echo "Error: Prism not found at $PRISM_DIR"
+  echo "Usage: $0 [prism-directory]"
+  exit 1
+fi
+
+echo "Adding tauri-plugin-pilot dependency to Prism..."
+cd "$PRISM_DIR/src-tauri"
+cargo add tauri-plugin-pilot --path "../../tauri-pilot/crates/tauri-plugin-pilot"
+
+echo "Done! Now add this to $PRISM_DIR/src-tauri/src/lib.rs after .plugin(tauri_plugin_opener::init()):"
+echo ""
+echo '    #[cfg(debug_assertions)]'
+echo '    let builder = builder.plugin(tauri_plugin_pilot::init());'
+echo ""
+echo "Then run: cd $PRISM_DIR && cargo tauri dev"
+echo "Test with: tauri-pilot ping"


### PR DESCRIPTION
## Summary
- **T01**: Cargo workspace with 2 crates, edition 2024, clippy strict (unwrap_used=deny, pedantic=warn)
- **T02**: JSON-RPC 2.0 types (Request, Response, RpcError) with round-trip tests
- **T03**: Unix socket server with newline-delimited framing, per-connection tasks
- **T04**: Handler dispatch with ping method
- **T05**: CLI socket client with connect/call, Clap parser with --socket auto-detection
- **T06**: All 20 CLI subcommands defined, target resolution (@ref, CSS selector, coords)
- **T07**: EvalEngine — pending HashMap, script wrapping (ADR-001), timeout
- **T08**: __callback IPC handler, EvalEngine in app state
- **T09**: bridge.js — snapshot() TreeWalker, refs, ROLE_MAP, interactive filter
- **T10**: bridge.js injection via js_init_script, snapshot handler with eval bridge
- **T11**: Snapshot text formatter — indented accessibility tree output

**Total: 34 story points across 11 tasks**

## Architecture
- Plugin communicates via Unix socket (`/tmp/tauri-pilot-{identifier}.sock`)
- JSON-RPC 2.0 protocol, hand-crafted (~50 lines per crate)
- eval+callback pattern (ADR-001): webview.eval() → JS invoke callback → oneshot channel
- bridge.js injected at boot via js_init_script()

## Test plan
- [x] `cargo test --workspace` — 41 tests passing
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual test on Prism: `tauri-pilot ping` and `tauri-pilot snapshot -i`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initial release of `tauri-plugin-pilot` and `tauri-pilot-cli` to inspect and control Tauri apps via a JSON‑RPC Unix socket, with a JS eval bridge, accessibility snapshot, and a broad set of interaction/read tools. Debug‑only on Unix with safe socket cleanup; tighter IPC and protocol validation improve reliability.

- **New Features**
  - Cargo workspace with strict clippy; two crates: `tauri-plugin-pilot` and `tauri-pilot-cli`.
  - JSON‑RPC 2.0 over newline‑framed Unix socket at `/tmp/tauri-pilot-{identifier}.sock`.
  - JS bridge injected at boot; eval engine with callback pattern and timeouts.
  - Handlers + CLI for: `ping`, `snapshot`, interactions (`click`, `fill`, `type`, `press`, `select`, `check`, `scroll`), read (`text`, `html`, `value`, `attrs`), `eval`, `ipc`, navigation/state (`navigate`, `url`, `title`, `state`), `wait`, and `screenshot` (CLI decodes base64 to PNG).
  - Permission manifest with default allow for `__callback` and plugin `build.rs` for permission discovery; `links` added to crate for proper plugin build.
  - CLI niceties: socket auto‑detect and `--json`; SKILL guide and Prism integration script.

- **Bug Fixes**
  - IPC hardening: use a safe JS string literal for command names, validate response IDs, normalize `null` params, require a non‑empty IPC `command` (invalid params return `-32602`).
  - IPC invoke path: use `__TAURI_INTERNALS__.invoke` for IPC/callbacks so it works without `withGlobalTauri` in Tauri v2.
  - Protocol validation: reject non‑"2.0" JSON‑RPC requests with `-32600`.
  - Startup robustness: bind socket synchronously with std `UnixListener` in plugin setup, then convert to Tokio in `run()`; pre‑bind + connect probe, race‑free inode capture via `fstat`, unlink stale sockets only on ConnectionRefused; RAII guard unlinks only its own socket; sanitize app identifier for the socket filename.
  - Eval/snapshot/interaction reliability: await async eval results and IPC callbacks; handle non‑Error rejections; skip hidden inputs; enforce max depth; guard `checked`; fix `type` value mutation; use native setter for `select`; prefer `"main"` webview; clean up pending evals on channel close; clearer “(empty snapshot)” output and socket/fs errors.
  - Bridge API parity: all bridge actions accept a single params object (e.g., `click({ref})`) to match Rust handlers.
  - Platform gating: plugin active only on Unix in debug builds; server module gated behind `unix` for non‑Unix build compatibility.
  - Non‑blocking socket setup no longer panics: propagate `set_nonblocking` errors instead of `expect()`.
  - Target resolution in bridge: added `resolveTarget` to support `@ref`, CSS selectors, and `x,y` coords consistently; `html({selector})` now returns that element’s HTML instead of the full document.

<sup>Written for commit 2bb5ea01cfeacab9fbc83b34bcd2f73b1d368132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Tauri testing & automation suite: a CLI and plugin for interactive app control, DOM snapshotting, element inspection, actions (click/fill/type/press/select/check/scroll), navigation, eval/ipc, waits, and screenshots (JSON or human-readable; screenshots can be saved).

* **Documentation**
  * User guide with command reference, example workflows, flags, and socket autodetection.

* **Chores**
  * Workspace configuration and a helper script to integrate the plugin into a local Tauri project for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->