### PR TITLE
feat: network request interception (fetch + XHR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- **Network request interception** — monkey-patch `fetch` and `XMLHttpRequest` in the JS bridge with a 200-entry ring buffer ([#7])
+  - `network.getRequests` and `network.clear` JSON-RPC methods
+  - `tauri-pilot network` CLI command with `--filter`, `--failed`, `--last`, `--follow`, `--clear` flags
+  - Colored status codes (2xx green, 3xx cyan, 4xx yellow, 5xx red)
+  - NDJSON output in `--follow --json` mode for `jq` compatibility
+- **Console log capture** — monkey-patch `console.log/warn/error/info` in the JS bridge with a 500-entry ring buffer ([#17])
+  - `console.getLogs` and `console.clear` JSON-RPC methods
+  - `tauri-pilot logs` CLI command with `--level`, `--last`, `--follow`, `--clear` flags
+  - Colored output formatting for log levels
+  - NDJSON output in `--follow --json` mode for `jq` compatibility
+- **Colored CLI output** — TTY-aware formatting with `owo-colors` + `indicatif` ([#3])
+  - `style.rs` reusable helpers (success/error/warning/info/dim/bold)
+  - Automatic `NO_COLOR` support
+  - Colored accessibility tree (cyan roles, bold names, dim refs)
+  - Spinner for screenshot capture
+- **Phase 1: Skeleton, Protocol, and Snapshot** — full foundation ([#1])
+  - Cargo workspace with two crates (`tauri-plugin-pilot`, `tauri-pilot-cli`)
+  - JSON-RPC 2.0 protocol types with round-trip tests
+  - JS bridge (`window.__PILOT__`) with TreeWalker snapshot, refs, and `ROLE_MAP`
+  - Unix socket server with newline-delimited JSON-RPC framing
+  - `EvalEngine` with callback pattern (eval + oneshot channel + timeout)
+  - `__callback` IPC handler with `__TAURI_INTERNALS__.invoke`
+  - 23 JSON-RPC methods: `ping`, `snapshot`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`, `eval`, `screenshot`, `text`, `html`, `value`, `attrs`, `wait`, `navigate`, `url`, `title`, `state`, `ipc`, `console.getLogs`, `console.clear`
+  - CLI with Clap: all subcommands, target resolution (`@ref`, CSS selector, `x,y` coords), `--json` flag
+  - `waitFor` with `MutationObserver` + configurable timeout
+  - Screenshot support via `html-to-image` (base64 PNG save-to-file)
+  - `SKILL.md` for Claude Code integration
+  - Prism integration script (`scripts/integrate-prism.sh`)
+  - `SocketGuard` RAII for socket cleanup on shutdown/panic
+  - `resolveTarget()` helper for ref/selector/coords
+  - Identifier sanitization for socket paths
+  - Debug-only compilation (`#[cfg(debug_assertions)]`)
+- **Documentation site** — Astro Starlight at `docs/` ([#5])
+  - 6 pages: Getting Started, CLI Reference, Plugin Setup, Architecture, AI Agent Integration, Contributing
+  - Dark theme with cyan accent
+  - GitHub Actions workflow for GitHub Pages deployment
+- **Project logo and badges** in README ([#4])
+
+### Fixed
+
+- Bundle `html-to-image` into bridge JS for screenshot support ([#2])
+- Upgrade Node.js to 22 for Astro 6.x compatibility in CI
+- IPC command injection via `JSON.parse` — use `serde_json` string literal
+- JSON-RPC version field validation at server boundary
+- Socket bind failure propagation from plugin setup
+- `set_nonblocking` error propagation (replace `expect()` with `?`)
+- `fstat`-based inode guard for socket cleanup race conditions
+- `std::os::unix::net::UnixListener` for sync bind in Tauri plugin setup
+- `__TAURI_INTERNALS__.invoke` instead of `__TAURI__.core.invoke`
+- Bridge functions accept params object (not positional arguments)
+- `build.rs` + permissions for `__callback` IPC command
+
+[#1]: https://github.com/mpiton/tauri-pilot/pull/1
+[#2]: https://github.com/mpiton/tauri-pilot/pull/2
+[#3]: https://github.com/mpiton/tauri-pilot/pull/3
+[#4]: https://github.com/mpiton/tauri-pilot/pull/4
+[#5]: https://github.com/mpiton/tauri-pilot/pull/5
+[#7]: https://github.com/mpiton/tauri-pilot/issues/7
+[#17]: https://github.com/mpiton/tauri-pilot/pull/17

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,112 +1,132 @@
-# tauri-pilot — Skill for Claude Code
+---
+name: tauri-pilot
+description: Inspect, interact with, and test a running Tauri v2 app via CLI. Communicates over Unix socket using JSON-RPC 2.0. Use when testing UI, automating interactions, or debugging a Tauri app.
+---
 
-## Overview
+# tauri-pilot
 
-`tauri-pilot` lets you inspect, interact with, and test a running Tauri v2 app via CLI. It communicates over a Unix socket using JSON-RPC 2.0.
-
-## Standard Workflow
+## Workflow
 
 ```
 1. ping          — verify connectivity
 2. snapshot -i   — get interactive elements with refs
-3. read refs     — inspect specific elements (text, value, attrs)
+3. read refs     — inspect elements (text, value, attrs)
 4. act on refs   — click, fill, type, select, check
 5. snapshot -i   — verify result
 ```
 
 ## Rules
 
-1. **Always snapshot before interacting.** Refs reset on each snapshot call.
-2. **Prefer `snapshot -i`** (interactive only) to minimize output tokens.
-3. **Use `wait` after async actions** (navigation, data loading, animations).
-4. **Use `@ref` notation** (e.g., `@e3`) to target elements from the snapshot.
-5. **One action at a time**, then re-snapshot to verify.
-6. **Check `logs --level error`** after actions to catch JS errors.
+1. **Always snapshot before interacting.** Refs reset on each snapshot.
+2. **Prefer `snapshot -i`** to minimize output.
+3. **Use `wait` after async actions** (navigation, data loading).
+4. **One action at a time**, then re-snapshot to verify.
+5. **Check `logs --level error`** after actions to catch JS errors.
 
-## Commands Reference
+## Targeting
 
-| Command | Description | Example |
-|---------|-------------|---------|
-| `ping` | Check connectivity | `tauri-pilot ping` |
-| `snapshot` | Accessibility tree | `tauri-pilot snapshot -i` |
-| `click` | Click element | `tauri-pilot click @e3` |
-| `fill` | Set input value | `tauri-pilot fill @e2 "hello"` |
-| `type` | Type characters | `tauri-pilot type @e2 "abc"` |
-| `press` | Press key | `tauri-pilot press Enter` |
-| `select` | Select option | `tauri-pilot select @e5 "opt1"` |
-| `check` | Toggle checkbox | `tauri-pilot check @e6` |
-| `scroll` | Scroll page/element | `tauri-pilot scroll down 500` |
-| `text` | Get text content | `tauri-pilot text @e1` |
-| `html` | Get innerHTML | `tauri-pilot html @e1` |
-| `value` | Get input value | `tauri-pilot value @e2` |
-| `attrs` | Get attributes | `tauri-pilot attrs @e1` |
-| `eval` | Run arbitrary JS | `tauri-pilot eval "document.title"` |
-| `ipc` | Invoke Tauri IPC command | `tauri-pilot ipc greet '{"name":"World"}'` |
-| `wait` | Wait for element | `tauri-pilot wait --selector ".loaded"` |
-| `navigate` | Go to URL | `tauri-pilot navigate "https://..."` |
-| `url` | Get current URL | `tauri-pilot url` |
-| `title` | Get page title | `tauri-pilot title` |
-| `state` | Get app state | `tauri-pilot state` |
-| `screenshot` | Capture PNG | `tauri-pilot screenshot ./out.png` |
-| `logs` | Show console output | `tauri-pilot logs` |
-| `logs --level` | Filter by level | `tauri-pilot logs --level error` |
-| `logs --last` | Last N entries | `tauri-pilot logs --last 10` |
-| `logs --follow` | Stream logs | `tauri-pilot logs -f` |
-| `logs --clear` | Flush buffer | `tauri-pilot logs --clear` |
+Three target formats, auto-detected:
 
-## Example Workflows
+| Format | Example | Usage |
+|--------|---------|-------|
+| `@ref` | `@e3` | Element ref from last snapshot |
+| CSS selector | `#login-btn`, `.card` | Direct DOM query |
+| Coordinates | `100,200` | Click at x,y position |
 
-### Test a login form
+## Commands
+
+### Connectivity & State
+
+| Command | Description |
+|---------|-------------|
+| `ping` | Check connectivity |
+| `state` | Get app state (URL, title, viewport, scroll) |
+| `url` | Get current URL |
+| `title` | Get page title |
+
+### Snapshot & Inspection
+
+| Command | Description |
+|---------|-------------|
+| `snapshot` | Full accessibility tree |
+| `snapshot -i` | Interactive elements only |
+| `snapshot -s ".panel"` | Scope to CSS selector |
+| `snapshot -d 3` | Limit tree depth |
+| `text <target>` | Get text content |
+| `html [target]` | Get innerHTML (page if no target) |
+| `value <target>` | Get input value |
+| `attrs <target>` | Get all attributes |
+
+### Interaction
+
+| Command | Example |
+|---------|---------|
+| `click <target>` | `click @e3` |
+| `fill <target> <value>` | `fill @e2 "hello"` |
+| `type <target> <text>` | `type @e2 "abc"` |
+| `press <key>` | `press Enter` |
+| `select <target> <value>` | `select @e5 "opt1"` |
+| `check <target>` | `check @e6` |
+| `scroll <dir> [amount] [--ref <target>]` | `scroll down 500` |
+
+### Navigation & Waiting
+
+| Command | Description |
+|---------|-------------|
+| `navigate <url>` | Go to URL |
+| `wait [target]` | Wait for element to appear |
+| `wait --selector ".loaded"` | Wait for CSS selector |
+| `wait --gone @e3` | Wait for element to disappear |
+| `wait --timeout 5000` | Custom timeout (default: 10000ms) |
+
+### Debugging
+
+| Command | Description |
+|---------|-------------|
+| `eval <script>` | Run arbitrary JS |
+| `ipc <command> [--args <json>]` | Invoke Tauri IPC command |
+| `screenshot [path] [--selector ".el"]` | Capture PNG |
+| `logs` | Show console output |
+| `logs --level error` | Filter by level (log/info/warn/error) |
+| `logs --last 10` | Last N entries |
+| `logs -f` | Stream logs (follow) |
+| `logs --clear` | Flush buffer |
+| `network` | Show captured network requests |
+| `network --last 10` | Last N requests |
+| `network --filter "api/"` | Filter by URL pattern |
+| `network --failed` | Only 4xx/5xx and network errors |
+| `network -f` | Stream requests (follow) |
+| `network --clear` | Flush request buffer |
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--socket <path>` | Explicit socket path (auto-detected by default) |
+| `--json` | Raw JSON output |
+
+## Socket Auto-Detection
+
+1. `$TAURI_PILOT_SOCKET` env var
+2. Most recent `/tmp/tauri-pilot-*.sock` file
+
+## Examples
 
 ```bash
+# Login form test
 tauri-pilot ping
 tauri-pilot snapshot -i
-# Output: textbox "Email" [ref=e1], textbox "Password" [ref=e2], button "Login" [ref=e3]
 tauri-pilot fill @e1 "user@example.com"
 tauri-pilot fill @e2 "password123"
 tauri-pilot click @e3
 tauri-pilot wait --selector ".dashboard"
 tauri-pilot snapshot -i
-```
 
-### Verify page content
-
-```bash
-tauri-pilot snapshot
-# Full tree — look for specific text
-tauri-pilot text @e5
-tauri-pilot attrs @e5
-tauri-pilot html @e5
-```
-
-### Test navigation
-
-```bash
-tauri-pilot url
-tauri-pilot navigate "/settings"
-tauri-pilot wait --selector "#settings-page"
-tauri-pilot snapshot -i
-```
-
-### Debug with console logs
-
-```bash
+# Debug after action
 tauri-pilot logs --clear
-tauri-pilot click @e3           # trigger action
-tauri-pilot logs --level error  # check for JS errors
-tauri-pilot logs --json         # structured output for parsing
+tauri-pilot click @e3
+tauri-pilot logs --level error
+
+# IPC call
+tauri-pilot ipc greet --args '{"name":"World"}'
 ```
-
-## Flags
-
-- `--socket <path>` — Explicit socket path (auto-detected by default)
-- `--json` — Output raw JSON instead of compact text
-- `-i` / `--interactive` — Snapshot interactive elements only
-- `-s` / `--selector` — Scope snapshot to CSS selector
-- `-d` / `--depth` — Limit snapshot depth
-
-## Socket Auto-Detection
-
-If `--socket` is not provided, the CLI looks for:
-1. `$TAURI_PILOT_SOCKET` env var
-2. Most recent `/tmp/tauri-pilot-*.sock` file

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Inspect, interact with, and test a running Tauri v2 app via CLI. Co
 
 ## Workflow
 
-```
+```text
 1. ping          — verify connectivity
 2. snapshot -i   — get interactive elements with refs
 3. read refs     — inspect elements (text, value, attrs)

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -106,6 +106,28 @@ pub(crate) enum Command {
         #[arg(long, short = 'f')]
         follow: bool,
     },
+    /// Display or stream captured network requests.
+    Network {
+        /// Filter by URL pattern (substring match).
+        #[arg(long)]
+        filter: Option<String>,
+
+        /// Show only failed requests (4xx/5xx and network errors).
+        #[arg(long)]
+        failed: bool,
+
+        /// Show last N requests.
+        #[arg(long)]
+        last: Option<usize>,
+
+        /// Clear the request buffer.
+        #[arg(long, conflicts_with = "follow")]
+        clear: bool,
+
+        /// Continuously poll for new requests.
+        #[arg(long, short = 'f')]
+        follow: bool,
+    },
 }
 
 /// Parsed target for element-targeting commands.

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -30,8 +30,9 @@ async fn main() -> Result<()> {
 
     let is_snapshot = matches!(args.command, Command::Snapshot { .. });
     let is_logs = matches!(args.command, Command::Logs { .. });
+    let is_network = matches!(args.command, Command::Network { .. });
 
-    // Handle --follow mode: loop forever polling for new logs
+    // Handle --follow mode: loop forever polling for new entries
     if let Command::Logs {
         follow: true,
         ref level,
@@ -39,44 +40,16 @@ async fn main() -> Result<()> {
         ..
     } = args.command
     {
-        let mut last_seen_id: u64 = 0;
-        let mut first_poll = true;
-        loop {
-            let mut params = serde_json::Map::new();
-            if last_seen_id > 0 {
-                params.insert("sinceId".into(), json!(last_seen_id));
-            }
-            if let Some(l) = level {
-                params.insert("level".into(), json!(l.clone()));
-            }
-            if first_poll {
-                if let Some(n) = last {
-                    params.insert("last".into(), json!(n));
-                }
-                first_poll = false;
-            }
-            let result = client
-                .call("console.getLogs", Some(Value::Object(params)))
-                .await?;
-            if let Some(entries) = result.as_array()
-                && !entries.is_empty()
-            {
-                if args.json {
-                    // Emit NDJSON: one JSON object per entry for jq compatibility
-                    for entry in entries {
-                        println!("{entry}");
-                    }
-                } else {
-                    print!("{}", output::format_logs(&result));
-                }
-                last_seen_id = entries
-                    .last()
-                    .and_then(|e| e.get("id"))
-                    .and_then(serde_json::Value::as_u64)
-                    .unwrap_or(last_seen_id);
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
+        follow_logs(&mut client, args.json, level.as_deref(), *last).await?;
+    } else if let Command::Network {
+        follow: true,
+        ref filter,
+        ref last,
+        failed,
+        ..
+    } = args.command
+    {
+        follow_network(&mut client, args.json, filter.as_deref(), *last, failed).await?;
     }
 
     let screenshot_path = if let Command::Screenshot { ref path, .. } = args.command {
@@ -121,11 +94,112 @@ async fn main() -> Result<()> {
         } else {
             print!("{}", output::format_logs(&result));
         }
+    } else if is_network {
+        if result.get("cleared").is_some() {
+            output::format_text(&result);
+        } else {
+            print!("{}", output::format_network(&result));
+        }
     } else {
         output::format_text(&result);
     }
 
     Ok(())
+}
+
+async fn follow_logs(
+    client: &mut Client,
+    emit_json: bool,
+    level: Option<&str>,
+    last: Option<usize>,
+) -> Result<()> {
+    let mut last_seen_id: u64 = 0;
+    let mut first_poll = true;
+    loop {
+        let mut params = serde_json::Map::new();
+        if last_seen_id > 0 {
+            params.insert("sinceId".into(), json!(last_seen_id));
+        }
+        if let Some(l) = level {
+            params.insert("level".into(), json!(l));
+        }
+        if first_poll {
+            if let Some(n) = last {
+                params.insert("last".into(), json!(n));
+            }
+            first_poll = false;
+        }
+        let result = client
+            .call("console.getLogs", Some(Value::Object(params)))
+            .await?;
+        if let Some(entries) = result.as_array()
+            && !entries.is_empty()
+        {
+            if emit_json {
+                // Emit NDJSON: one JSON object per entry for jq compatibility
+                for entry in entries {
+                    println!("{entry}");
+                }
+            } else {
+                print!("{}", output::format_logs(&result));
+            }
+            last_seen_id = entries
+                .last()
+                .and_then(|e| e.get("id"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(last_seen_id);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn follow_network(
+    client: &mut Client,
+    emit_json: bool,
+    filter: Option<&str>,
+    last: Option<usize>,
+    failed: bool,
+) -> Result<()> {
+    let mut last_seen_id: u64 = 0;
+    let mut first_poll = true;
+    loop {
+        let mut params = serde_json::Map::new();
+        if last_seen_id > 0 {
+            params.insert("sinceId".into(), json!(last_seen_id));
+        }
+        if let Some(f) = filter {
+            params.insert("filter".into(), json!(f));
+        }
+        if failed {
+            params.insert("failedOnly".into(), json!(true));
+        }
+        if first_poll {
+            if let Some(n) = last {
+                params.insert("last".into(), json!(n));
+            }
+            first_poll = false;
+        }
+        let result = client
+            .call("network.getRequests", Some(Value::Object(params)))
+            .await?;
+        if let Some(entries) = result.as_array()
+            && !entries.is_empty()
+        {
+            if emit_json {
+                for entry in entries {
+                    println!("{entry}");
+                }
+            } else {
+                print!("{}", output::format_network(&result));
+            }
+            last_seen_id = entries
+                .last()
+                .and_then(|e| e.get("id"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(last_seen_id);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 async fn run_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {
@@ -148,6 +222,55 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
                 )
                 .await
         }
+        Command::Ipc { command, args } => run_ipc_command(client, &command, args.as_deref()).await,
+        Command::Screenshot { path, selector } => {
+            client
+                .call(
+                    "screenshot",
+                    Some(json!({"path": path, "selector": selector})),
+                )
+                .await
+        }
+        Command::Navigate { url } => client.call("navigate", Some(json!({"url": url}))).await,
+        Command::Url => client.call("url", None).await,
+        Command::Title => client.call("title", None).await,
+        Command::Wait {
+            target,
+            selector,
+            gone,
+            timeout,
+        } => {
+            client
+                .call(
+                    "wait",
+                    Some(json!({
+                        "target": target,
+                        "selector": selector,
+                        "gone": gone,
+                        "timeout": timeout,
+                    })),
+                )
+                .await
+        }
+        Command::Logs {
+            level,
+            last,
+            clear,
+            follow,
+        } => run_logs_command(client, level, last, clear, follow).await,
+        Command::Network {
+            filter,
+            failed,
+            last,
+            clear,
+            follow,
+        } => run_network_command(client, filter, failed, last, clear, follow).await,
+        cmd => run_dom_command(client, cmd).await,
+    }
+}
+
+async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {
+    match command {
         Command::Click { target } => client.call("click", Some(target_params(&target))).await,
         Command::Fill { target, value } => {
             let mut p = target_params(&target);
@@ -186,42 +309,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
         Command::Value { target } => client.call("value", Some(target_params(&target))).await,
         Command::Attrs { target } => client.call("attrs", Some(target_params(&target))).await,
         Command::Eval { script } => client.call("eval", Some(json!({"script": script}))).await,
-        Command::Ipc { command, args } => run_ipc_command(client, &command, args.as_deref()).await,
-        Command::Screenshot { path, selector } => {
-            client
-                .call(
-                    "screenshot",
-                    Some(json!({"path": path, "selector": selector})),
-                )
-                .await
-        }
-        Command::Navigate { url } => client.call("navigate", Some(json!({"url": url}))).await,
-        Command::Url => client.call("url", None).await,
-        Command::Title => client.call("title", None).await,
-        Command::Wait {
-            target,
-            selector,
-            gone,
-            timeout,
-        } => {
-            client
-                .call(
-                    "wait",
-                    Some(json!({
-                        "target": target,
-                        "selector": selector,
-                        "gone": gone,
-                        "timeout": timeout,
-                    })),
-                )
-                .await
-        }
-        Command::Logs {
-            level,
-            last,
-            clear,
-            follow,
-        } => run_logs_command(client, level, last, clear, follow).await,
+        _ => anyhow::bail!("unexpected command in run_dom_command"),
     }
 }
 
@@ -261,6 +349,38 @@ async fn run_logs_command(
     }
     client
         .call("console.getLogs", Some(serde_json::Value::Object(params)))
+        .await
+}
+
+async fn run_network_command(
+    client: &mut Client,
+    filter: Option<String>,
+    failed: bool,
+    last: Option<usize>,
+    clear: bool,
+    follow: bool,
+) -> Result<serde_json::Value> {
+    if follow {
+        anyhow::bail!("follow mode must be handled before run_command");
+    }
+    if clear {
+        return client.call("network.clear", None).await;
+    }
+    let mut params = serde_json::Map::new();
+    if let Some(f) = filter {
+        params.insert("filter".into(), json!(f));
+    }
+    if failed {
+        params.insert("failedOnly".into(), json!(true));
+    }
+    if let Some(n) = last {
+        params.insert("last".into(), json!(n));
+    }
+    client
+        .call(
+            "network.getRequests",
+            Some(serde_json::Value::Object(params)),
+        )
         .await
 }
 

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -98,6 +98,16 @@ pub(crate) fn format_snapshot(value: &serde_json::Value) {
     }
 }
 
+/// Format a millisecond timestamp as `HH:MM:SS.mmm`.
+fn format_timestamp(timestamp: u64) -> String {
+    let secs = (timestamp / 1000) % 86400;
+    let ms = timestamp % 1000;
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
 /// Format console log entries for human-readable display.
 pub(crate) fn format_logs(value: &serde_json::Value) -> String {
     let mut output = String::new();
@@ -115,13 +125,7 @@ pub(crate) fn format_logs(value: &serde_json::Value) -> String {
         let level = entry.get("level").and_then(|l| l.as_str()).unwrap_or("log");
         let args = entry.get("args").and_then(|a| a.as_array());
 
-        // Format timestamp as HH:MM:SS.mmm
-        let secs = (timestamp / 1000) % 86400;
-        let ms = timestamp % 1000;
-        let h = secs / 3600;
-        let m = (secs % 3600) / 60;
-        let s = secs % 60;
-        let time_str = format!("{h:02}:{m:02}:{s:02}.{ms:03}");
+        let time_str = format_timestamp(timestamp);
 
         // Format args (strip ANSI escape sequences to prevent terminal injection)
         let args_str = match args {
@@ -148,6 +152,67 @@ pub(crate) fn format_logs(value: &serde_json::Value) -> String {
         };
 
         let _ = writeln!(output, "[{time_str}] {level_display} {args_str}");
+    }
+    output
+}
+
+/// Format network request entries for human-readable display.
+pub(crate) fn format_network(value: &serde_json::Value) -> String {
+    let mut output = String::new();
+    let Some(entries) = value.as_array() else {
+        return format!("{}\n", crate::style::error("Unexpected response format"));
+    };
+    if entries.is_empty() {
+        return String::from("No requests captured\n");
+    }
+    for entry in entries {
+        let timestamp = entry
+            .get("timestamp")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let method = entry.get("method").and_then(|m| m.as_str()).unwrap_or("?");
+        let url = entry.get("url").and_then(|u| u.as_str()).unwrap_or("?");
+        let status = entry
+            .get("status")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let duration = entry
+            .get("duration_ms")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let error = entry.get("error").and_then(|e| e.as_str());
+
+        let time_str = format_timestamp(timestamp);
+
+        // Strip ANSI from URL/method/error to prevent terminal injection
+        let method_safe = strip_ansi(method);
+        let url_safe = strip_ansi(url);
+
+        // Color status by range — status 0 is always a network error
+        let status_display = match status {
+            0 => crate::style::error("ERR"),
+            200..=299 => crate::style::success(&status.to_string()),
+            300..=399 => crate::style::info(status),
+            400..=499 => crate::style::warn(status),
+            _ => crate::style::error(&status.to_string()),
+        };
+
+        let method_display = crate::style::bold(method_safe);
+        let duration_display = crate::style::dim(format!("{duration}ms"));
+
+        if let Some(err) = error {
+            let err_safe = strip_ansi(err);
+            let _ = writeln!(
+                output,
+                "[{time_str}] {method_display} {status_display} {url_safe} {}",
+                crate::style::error(&err_safe)
+            );
+        } else {
+            let _ = writeln!(
+                output,
+                "[{time_str}] {method_display} {status_display} {url_safe} {duration_display}"
+            );
+        }
     }
     output
 }
@@ -284,6 +349,34 @@ mod tests {
     #[test]
     fn test_format_logs_non_array() {
         let output = format_logs(&json!({"unexpected": true}));
+        assert!(output.contains("Unexpected"));
+    }
+
+    #[test]
+    fn test_format_network_with_entries() {
+        let requests = json!([
+            {"id": 1, "timestamp": 3661123_u64, "method": "GET", "url": "/api/users", "status": 200, "duration_ms": 150, "error": null, "request_size": 0, "response_size": 1024},
+            {"id": 2, "timestamp": 3661500_u64, "method": "POST", "url": "/api/login", "status": 500, "duration_ms": 2000, "error": "Internal Server Error", "request_size": 42, "response_size": 128},
+        ]);
+        let output = format_network(&requests);
+        assert!(output.contains("01:01:01.123"));
+        assert!(output.contains("GET"));
+        assert!(output.contains("/api/users"));
+        assert!(output.contains("150ms"));
+        assert!(output.contains("POST"));
+        assert!(output.contains("/api/login"));
+        assert!(output.contains("Internal Server Error"));
+    }
+
+    #[test]
+    fn test_format_network_empty_array() {
+        let output = format_network(&json!([]));
+        assert!(output.contains("No requests captured"));
+    }
+
+    #[test]
+    fn test_format_network_non_array() {
+        let output = format_network(&json!({"unexpected": true}));
         assert!(output.contains("Unexpected"));
     }
 

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -204,7 +204,7 @@ pub(crate) fn format_network(value: &serde_json::Value) -> String {
             let err_safe = strip_ansi(err);
             let _ = writeln!(
                 output,
-                "[{time_str}] {method_display} {status_display} {url_safe} {}",
+                "[{time_str}] {method_display} {status_display} {url_safe} {} {duration_display}",
                 crate::style::error(&err_safe)
             );
         } else {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -8,6 +8,10 @@
   let _logIdCounter = 0;
   const MAX_LOGS = 500;
 
+  const _networkRequests = [];
+  let _netIdCounter = 0;
+  const MAX_REQUESTS = 200;
+
   const ROLE_MAP = {
     A: "link",
     BUTTON: "button",
@@ -114,6 +118,119 @@
 
   function clearLogs() {
     _logs.length = 0;
+    return { cleared: true };
+  }
+
+  const _originalFetch = window.fetch.bind(window);
+  window.fetch = function(input, init) {
+    const method = (init && init.method) || (input && input.method) || "GET";
+    const url = (typeof input === "string") ? input : (input && input.url) || String(input);
+    const timestamp = Date.now();
+    const requestSize = (init && init.body && init.body.length) || 0;
+    return _originalFetch(input, init).then(function(response) {
+      const duration_ms = Date.now() - timestamp;
+      const status = response.status;
+      const responseSize = parseInt(response.headers.get("Content-Length") || "0", 10) || 0;
+      const entry = {
+        id: ++_netIdCounter,
+        timestamp: timestamp,
+        method: method,
+        url: url,
+        status: status,
+        duration_ms: duration_ms,
+        error: null,
+        request_size: requestSize,
+        response_size: responseSize,
+      };
+      _networkRequests.push(entry);
+      if (_networkRequests.length > MAX_REQUESTS) _networkRequests.shift();
+      return response;
+    }, function(err) {
+      const duration_ms = Date.now() - timestamp;
+      const entry = {
+        id: ++_netIdCounter,
+        timestamp: timestamp,
+        method: method,
+        url: url,
+        status: 0,
+        duration_ms: duration_ms,
+        error: err ? err.message : "Network error",
+        request_size: requestSize,
+        response_size: 0,
+      };
+      _networkRequests.push(entry);
+      if (_networkRequests.length > MAX_REQUESTS) _networkRequests.shift();
+      throw err;
+    });
+  };
+
+  const _origXhrOpen = XMLHttpRequest.prototype.open;
+  const _origXhrSend = XMLHttpRequest.prototype.send;
+
+  XMLHttpRequest.prototype.open = function(method, url) {
+    this._pilot = { method: method, url: url };
+    return _origXhrOpen.apply(this, arguments);
+  };
+
+  XMLHttpRequest.prototype.send = function(body) {
+    if (this._pilot) {
+      const pilot = this._pilot;
+      const timestamp = Date.now();
+      const requestSize = (body && body.length) || 0;
+      let recorded = false;
+      const pushEntry = (status, error, responseSize) => {
+        if (recorded) return;
+        recorded = true;
+        const entry = {
+          id: ++_netIdCounter,
+          timestamp: timestamp,
+          method: pilot.method,
+          url: pilot.url,
+          status: status,
+          duration_ms: Date.now() - timestamp,
+          error: error,
+          request_size: requestSize,
+          response_size: responseSize,
+        };
+        _networkRequests.push(entry);
+        if (_networkRequests.length > MAX_REQUESTS) _networkRequests.shift();
+      };
+      this.addEventListener("load", () => {
+        const responseSize = (this.response && this.response.length) ||
+          parseInt(this.getResponseHeader("Content-Length") || "0", 10) || 0;
+        pushEntry(this.status, null, responseSize);
+      });
+      this.addEventListener("error", () => {
+        pushEntry(0, "Network error", 0);
+      });
+      this.addEventListener("timeout", () => {
+        pushEntry(0, "Timeout", 0);
+      });
+    }
+    return _origXhrSend.apply(this, arguments);
+  };
+
+  function networkRequests(options) {
+    let result = _networkRequests.slice();
+    if (options) {
+      if (options.filter) {
+        result = result.filter(e => e.url.includes(options.filter));
+      }
+      if (options.failedOnly) {
+        result = result.filter(e => e.status >= 400 || e.status === 0 || e.error);
+      }
+      if (options.sinceId) {
+        result = result.filter(e => e.id > options.sinceId);
+      }
+      if (options.last) {
+        result = result.slice(-options.last);
+      }
+    }
+    return result;
+  }
+
+  function clearNetwork() {
+    _networkRequests.length = 0;
     return { cleared: true };
   }
 
@@ -496,5 +613,7 @@
     screenshot: screenshot,
     consoleLogs: consoleLogs,
     clearLogs: clearLogs,
+    networkRequests: networkRequests,
+    clearNetwork: clearNetwork,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -121,19 +121,21 @@
     return { cleared: true };
   }
 
+  function bodySize(body) {
+    if (!body) return 0;
+    if (typeof body === "string") return body.length;
+    if (body instanceof URLSearchParams) return body.toString().length;
+    if (body instanceof Blob) return body.size;
+    if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) return body.byteLength;
+    return 0;
+  }
+
   const _originalFetch = window.fetch.bind(window);
   window.fetch = function(input, init) {
     const method = (init && init.method) || (input && input.method) || "GET";
     const url = (typeof input === "string") ? input : (input && input.url) || String(input);
     const timestamp = Date.now();
-    const reqBody = init && init.body;
-    const requestSize = reqBody
-      ? (typeof reqBody === "string" ? reqBody.length
-        : reqBody instanceof Blob ? reqBody.size
-        : reqBody instanceof ArrayBuffer ? reqBody.byteLength
-        : reqBody instanceof URLSearchParams ? reqBody.toString().length
-        : 0)
-      : 0;
+    const requestSize = bodySize(init && init.body);
     return _originalFetch(input, init).then(function(response) {
       const duration_ms = Date.now() - timestamp;
       const status = response.status;
@@ -175,24 +177,28 @@
   const _origXhrSend = XMLHttpRequest.prototype.send;
 
   XMLHttpRequest.prototype.open = function(method, url) {
-    this._pilot = { method: method, url: url };
-    return _origXhrOpen.apply(this, arguments);
+    const result = _origXhrOpen.apply(this, arguments);
+    this._pilot = { method: String(method), url: String(url) };
+    return result;
   };
 
   XMLHttpRequest.prototype.send = function(body) {
     if (this._pilot) {
       const pilot = this._pilot;
       const timestamp = Date.now();
-      const requestSize = body
-        ? (typeof body === "string" ? body.length
-          : body instanceof Blob ? body.size
-          : body instanceof ArrayBuffer ? body.byteLength
-          : 0)
-        : 0;
+      const requestSize = bodySize(body);
       let recorded = false;
+      let onLoad, onError, onTimeout, onAbort;
+      const cleanup = () => {
+        this.removeEventListener("load", onLoad);
+        this.removeEventListener("error", onError);
+        this.removeEventListener("timeout", onTimeout);
+        this.removeEventListener("abort", onAbort);
+      };
       const pushEntry = (status, error, responseSize) => {
         if (recorded) return;
         recorded = true;
+        cleanup();
         const entry = {
           id: ++_netIdCounter,
           timestamp: timestamp,
@@ -207,23 +213,27 @@
         _networkRequests.push(entry);
         if (_networkRequests.length > MAX_REQUESTS) _networkRequests.shift();
       };
-      this.addEventListener("load", () => {
+      onLoad = () => {
         const cl = parseInt(this.getResponseHeader("Content-Length") || "0", 10) || 0;
         const r = this.response;
         const responseSize = (this.responseType === "" || this.responseType === "text")
           ? ((r && r.length) || cl)
           : (r instanceof ArrayBuffer ? r.byteLength : (r instanceof Blob ? r.size : cl));
         pushEntry(this.status, null, responseSize);
-      });
-      this.addEventListener("error", () => {
-        pushEntry(0, "Network error", 0);
-      });
-      this.addEventListener("timeout", () => {
-        pushEntry(0, "Timeout", 0);
-      });
-      this.addEventListener("abort", () => {
-        pushEntry(0, "Aborted", 0);
-      });
+      };
+      onError = () => { pushEntry(0, "Network error", 0); };
+      onTimeout = () => { pushEntry(0, "Timeout", 0); };
+      onAbort = () => { pushEntry(0, "Aborted", 0); };
+      this.addEventListener("load", onLoad);
+      this.addEventListener("error", onError);
+      this.addEventListener("timeout", onTimeout);
+      this.addEventListener("abort", onAbort);
+      try {
+        return _origXhrSend.apply(this, arguments);
+      } catch (err) {
+        cleanup();
+        throw err;
+      }
     }
     return _origXhrSend.apply(this, arguments);
   };

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -126,7 +126,14 @@
     const method = (init && init.method) || (input && input.method) || "GET";
     const url = (typeof input === "string") ? input : (input && input.url) || String(input);
     const timestamp = Date.now();
-    const requestSize = (init && init.body && init.body.length) || 0;
+    const reqBody = init && init.body;
+    const requestSize = reqBody
+      ? (typeof reqBody === "string" ? reqBody.length
+        : reqBody instanceof Blob ? reqBody.size
+        : reqBody instanceof ArrayBuffer ? reqBody.byteLength
+        : reqBody instanceof URLSearchParams ? reqBody.toString().length
+        : 0)
+      : 0;
     return _originalFetch(input, init).then(function(response) {
       const duration_ms = Date.now() - timestamp;
       const status = response.status;
@@ -176,7 +183,12 @@
     if (this._pilot) {
       const pilot = this._pilot;
       const timestamp = Date.now();
-      const requestSize = (body && body.length) || 0;
+      const requestSize = body
+        ? (typeof body === "string" ? body.length
+          : body instanceof Blob ? body.size
+          : body instanceof ArrayBuffer ? body.byteLength
+          : 0)
+        : 0;
       let recorded = false;
       const pushEntry = (status, error, responseSize) => {
         if (recorded) return;
@@ -196,8 +208,11 @@
         if (_networkRequests.length > MAX_REQUESTS) _networkRequests.shift();
       };
       this.addEventListener("load", () => {
-        const responseSize = (this.response && this.response.length) ||
-          parseInt(this.getResponseHeader("Content-Length") || "0", 10) || 0;
+        const cl = parseInt(this.getResponseHeader("Content-Length") || "0", 10) || 0;
+        const r = this.response;
+        const responseSize = (this.responseType === "" || this.responseType === "text")
+          ? ((r && r.length) || cl)
+          : (r instanceof ArrayBuffer ? r.byteLength : (r instanceof Blob ? r.size : cl));
         pushEntry(this.status, null, responseSize);
       });
       this.addEventListener("error", () => {
@@ -205,6 +220,9 @@
       });
       this.addEventListener("timeout", () => {
         pushEntry(0, "Timeout", 0);
+      });
+      this.addEventListener("abort", () => {
+        pushEntry(0, "Aborted", 0);
       });
     }
     return _origXhrSend.apply(this, arguments);

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -22,6 +22,10 @@ pub(crate) async fn dispatch(
         }
         "console.getLogs" => handle_eval_method("consoleLogs", params, engine, eval_fn).await,
         "console.clear" => handle_eval_method("clearLogs", params, engine, eval_fn).await,
+        "network.getRequests" => {
+            handle_eval_method("networkRequests", params, engine, eval_fn).await
+        }
+        "network.clear" => handle_eval_method("clearNetwork", params, engine, eval_fn).await,
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
@@ -229,5 +233,37 @@ mod tests {
     fn test_build_bridge_call_clear_logs() {
         let script = build_bridge_call("clearLogs", None).unwrap();
         assert_eq!(script, "window.__PILOT__.clearLogs({})");
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_network_get_requests_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("network.getRequests", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_network_clear_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("network.clear", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_network_requests() {
+        let params = json!({"filter": "/api", "failedOnly": true, "last": 10});
+        let script = build_bridge_call("networkRequests", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.networkRequests("));
+        assert!(script.contains("\"filter\":\"/api\""));
+    }
+
+    #[test]
+    fn test_build_bridge_call_clear_network() {
+        let script = build_bridge_call("clearNetwork", None).unwrap();
+        assert_eq!(script, "window.__PILOT__.clearNetwork({})");
     }
 }


### PR DESCRIPTION
## Summary

- Monkey-patch `fetch` and `XMLHttpRequest` in the JS bridge to capture HTTP requests into a 200-entry ring buffer
- Add `network.getRequests` and `network.clear` JSON-RPC methods in the handler
- Add `tauri-pilot network` CLI command with `--filter`, `--failed`, `--last`, `--follow (-f)`, `--clear` flags
- Colored status output (2xx green, 3xx cyan, 4xx yellow, 5xx/ERR red)
- ANSI injection prevention on URL/method/error fields via `strip_ansi`
- Extract `format_timestamp` helper (shared between logs and network)

### Entry shape
```json
{
  "id": 1,
  "timestamp": 1712073600000,
  "method": "POST",
  "url": "/api/sync/pull",
  "status": 500,
  "duration_ms": 1250,
  "error": null,
  "request_size": 42,
  "response_size": 128
}
```

Closes #7

## Test plan

- [x] `cargo test --workspace` — 74 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual test: `tauri-pilot network` against a running Tauri app with fetch/XHR calls
- [ ] Manual test: `tauri-pilot network --follow` streams new requests
- [ ] Manual test: `tauri-pilot network --failed` shows only 4xx/5xx
- [ ] Manual test: `tauri-pilot network --filter "api/"` filters by URL
- [ ] Manual test: `tauri-pilot network --clear` clears buffer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add network request interception for `fetch` and `XMLHttpRequest`, plus a `tauri-pilot network` CLI to view, filter, follow, and clear captured requests. Improves size accuracy and error reporting, making API debugging easier with colorized status output.

- **New Features**
  - JS bridge in `tauri-plugin-pilot` captures requests in a 200-entry ring buffer (method, URL, status, duration, sizes, error).
  - JSON-RPC: `network.getRequests`, `network.clear`.
  - `tauri-pilot network` flags: `--filter`, `--failed`, `--last`, `--follow/-f`, `--clear` (NDJSON with `--json` in follow mode).
  - Colored status (2xx green, 3xx cyan, 4xx yellow, 5xx/ERR red) with ANSI stripping and shared `HH:MM:SS.mmm` timestamps.

- **Bug Fixes**
  - Correct size detection: handle `Blob`/`ArrayBuffer`/TypedArray/DataView/`URLSearchParams` bodies and prefer `Content-Length` for non-text XHR.
  - Robust XHR tracking: track `abort`, normalize URL, clean up event listeners after settle, wrap `send` in try/catch; show duration next to errors in output.

<sup>Written for commit 234779135852f864fceb0c6ef9293858d8a391e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and inspect network requests from pages; CLI can view, filter, follow (stream), limit (last N), and clear recorded requests; timestamped, colorized status and duration shown.

* **Documentation**
  * Added a changelog and reorganized skill/command reference with expanded network and command examples.

* **Bug Fixes**
  * Reliability, security, and error-handling improvements across IPC, RPC, and tooling.

* **Tests**
  * Added tests covering network formatting and RPC behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->