### PR TITLE
feat: console log capture (console.log/warn/error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ tauri-pilot screenshot ./capture.png
 | `wait` | Wait for element to appear/disappear |
 | `navigate` | Change the WebView URL |
 | `state` | Get URL, title, viewport, scroll |
+| `logs` | Capture and display console output |
 
 ## For AI Agents
 
@@ -137,6 +138,7 @@ tauri-pilot is designed for AI agent consumption. The workflow is:
 2. Read the refs in the output (`@e1`, `@e2`, ...)
 3. `tauri-pilot click @e3` — interact using refs
 4. `tauri-pilot snapshot -i` — verify the result
+5. `tauri-pilot logs --level error` — check for JS errors
 
 Use `--json` for structured output when parsing programmatically.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,7 @@
 3. **Use `wait` after async actions** (navigation, data loading, animations).
 4. **Use `@ref` notation** (e.g., `@e3`) to target elements from the snapshot.
 5. **One action at a time**, then re-snapshot to verify.
+6. **Check `logs --level error`** after actions to catch JS errors.
 
 ## Commands Reference
 
@@ -47,6 +48,11 @@
 | `title` | Get page title | `tauri-pilot title` |
 | `state` | Get app state | `tauri-pilot state` |
 | `screenshot` | Capture PNG | `tauri-pilot screenshot ./out.png` |
+| `logs` | Show console output | `tauri-pilot logs` |
+| `logs --level` | Filter by level | `tauri-pilot logs --level error` |
+| `logs --last` | Last N entries | `tauri-pilot logs --last 10` |
+| `logs --follow` | Stream logs | `tauri-pilot logs -f` |
+| `logs --clear` | Flush buffer | `tauri-pilot logs --clear` |
 
 ## Example Workflows
 
@@ -80,6 +86,15 @@ tauri-pilot url
 tauri-pilot navigate "/settings"
 tauri-pilot wait --selector "#settings-page"
 tauri-pilot snapshot -i
+```
+
+### Debug with console logs
+
+```bash
+tauri-pilot logs --clear
+tauri-pilot click @e3           # trigger action
+tauri-pilot logs --level error  # check for JS errors
+tauri-pilot logs --json         # structured output for parsing
 ```
 
 ## Flags

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "io-util"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "io-util", "time"] }
 tracing.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -91,7 +91,7 @@ pub(crate) enum Command {
     /// Display or stream captured console logs.
     Logs {
         /// Filter by log level (log, info, warn, error).
-        #[arg(long)]
+        #[arg(long, value_parser = ["log", "info", "warn", "error"])]
         level: Option<String>,
 
         /// Show last N log entries.

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -88,6 +88,24 @@ pub(crate) enum Command {
         #[arg(long, default_value = "10000")]
         timeout: u64,
     },
+    /// Display or stream captured console logs.
+    Logs {
+        /// Filter by log level (log, info, warn, error).
+        #[arg(long)]
+        level: Option<String>,
+
+        /// Show last N log entries.
+        #[arg(long)]
+        last: Option<usize>,
+
+        /// Clear the log buffer.
+        #[arg(long, conflicts_with = "follow")]
+        clear: bool,
+
+        /// Continuously poll for new logs.
+        #[arg(long, short = 'f')]
+        follow: bool,
+    },
 }
 
 /// Parsed target for element-targeting commands.

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -7,7 +7,7 @@ mod style;
 use anyhow::Result;
 use base64::Engine;
 use clap::Parser;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -29,6 +29,53 @@ async fn main() -> Result<()> {
     let mut client = Client::connect(&socket).await?;
 
     let is_snapshot = matches!(args.command, Command::Snapshot { .. });
+    let is_logs = matches!(args.command, Command::Logs { .. });
+
+    // Handle --follow mode: loop forever polling for new logs
+    if let Command::Logs {
+        follow: true,
+        ref level,
+        ref last,
+        ..
+    } = args.command
+    {
+        let mut last_seen_id: u64 = 0;
+        let mut first_poll = true;
+        loop {
+            let mut params = serde_json::Map::new();
+            if last_seen_id > 0 {
+                params.insert("sinceId".into(), json!(last_seen_id));
+            }
+            if let Some(l) = level {
+                params.insert("level".into(), json!(l.clone()));
+            }
+            if first_poll {
+                if let Some(n) = last {
+                    params.insert("last".into(), json!(n));
+                }
+                first_poll = false;
+            }
+            let result = client
+                .call("console.getLogs", Some(Value::Object(params)))
+                .await?;
+            if let Some(entries) = result.as_array()
+                && !entries.is_empty()
+            {
+                if args.json {
+                    output::format_json(&result)?;
+                } else {
+                    print!("{}", output::format_logs(&result));
+                }
+                last_seen_id = entries
+                    .last()
+                    .and_then(|e| e.get("id"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(last_seen_id);
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
     let screenshot_path = if let Command::Screenshot { ref path, .. } = args.command {
         path.clone()
     } else {
@@ -64,6 +111,8 @@ async fn main() -> Result<()> {
         output::format_json(&result)?;
     } else if is_snapshot {
         output::format_snapshot(&result);
+    } else if is_logs {
+        print!("{}", output::format_logs(&result));
     } else {
         output::format_text(&result);
     }
@@ -129,16 +178,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
         Command::Value { target } => client.call("value", Some(target_params(&target))).await,
         Command::Attrs { target } => client.call("attrs", Some(target_params(&target))).await,
         Command::Eval { script } => client.call("eval", Some(json!({"script": script}))).await,
-        Command::Ipc { command, args } => {
-            let parsed_args: Option<serde_json::Value> =
-                args.as_deref().map(serde_json::from_str).transpose()?;
-            client
-                .call(
-                    "ipc",
-                    Some(json!({"command": command, "args": parsed_args})),
-                )
-                .await
-        }
+        Command::Ipc { command, args } => run_ipc_command(client, &command, args.as_deref()).await,
         Command::Screenshot { path, selector } => {
             client
                 .call(
@@ -168,7 +208,52 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
                 )
                 .await
         }
+        Command::Logs {
+            level,
+            last,
+            clear,
+            follow,
+        } => run_logs_command(client, level, last, clear, follow).await,
     }
+}
+
+async fn run_ipc_command(
+    client: &mut Client,
+    command: &str,
+    args: Option<&str>,
+) -> Result<serde_json::Value> {
+    let parsed_args: Option<serde_json::Value> = args.map(serde_json::from_str).transpose()?;
+    client
+        .call(
+            "ipc",
+            Some(json!({"command": command, "args": parsed_args})),
+        )
+        .await
+}
+
+async fn run_logs_command(
+    client: &mut Client,
+    level: Option<String>,
+    last: Option<usize>,
+    clear: bool,
+    follow: bool,
+) -> Result<serde_json::Value> {
+    if follow {
+        anyhow::bail!("follow mode must be handled before run_command");
+    }
+    if clear {
+        return client.call("console.clear", None).await;
+    }
+    let mut params = serde_json::Map::new();
+    if let Some(l) = level {
+        params.insert("level".into(), json!(l));
+    }
+    if let Some(n) = last {
+        params.insert("last".into(), json!(n));
+    }
+    client
+        .call("console.getLogs", Some(serde_json::Value::Object(params)))
+        .await
 }
 
 fn target_params(raw: &str) -> serde_json::Value {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -62,7 +62,12 @@ async fn main() -> Result<()> {
                 && !entries.is_empty()
             {
                 if args.json {
-                    output::format_json(&result)?;
+                    // Emit NDJSON: one JSON object per entry for jq compatibility
+                    if let Some(entries) = result.as_array() {
+                        for entry in entries {
+                            println!("{entry}");
+                        }
+                    }
                 } else {
                     print!("{}", output::format_logs(&result));
                 }
@@ -112,7 +117,12 @@ async fn main() -> Result<()> {
     } else if is_snapshot {
         output::format_snapshot(&result);
     } else if is_logs {
-        print!("{}", output::format_logs(&result));
+        // console.clear returns {"cleared": true}, not an array
+        if result.get("cleared").is_some() {
+            output::format_text(&result);
+        } else {
+            print!("{}", output::format_logs(&result));
+        }
     } else {
         output::format_text(&result);
     }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -63,10 +63,8 @@ async fn main() -> Result<()> {
             {
                 if args.json {
                     // Emit NDJSON: one JSON object per entry for jq compatibility
-                    if let Some(entries) = result.as_array() {
-                        for entry in entries {
-                            println!("{entry}");
-                        }
+                    for entry in entries {
+                        println!("{entry}");
                     }
                 } else {
                     print!("{}", output::format_logs(&result));

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -167,14 +167,19 @@ fn strip_ansi(input: &str) -> String {
                         break;
                     }
                 }
-            // Skip OSC sequences: ESC ] ... BEL or ST
+            // Skip OSC sequences: ESC ] ... BEL or ESC \ (ST)
             } else if chars.peek() == Some(&']') {
                 chars.next();
+                let mut prev_was_esc = false;
                 while let Some(&next) = chars.peek() {
                     chars.next();
-                    if next == '\x07' || next == '\\' {
+                    if next == '\x07' {
                         break;
                     }
+                    if prev_was_esc && next == '\\' {
+                        break;
+                    }
+                    prev_was_esc = next == '\x1b';
                 }
             } else {
                 // Skip single-char escape (ESC + one char)
@@ -290,7 +295,19 @@ mod tests {
 
     #[test]
     fn test_strip_ansi_removes_osc_sequences() {
+        // BEL terminator
         assert_eq!(strip_ansi("\x1b]0;title\x07text"), "text");
+        // ST terminator (ESC \)
+        assert_eq!(strip_ansi("\x1b]0;title\x1b\\text"), "text");
+    }
+
+    #[test]
+    fn test_strip_ansi_preserves_backslash_in_osc() {
+        // Bare backslash inside OSC should not terminate early
+        assert_eq!(
+            strip_ansi("\x1b]8;;http://host/path\\to\\file\x07link"),
+            "link"
+        );
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -25,7 +25,7 @@ pub(crate) fn format_text(value: &serde_json::Value) {
         return;
     }
     // {ok: true} → "✓ ok", {found: true} → "✓ found"
-    for key in ["ok", "found"] {
+    for key in ["ok", "found", "cleared"] {
         if value.get(key).and_then(serde_json::Value::as_bool) == Some(true) {
             println!("{}", crate::style::success(key));
             return;

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -98,6 +98,95 @@ pub(crate) fn format_snapshot(value: &serde_json::Value) {
     }
 }
 
+/// Format console log entries for human-readable display.
+pub(crate) fn format_logs(value: &serde_json::Value) -> String {
+    let mut output = String::new();
+    let Some(entries) = value.as_array() else {
+        return format!("{}\n", crate::style::error("Unexpected response format"));
+    };
+    if entries.is_empty() {
+        return String::from("No logs captured\n");
+    }
+    for entry in entries {
+        let timestamp = entry
+            .get("timestamp")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let level = entry.get("level").and_then(|l| l.as_str()).unwrap_or("log");
+        let args = entry.get("args").and_then(|a| a.as_array());
+
+        // Format timestamp as HH:MM:SS.mmm
+        let secs = (timestamp / 1000) % 86400;
+        let ms = timestamp % 1000;
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        let s = secs % 60;
+        let time_str = format!("{h:02}:{m:02}:{s:02}.{ms:03}");
+
+        // Format args (strip ANSI escape sequences to prevent terminal injection)
+        let args_str = match args {
+            Some(arr) => arr
+                .iter()
+                .map(|a| {
+                    let raw = match a {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    };
+                    strip_ansi(&raw)
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+            None => String::new(),
+        };
+
+        // Color by level
+        let level_display = match level {
+            "error" => crate::style::error(level),
+            "warn" => crate::style::warn(level),
+            "info" => crate::style::info(level),
+            _ => crate::style::dim(level),
+        };
+
+        let _ = writeln!(output, "[{time_str}] {level_display} {args_str}");
+    }
+    output
+}
+
+/// Strip ANSI escape sequences from a string to prevent terminal injection.
+fn strip_ansi(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip CSI sequences: ESC [ ... final_byte
+            if chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next.is_ascii_alphabetic() || next == '~' {
+                        break;
+                    }
+                }
+            // Skip OSC sequences: ESC ] ... BEL or ST
+            } else if chars.peek() == Some(&']') {
+                chars.next();
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next == '\x07' || next == '\\' {
+                        break;
+                    }
+                }
+            } else {
+                // Skip single-char escape (ESC + one char)
+                chars.next();
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,5 +256,45 @@ mod tests {
         format_snapshot(&json!({"elements": []}));
         format_snapshot(&json!({}));
         format_snapshot(&json!(null));
+    }
+
+    #[test]
+    fn test_format_logs_with_entries() {
+        let logs = json!([
+            {"id": 1, "timestamp": 3661123_u64, "level": "error", "args": ["fail"], "source": null},
+            {"id": 2, "timestamp": 3661500_u64, "level": "info", "args": ["ok", 42], "source": null},
+        ]);
+        let output = format_logs(&logs);
+        assert!(output.contains("01:01:01.123"));
+        assert!(output.contains("fail"));
+        assert!(output.contains("ok 42"));
+    }
+
+    #[test]
+    fn test_format_logs_empty_array() {
+        let output = format_logs(&json!([]));
+        assert!(output.contains("No logs captured"));
+    }
+
+    #[test]
+    fn test_format_logs_non_array() {
+        let output = format_logs(&json!({"unexpected": true}));
+        assert!(output.contains("Unexpected"));
+    }
+
+    #[test]
+    fn test_strip_ansi_removes_csi_sequences() {
+        assert_eq!(strip_ansi("\x1b[31mred\x1b[0m"), "red");
+        assert_eq!(strip_ansi("\x1b[2J\x1b[Hcleared"), "cleared");
+    }
+
+    #[test]
+    fn test_strip_ansi_removes_osc_sequences() {
+        assert_eq!(strip_ansi("\x1b]0;title\x07text"), "text");
+    }
+
+    #[test]
+    fn test_strip_ansi_preserves_plain_text() {
+        assert_eq!(strip_ansi("hello world"), "hello world");
     }
 }

--- a/crates/tauri-pilot-cli/src/style.rs
+++ b/crates/tauri-pilot-cli/src/style.rs
@@ -74,4 +74,10 @@ mod tests {
         let output = bold("important");
         assert!(output.contains("important"));
     }
+
+    #[test]
+    fn warn_contains_message() {
+        let output = warn("caution");
+        assert!(output.contains("caution"));
+    }
 }

--- a/crates/tauri-pilot-cli/src/style.rs
+++ b/crates/tauri-pilot-cli/src/style.rs
@@ -34,6 +34,11 @@ pub(crate) fn bold(msg: impl Display) -> String {
     format!("{}", msg.if_supports_color(Stdout, |t| t.bold()))
 }
 
+/// Format a warning message in yellow.
+pub(crate) fn warn(msg: impl Display) -> String {
+    format!("{}", msg.if_supports_color(Stdout, |t| t.yellow()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -62,7 +62,7 @@
     try {
       const stack = new Error().stack;
       if (!stack) return null;
-      // Skip: Error, extractSource, captureLog, console.X wrapper
+      // Skip frames: Error constructor, extractSource, console[level] wrapper
       const lines = stack.split('\n');
       for (let i = 3; i < lines.length; i++) {
         const line = lines[i];

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -4,6 +4,10 @@
   const idMap = new Map();
   let refCounter = 0;
 
+  const _logs = [];
+  let _logIdCounter = 0;
+  const MAX_LOGS = 500;
+
   const ROLE_MAP = {
     A: "link",
     BUTTON: "button",
@@ -41,6 +45,77 @@
     "textbox",
     "combobox",
   ]);
+
+  function serializeArg(arg) {
+    if (arg === null) return null;
+    if (arg === undefined) return null;
+    if (typeof arg === 'string' || typeof arg === 'number' || typeof arg === 'boolean') return arg;
+    try {
+      JSON.stringify(arg);
+      return arg;
+    } catch (_) {
+      return String(arg);
+    }
+  }
+
+  function extractSource() {
+    try {
+      const stack = new Error().stack;
+      if (!stack) return null;
+      // Skip: Error, extractSource, captureLog, console.X wrapper
+      const lines = stack.split('\n');
+      for (let i = 3; i < lines.length; i++) {
+        const line = lines[i];
+        if (line && !line.includes('__PILOT__')) return line.trim();
+      }
+      return null;
+    } catch (_) { return null; }
+  }
+
+  const _originalConsole = {
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+  };
+
+  ['log', 'warn', 'error', 'info'].forEach(level => {
+    console[level] = function(...args) {
+      const entry = {
+        id: ++_logIdCounter,
+        timestamp: Date.now(),
+        level: level,
+        args: args.map(serializeArg),
+        source: extractSource(),
+      };
+      _logs.push(entry);
+      if (_logs.length > MAX_LOGS) _logs.shift();
+      _originalConsole[level].apply(console, args);
+    };
+  });
+
+  function consoleLogs(options) {
+    let result = _logs.slice();
+    if (options) {
+      if (options.level) {
+        result = result.filter(e => e.level === options.level);
+      }
+      if (options.sinceId) {
+        result = result.filter(e => e.id > options.sinceId);
+      } else if (options.since) {
+        result = result.filter(e => e.timestamp > options.since);
+      }
+      if (options.last) {
+        result = result.slice(-options.last);
+      }
+    }
+    return result;
+  }
+
+  function clearLogs() {
+    _logs.length = 0;
+    return { cleared: true };
+  }
 
   function inputRole(el) {
     const t = (el.getAttribute("type") || "text").toLowerCase();
@@ -419,5 +494,7 @@
     eval: evalScript,
     wait: waitFor,
     screenshot: screenshot,
+    consoleLogs: consoleLogs,
+    clearLogs: clearLogs,
   };
 })();

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -20,6 +20,8 @@ pub(crate) async fn dispatch(
         | "state" | "wait" | "screenshot" => {
             handle_eval_method(method, params, engine, eval_fn).await
         }
+        "console.getLogs" => handle_eval_method("consoleLogs", params, engine, eval_fn).await,
+        "console.clear" => handle_eval_method("clearLogs", params, engine, eval_fn).await,
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
@@ -195,5 +197,37 @@ mod tests {
         handle_callback(&engine, id, None, Some("TypeError: x".to_owned()));
         let result = rx.await.unwrap();
         assert_eq!(result, Err("TypeError: x".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_console_get_logs_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("console.getLogs", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_console_clear_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("console.clear", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_console_logs() {
+        let params = json!({"level": "error", "last": 10});
+        let script = build_bridge_call("consoleLogs", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.consoleLogs("));
+        assert!(script.contains("\"level\":\"error\""));
+    }
+
+    #[test]
+    fn test_build_bridge_call_clear_logs() {
+        let script = build_bridge_call("clearLogs", None).unwrap();
+        assert_eq!(script, "window.__PILOT__.clearLogs({})");
     }
 }

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -62,7 +62,7 @@ The protocol is implemented with three hand-rolled serde structs (~50 lines tota
 | `Response` | `jsonrpc`, `id`, `result?`, `error?` |
 | `RpcError` | `code`, `message`, `data?` |
 
-21 methods are available: `ping`, `snapshot`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`, `eval`, `screenshot`, `text`, `html`, `value`, `attrs`, `wait`, `navigate`, `url`, `title`, `state`, `ipc`.
+23 methods are available: `ping`, `snapshot`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`, `eval`, `screenshot`, `text`, `html`, `value`, `attrs`, `wait`, `navigate`, `url`, `title`, `state`, `ipc`, `console.getLogs`, `console.clear`.
 
 ## Element Reference System
 
@@ -104,6 +104,7 @@ Key internals:
 - **Snapshot**: Uses a manual recursive traversal over `node.children` to walk the DOM. A `ROLE_MAP` maps implicit HTML element roles (e.g. `<button>` → `"button"`, `<a>` → `"link"`) for elements without an explicit ARIA role.
 - **Actions**: Dispatch realistic DOM event sequences — `focus → mousedown → mouseup → click` — ensuring compatibility with React, Vue, and other frameworks that rely on synthetic events.
 - **`fill`**: Uses the native `HTMLInputElement` value setter via `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` to trigger React's synthetic change events correctly.
+- **Console capture**: Monkey-patches `console.log/warn/error/info`, stores entries in a 500-entry ring buffer with `id`, `timestamp`, `level`, `args`, and `source`. Exposed via `consoleLogs(options)` and `clearLogs()`.
 
 ## Project Structure
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -473,6 +473,78 @@ tauri-pilot wait --selector ".toast-success" --timeout 5000
 
 ---
 
+### `logs`
+
+Display or stream captured console logs (`console.log`, `console.warn`, `console.error`, `console.info`).
+
+The JS bridge monkey-patches the browser console methods and stores entries in a 500-entry ring buffer with timestamp, level, serialized arguments, and source location.
+
+```bash
+tauri-pilot logs [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--level <level>` | Filter by log level: `log`, `info`, `warn`, `error` |
+| `--last <n>` | Show only the last N entries |
+| `-f`, `--follow` | Continuously poll for new logs (500ms interval) |
+| `--clear` | Flush the ring buffer |
+
+**Examples:**
+
+```bash
+# Show all captured logs
+$ tauri-pilot logs
+[14:32:01.123] log App initialized
+[14:32:01.456] warn Deprecated API call
+[14:32:02.789] ✗ error Failed to fetch: NetworkError
+
+# Filter by level
+$ tauri-pilot logs --level error
+[14:32:02.789] ✗ error Failed to fetch: NetworkError
+
+# Last 5 entries
+$ tauri-pilot logs --last 5
+
+# Stream logs in real-time
+$ tauri-pilot logs --follow
+
+# Stream errors as NDJSON (one JSON object per line, compatible with jq)
+$ tauri-pilot logs --follow --level error --json
+
+# Clear the buffer
+$ tauri-pilot logs --clear
+✓ cleared
+```
+
+**JSON output format:**
+
+```json
+[
+  {
+    "id": 1,
+    "timestamp": 1712073600000,
+    "level": "error",
+    "args": ["Failed to fetch:", "NetworkError: 500"],
+    "source": "app.js:42"
+  }
+]
+```
+
+**JSON-RPC examples:**
+
+```json
+// Get logs filtered by level
+{"jsonrpc":"2.0","id":1,"method":"console.getLogs","params":{"level":"error","last":10}}
+
+// Clear buffer
+{"jsonrpc":"2.0","id":2,"method":"console.clear"}
+```
+
+---
+
 ## JSON-RPC Protocol
 
 The CLI communicates with the plugin over a Unix socket using a hand-rolled JSON-RPC 2.0 protocol with newline-delimited framing (`\n`).


### PR DESCRIPTION
## Summary
- Monkey-patch `console.log/warn/error/info` in the JS bridge with a 500-entry ring buffer storing timestamp, level, args, and source location
- Add `console.getLogs` and `console.clear` JSON-RPC methods to the plugin handler
- Add `tauri-pilot logs` CLI command with `--level`, `--last`, `--follow`, `--clear`, `--json` flags
- Colored output formatting (error=red, warn=yellow, info=cyan, log=dim) with ANSI escape stripping for security

## Test plan
- [x] 65 tests pass (`cargo test --workspace`) — 34 CLI + 31 plugin
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Manual: run a Tauri app with plugin, trigger `console.log("hello")` in the webview, verify `tauri-pilot logs` displays the entry
- [ ] Manual: verify `tauri-pilot logs --level error` filters correctly
- [ ] Manual: verify `tauri-pilot logs --follow` streams new entries
- [ ] Manual: verify `tauri-pilot logs --clear` flushes the buffer

Closes #6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture webview console logs and expose them via a new `tauri-pilot logs` command and RPC endpoints for filtering, streaming, and clearing. Adds safer output and NDJSON streaming for `--follow --json`, plus docs across CLI reference, README, and `SKILL.md`.

- **New Features**
  - Capture `console.log/info/warn/error` in a 500-entry ring buffer with id, timestamp, level, args, and source.
  - RPC: `console.getLogs` (filters: `level`, `last`, `sinceId` or `since`), `console.clear`.
  - CLI: `tauri-pilot logs` with `--level`, `--last`, `--follow`, `--clear`, `--json`; colored output with ANSI stripping; follow mode uses `tokio` `time`.
  - Docs: CLI reference, architecture notes, and examples in README and `SKILL.md`.

- **Bug Fixes**
  - Correct OSC terminator handling (ESC \) in ANSI stripper for better safety.
  - Validate `--level` values at parse time via `clap`.
  - Display a clear success message for `logs --clear` instead of raw JSON.
  - Emit NDJSON per entry in `--follow --json` and simplify streaming logic.

<sup>Written for commit 3af3fb5d256001897fd57d85b18ed06a403abedf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logs CLI subcommand to view/filter browser console output (level, --last), stream in real time (--follow) and clear captured logs.
  * App now captures structured console entries in-memory and exposes APIs to list and clear them; CLI supports NDJSON output per entry.

* **Bug Fixes / UX**
  * Improved human-readable log formatting (timestamp, colored levels, sanitized args).
  * Added a yellow-styled warning format for terminal output.

* **Documentation**
  * Documented the new logs command and JSON-RPC methods.

* **Tests**
  * Added unit tests for log formatting and ANSI-stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->