### PR TITLE
feat: snapshot diff — show only what changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,4 +72,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [#4]: https://github.com/mpiton/tauri-pilot/pull/4
 [#5]: https://github.com/mpiton/tauri-pilot/pull/5
 [#7]: https://github.com/mpiton/tauri-pilot/issues/7
+[#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Snapshot diff command** — compare current page state with a previous snapshot ([#8])
+  - `diff` JSON-RPC method in plugin with added/removed/changed detection
+  - `tauri-pilot diff` CLI command with `--ref FILE`, `--interactive`, `--selector`, `--depth` flags
+  - `tauri-pilot snapshot --save FILE` flag to persist snapshots for later comparison
+  - Colored diff output: red `-` removed, green `+` added, yellow `~` changed with field-level detail
+  - Snapshot storage in `EvalEngine` — last snapshot retained automatically after each `snapshot` call
 - **Network request interception** — monkey-patch `fetch` and `XMLHttpRequest` in the JS bridge with a 200-entry ring buffer ([#7])
   - `network.getRequests` and `network.clear` JSON-RPC methods
   - `tauri-pilot network` CLI command with `--filter`, `--failed`, `--last`, `--follow`, `--clear` flags

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -30,6 +30,23 @@ pub(crate) enum Command {
         selector: Option<String>,
         #[arg(short, long)]
         depth: Option<u8>,
+        #[arg(long, value_name = "FILE")]
+        save: Option<std::path::PathBuf>,
+    },
+    /// Compare current page with previous snapshot, showing only differences
+    Diff {
+        /// Path to a saved snapshot file to compare against
+        #[arg(long, value_name = "FILE")]
+        r#ref: Option<std::path::PathBuf>,
+        /// Only include interactive elements
+        #[arg(short, long)]
+        interactive: bool,
+        /// CSS selector to scope the snapshot
+        #[arg(short, long)]
+        selector: Option<String>,
+        /// Maximum depth to traverse
+        #[arg(short, long)]
+        depth: Option<u8>,
     },
     /// Click an element.
     Click { target: String },
@@ -187,5 +204,59 @@ mod tests {
             parse_target("abc,def"),
             Target::Selector("abc,def".to_owned())
         );
+    }
+
+    #[test]
+    fn test_parse_diff_command() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "diff"]);
+        assert!(matches!(
+            cli.command,
+            Command::Diff {
+                r#ref: None,
+                interactive: false,
+                selector: None,
+                depth: None,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_diff_with_ref() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "diff",
+            "--ref",
+            "/tmp/snap.json",
+        ]);
+        if let Command::Diff {
+            r#ref: Some(path), ..
+        } = cli.command
+        {
+            assert_eq!(path, std::path::PathBuf::from("/tmp/snap.json"));
+        } else {
+            panic!("Expected Diff command with ref");
+        }
+    }
+
+    #[test]
+    fn test_parse_snapshot_with_save() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "snapshot",
+            "--save",
+            "/tmp/snap.json",
+        ]);
+        if let Command::Snapshot {
+            save: Some(path), ..
+        } = cli.command
+        {
+            assert_eq!(path, std::path::PathBuf::from("/tmp/snap.json"));
+        } else {
+            panic!("Expected Snapshot command with save");
+        }
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -4,7 +4,7 @@ mod output;
 mod protocol;
 mod style;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base64::Engine;
 use clap::Parser;
 use serde_json::{Value, json};
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
     let mut client = Client::connect(&socket).await?;
 
     let is_snapshot = matches!(args.command, Command::Snapshot { .. });
+    let is_diff = matches!(args.command, Command::Diff { .. });
     let is_logs = matches!(args.command, Command::Logs { .. });
     let is_network = matches!(args.command, Command::Network { .. });
 
@@ -87,6 +88,8 @@ async fn main() -> Result<()> {
         output::format_json(&result)?;
     } else if is_snapshot {
         output::format_snapshot(&result);
+    } else if is_diff {
+        output::format_diff(&result);
     } else if is_logs {
         // console.clear returns {"cleared": true}, not an array
         if result.get("cleared").is_some() {
@@ -210,8 +213,9 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             interactive,
             selector,
             depth,
+            save,
         } => {
-            client
+            let result = client
                 .call(
                     "snapshot",
                     Some(json!({
@@ -220,8 +224,21 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
                         "depth": depth,
                     })),
                 )
-                .await
+                .await?;
+            if let Some(ref path) = save {
+                let json = serde_json::to_string_pretty(&result)?;
+                std::fs::write(path, &json)
+                    .with_context(|| format!("Failed to save snapshot to {}", path.display()))?;
+                eprintln!("Snapshot saved to {}", path.display());
+            }
+            Ok(result)
         }
+        Command::Diff {
+            r#ref: ref_path,
+            interactive,
+            selector,
+            depth,
+        } => run_diff_command(client, ref_path, interactive, selector, depth).await,
         Command::Ipc { command, args } => run_ipc_command(client, &command, args.as_deref()).await,
         Command::Screenshot { path, selector } => {
             client
@@ -267,6 +284,39 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
         } => run_network_command(client, filter, failed, last, clear, follow).await,
         cmd => run_dom_command(client, cmd).await,
     }
+}
+
+async fn run_diff_command(
+    client: &mut Client,
+    ref_path: Option<std::path::PathBuf>,
+    interactive: bool,
+    selector: Option<String>,
+    depth: Option<u8>,
+) -> Result<serde_json::Value> {
+    let mut params = json!({
+        "interactive": interactive,
+        "selector": selector,
+        "depth": depth,
+    });
+    if let Some(path) = ref_path {
+        let meta = std::fs::metadata(&path)
+            .with_context(|| format!("Failed to stat snapshot file: {}", path.display()))?;
+        anyhow::ensure!(
+            meta.len() < 50 * 1024 * 1024,
+            "Snapshot file too large (>50 MB): {}",
+            path.display()
+        );
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read snapshot file: {}", path.display()))?;
+        let reference: serde_json::Value =
+            serde_json::from_str(&content).context("Invalid snapshot file format")?;
+        anyhow::ensure!(
+            reference.get("elements").is_some(),
+            "Snapshot file missing \"elements\" key — not a valid snapshot"
+        );
+        params["reference"] = reference;
+    }
+    client.call("diff", Some(params)).await
 }
 
 async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -217,6 +217,129 @@ pub(crate) fn format_network(value: &serde_json::Value) -> String {
     output
 }
 
+/// Format a diff result showing added, removed, and changed elements.
+pub(crate) fn format_diff(value: &serde_json::Value) {
+    let added = value.get("added").and_then(|v| v.as_array());
+    let removed = value.get("removed").and_then(|v| v.as_array());
+    let changed_entries = value.get("changed").and_then(|v| v.as_array());
+
+    let is_empty = added.is_none_or(Vec::is_empty)
+        && removed.is_none_or(Vec::is_empty)
+        && changed_entries.is_none_or(Vec::is_empty);
+
+    if is_empty {
+        println!("{}", crate::style::dim("No changes detected."));
+        return;
+    }
+
+    if let Some(entries) = removed {
+        for el in entries {
+            println!("{}", format_diff_entry("-", el, &crate::style::error));
+        }
+    }
+
+    if let Some(entries) = added {
+        for el in entries {
+            println!("{}", format_diff_entry("+", el, &crate::style::success));
+        }
+    }
+
+    if let Some(entries) = changed_entries {
+        for entry in entries {
+            let el = entry.get("new").unwrap_or(entry);
+            let role = el
+                .get("role")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?");
+            let r#ref = el
+                .get("ref")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?");
+            let name = el.get("name").and_then(serde_json::Value::as_str);
+
+            let old = entry.get("old");
+            let field_changes = entry.get("changes").and_then(|c| c.as_array());
+
+            if let Some(fields) = field_changes {
+                for field in fields {
+                    let field_name = field.as_str().unwrap_or("?");
+                    let old_val = old
+                        .and_then(|o| o.get(field_name))
+                        .map(|v| match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        })
+                        .unwrap_or_default();
+                    let new_val = el
+                        .get(field_name)
+                        .map(|v| match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        })
+                        .unwrap_or_default();
+
+                    let mut line =
+                        format!("{} {} ", crate::style::warn("~"), crate::style::info(role),);
+                    if let Some(n) = name {
+                        let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
+                    }
+                    let _ = write!(
+                        line,
+                        "{} {}: {} \u{2192} {}",
+                        crate::style::dim(format!("[ref={ref}]")),
+                        field_name,
+                        crate::style::dim(format!("\"{old_val}\"")),
+                        crate::style::dim(format!("\"{new_val}\"")),
+                    );
+                    println!("{line}");
+                }
+            } else {
+                let mut line =
+                    format!("{} {} ", crate::style::warn("~"), crate::style::info(role),);
+                if let Some(n) = name {
+                    let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
+                }
+                let _ = write!(line, "{}", crate::style::dim(format!("[ref={ref}]")));
+                println!("{line}");
+            }
+        }
+    }
+}
+
+fn format_diff_entry(
+    prefix: &str,
+    el: &serde_json::Value,
+    prefix_style: &dyn Fn(&str) -> String,
+) -> String {
+    let role = el
+        .get("role")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let r#ref = el
+        .get("ref")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let name = el.get("name").and_then(serde_json::Value::as_str);
+
+    let mut line = format!("{} {} ", prefix_style(prefix), crate::style::info(role),);
+    if let Some(n) = name {
+        let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
+    }
+    let _ = write!(line, "{}", crate::style::dim(format!("[ref={ref}]")));
+
+    if let Some(val) = el.get("value").and_then(serde_json::Value::as_str) {
+        let _ = write!(line, " {}", crate::style::dim(format!("value=\"{val}\"")));
+    }
+    if el.get("checked").and_then(serde_json::Value::as_bool) == Some(true) {
+        let _ = write!(line, " {}", crate::style::dim("checked"));
+    }
+    if el.get("disabled").and_then(serde_json::Value::as_bool) == Some(true) {
+        let _ = write!(line, " {}", crate::style::dim("disabled"));
+    }
+
+    line
+}
+
 /// Strip ANSI escape sequences from a string to prevent terminal injection.
 fn strip_ansi(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
@@ -406,5 +529,61 @@ mod tests {
     #[test]
     fn test_strip_ansi_preserves_plain_text() {
         assert_eq!(strip_ansi("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_format_diff_no_changes() {
+        // Should not panic and print "No changes detected."
+        format_diff(&json!({"added": [], "removed": [], "changed": []}));
+        format_diff(&json!({}));
+    }
+
+    #[test]
+    fn test_format_diff_added() {
+        let diff = json!({
+            "added": [{"ref": "e8", "role": "button", "depth": 0, "name": "Submit"}],
+            "removed": [],
+            "changed": []
+        });
+        // Just verify it doesn't panic — output goes to stdout
+        format_diff(&diff);
+    }
+
+    #[test]
+    fn test_format_diff_removed() {
+        let diff = json!({
+            "added": [],
+            "removed": [{"ref": "e3", "role": "button", "depth": 0, "name": "Loading..."}],
+            "changed": []
+        });
+        format_diff(&diff);
+    }
+
+    #[test]
+    fn test_format_diff_changed() {
+        let diff = json!({
+            "added": [],
+            "removed": [],
+            "changed": [{
+                "old": {"ref": "e2", "role": "textbox", "name": "Search", "value": ""},
+                "new": {"ref": "e2", "role": "textbox", "name": "Search", "value": "workspace"},
+                "changes": ["value"]
+            }]
+        });
+        format_diff(&diff);
+    }
+
+    #[test]
+    fn test_format_diff_mixed() {
+        let diff = json!({
+            "added": [{"ref": "e9", "role": "link", "name": "Home"}],
+            "removed": [{"ref": "e1", "role": "button", "name": "Old"}],
+            "changed": [{
+                "old": {"ref": "e5", "role": "checkbox", "name": "Agree", "checked": false},
+                "new": {"ref": "e5", "role": "checkbox", "name": "Agree", "checked": true},
+                "changes": ["checked"]
+            }]
+        });
+        format_diff(&diff);
     }
 }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -247,15 +247,20 @@ pub(crate) fn format_diff(value: &serde_json::Value) {
     if let Some(entries) = changed_entries {
         for entry in entries {
             let el = entry.get("new").unwrap_or(entry);
-            let role = el
-                .get("role")
+            let role = strip_ansi(
+                el.get("role")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("?"),
+            );
+            let r#ref = strip_ansi(
+                el.get("ref")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("?"),
+            );
+            let name = el
+                .get("name")
                 .and_then(serde_json::Value::as_str)
-                .unwrap_or("?");
-            let r#ref = el
-                .get("ref")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("?");
-            let name = el.get("name").and_then(serde_json::Value::as_str);
+                .map(strip_ansi);
 
             let old = entry.get("old");
             let field_changes = entry.get("changes").and_then(|c| c.as_array());
@@ -263,24 +268,26 @@ pub(crate) fn format_diff(value: &serde_json::Value) {
             if let Some(fields) = field_changes {
                 for field in fields {
                     let field_name = field.as_str().unwrap_or("?");
-                    let old_val = old
-                        .and_then(|o| o.get(field_name))
-                        .map(|v| match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        })
-                        .unwrap_or_default();
-                    let new_val = el
-                        .get(field_name)
-                        .map(|v| match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        })
-                        .unwrap_or_default();
+                    let old_val = strip_ansi(
+                        &old.and_then(|o| o.get(field_name))
+                            .map(|v| match v {
+                                serde_json::Value::String(s) => s.clone(),
+                                other => other.to_string(),
+                            })
+                            .unwrap_or_default(),
+                    );
+                    let new_val = strip_ansi(
+                        &el.get(field_name)
+                            .map(|v| match v {
+                                serde_json::Value::String(s) => s.clone(),
+                                other => other.to_string(),
+                            })
+                            .unwrap_or_default(),
+                    );
 
                     let mut line =
-                        format!("{} {} ", crate::style::warn("~"), crate::style::info(role),);
-                    if let Some(n) = name {
+                        format!("{} {} ", crate::style::warn("~"), crate::style::info(&role),);
+                    if let Some(ref n) = name {
                         let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
                     }
                     let _ = write!(
@@ -295,8 +302,8 @@ pub(crate) fn format_diff(value: &serde_json::Value) {
                 }
             } else {
                 let mut line =
-                    format!("{} {} ", crate::style::warn("~"), crate::style::info(role),);
-                if let Some(n) = name {
+                    format!("{} {} ", crate::style::warn("~"), crate::style::info(&role),);
+                if let Some(ref n) = name {
                     let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
                 }
                 let _ = write!(line, "{}", crate::style::dim(format!("[ref={ref}]")));

--- a/crates/tauri-plugin-pilot/src/diff.rs
+++ b/crates/tauri-plugin-pilot/src/diff.rs
@@ -1,0 +1,348 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SnapshotElement {
+    #[serde(rename = "ref")]
+    pub ref_id: String,
+    pub role: String,
+    pub depth: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChangedEntry {
+    pub old: SnapshotElement,
+    pub new: SnapshotElement,
+    pub changes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffResult {
+    pub added: Vec<SnapshotElement>,
+    pub removed: Vec<SnapshotElement>,
+    pub changed: Vec<ChangedEntry>,
+}
+
+/// Identity key for stable matching between snapshots.
+/// Uses (role, name, depth) since refs reset each snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ElementKey {
+    role: String,
+    name: Option<String>,
+    depth: u64,
+}
+
+impl ElementKey {
+    fn from(el: &SnapshotElement) -> Self {
+        Self {
+            role: el.role.clone(),
+            name: el.name.clone(),
+            depth: el.depth,
+        }
+    }
+}
+
+/// Compare two snapshot element lists and return added, removed, and changed entries.
+///
+/// Match elements by (role, name, depth). For duplicate keys, match by position order
+/// within the group. Unmatched old → removed, unmatched new → added.
+#[must_use]
+pub fn compute_diff(old: &[SnapshotElement], new: &[SnapshotElement]) -> DiffResult {
+    let mut old_groups: HashMap<ElementKey, Vec<usize>> = HashMap::new();
+    for (i, el) in old.iter().enumerate() {
+        old_groups.entry(ElementKey::from(el)).or_default().push(i);
+    }
+
+    let mut new_groups: HashMap<ElementKey, Vec<usize>> = HashMap::new();
+    for (i, el) in new.iter().enumerate() {
+        new_groups.entry(ElementKey::from(el)).or_default().push(i);
+    }
+
+    let mut matched_old: Vec<bool> = vec![false; old.len()];
+    let mut matched_new: Vec<bool> = vec![false; new.len()];
+    let mut changed: Vec<ChangedEntry> = Vec::new();
+
+    // Match by key and position within group
+    for (key, old_indices) in &old_groups {
+        if let Some(new_indices) = new_groups.get(key) {
+            let pair_count = old_indices.len().min(new_indices.len());
+            for i in 0..pair_count {
+                let old_idx = old_indices[i];
+                let new_idx = new_indices[i];
+                matched_old[old_idx] = true;
+                matched_new[new_idx] = true;
+
+                let old_el = &old[old_idx];
+                let new_el = &new[new_idx];
+                let mut field_changes: Vec<String> = Vec::new();
+
+                if old_el.value != new_el.value {
+                    field_changes.push("value".to_owned());
+                }
+                if old_el.checked != new_el.checked {
+                    field_changes.push("checked".to_owned());
+                }
+                if old_el.disabled != new_el.disabled {
+                    field_changes.push("disabled".to_owned());
+                }
+
+                if !field_changes.is_empty() {
+                    changed.push(ChangedEntry {
+                        old: old_el.clone(),
+                        new: new_el.clone(),
+                        changes: field_changes,
+                    });
+                }
+            }
+        }
+    }
+
+    let removed: Vec<SnapshotElement> = old
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !matched_old[*i])
+        .map(|(_, el)| el.clone())
+        .collect();
+
+    let added: Vec<SnapshotElement> = new
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !matched_new[*i])
+        .map(|(_, el)| el.clone())
+        .collect();
+
+    // Sort changed entries for deterministic output (HashMap iteration is unordered)
+    changed.sort_by(|a, b| {
+        a.new
+            .depth
+            .cmp(&b.new.depth)
+            .then_with(|| a.new.role.cmp(&b.new.role))
+            .then_with(|| a.new.name.cmp(&b.new.name))
+    });
+
+    DiffResult {
+        added,
+        removed,
+        changed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn el(ref_id: &str, role: &str, depth: u64) -> SnapshotElement {
+        SnapshotElement {
+            ref_id: ref_id.to_owned(),
+            role: role.to_owned(),
+            depth,
+            name: None,
+            value: None,
+            checked: None,
+            disabled: None,
+        }
+    }
+
+    fn el_named(ref_id: &str, role: &str, depth: u64, name: &str) -> SnapshotElement {
+        SnapshotElement {
+            ref_id: ref_id.to_owned(),
+            role: role.to_owned(),
+            depth,
+            name: Some(name.to_owned()),
+            value: None,
+            checked: None,
+            disabled: None,
+        }
+    }
+
+    #[test]
+    fn test_diff_identical_snapshots() {
+        let snapshot = vec![el("e1", "button", 1), el("e2", "input", 2)];
+        let result = compute_diff(&snapshot, &snapshot);
+        assert!(result.added.is_empty());
+        assert!(result.removed.is_empty());
+        assert!(result.changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_added_elements() {
+        let old = vec![el("e1", "button", 1)];
+        let new = vec![el("e1", "button", 1), el("e2", "input", 2)];
+        let result = compute_diff(&old, &new);
+        assert_eq!(result.added.len(), 1);
+        assert_eq!(result.added[0].role, "input");
+        assert!(result.removed.is_empty());
+        assert!(result.changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_removed_elements() {
+        let old = vec![el("e1", "button", 1), el("e2", "input", 2)];
+        let new = vec![el("e1", "button", 1)];
+        let result = compute_diff(&old, &new);
+        assert!(result.added.is_empty());
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].role, "input");
+        assert!(result.changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_changed_value() {
+        let old = vec![SnapshotElement {
+            ref_id: "e1".to_owned(),
+            role: "input".to_owned(),
+            depth: 1,
+            name: Some("username".to_owned()),
+            value: Some("old".to_owned()),
+            checked: None,
+            disabled: None,
+        }];
+        let new = vec![SnapshotElement {
+            ref_id: "e2".to_owned(),
+            role: "input".to_owned(),
+            depth: 1,
+            name: Some("username".to_owned()),
+            value: Some("new".to_owned()),
+            checked: None,
+            disabled: None,
+        }];
+        let result = compute_diff(&old, &new);
+        assert!(result.added.is_empty());
+        assert!(result.removed.is_empty());
+        assert_eq!(result.changed.len(), 1);
+        assert_eq!(result.changed[0].changes, vec!["value"]);
+    }
+
+    #[test]
+    fn test_diff_changed_multiple_fields() {
+        let old = vec![SnapshotElement {
+            ref_id: "e1".to_owned(),
+            role: "checkbox".to_owned(),
+            depth: 2,
+            name: Some("agree".to_owned()),
+            value: Some("on".to_owned()),
+            checked: Some(false),
+            disabled: Some(false),
+        }];
+        let new = vec![SnapshotElement {
+            ref_id: "e2".to_owned(),
+            role: "checkbox".to_owned(),
+            depth: 2,
+            name: Some("agree".to_owned()),
+            value: Some("off".to_owned()),
+            checked: Some(true),
+            disabled: Some(true),
+        }];
+        let result = compute_diff(&old, &new);
+        assert!(result.added.is_empty());
+        assert!(result.removed.is_empty());
+        assert_eq!(result.changed.len(), 1);
+        assert!(result.changed[0].changes.contains(&"value".to_owned()));
+        assert!(result.changed[0].changes.contains(&"checked".to_owned()));
+        assert!(result.changed[0].changes.contains(&"disabled".to_owned()));
+    }
+
+    #[test]
+    fn test_diff_mixed_changes() {
+        let old = vec![
+            el_named("e1", "button", 1, "submit"),
+            SnapshotElement {
+                ref_id: "e2".to_owned(),
+                role: "input".to_owned(),
+                depth: 2,
+                name: Some("email".to_owned()),
+                value: Some("old@example.com".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+            el_named("e3", "link", 3, "home"),
+        ];
+        let new = vec![
+            el_named("e1", "button", 1, "submit"),
+            SnapshotElement {
+                ref_id: "e4".to_owned(),
+                role: "input".to_owned(),
+                depth: 2,
+                name: Some("email".to_owned()),
+                value: Some("new@example.com".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+            el_named("e5", "paragraph", 4, "info"),
+        ];
+        let result = compute_diff(&old, &new);
+        assert_eq!(result.added.len(), 1);
+        assert_eq!(result.added[0].role, "paragraph");
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].role, "link");
+        assert_eq!(result.changed.len(), 1);
+        assert_eq!(result.changed[0].changes, vec!["value"]);
+    }
+
+    #[test]
+    fn test_diff_empty_old() {
+        let old: Vec<SnapshotElement> = vec![];
+        let new = vec![el("e1", "button", 1), el("e2", "input", 2)];
+        let result = compute_diff(&old, &new);
+        assert_eq!(result.added.len(), 2);
+        assert!(result.removed.is_empty());
+        assert!(result.changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_duplicate_roles() {
+        // Two buttons at same depth — matched by position order within group
+        let old = vec![
+            SnapshotElement {
+                ref_id: "e1".to_owned(),
+                role: "button".to_owned(),
+                depth: 1,
+                name: None,
+                value: Some("save".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+            SnapshotElement {
+                ref_id: "e2".to_owned(),
+                role: "button".to_owned(),
+                depth: 1,
+                name: None,
+                value: Some("cancel".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+        ];
+        let new = vec![
+            SnapshotElement {
+                ref_id: "e3".to_owned(),
+                role: "button".to_owned(),
+                depth: 1,
+                name: None,
+                value: Some("save".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+            SnapshotElement {
+                ref_id: "e4".to_owned(),
+                role: "button".to_owned(),
+                depth: 1,
+                name: None,
+                value: Some("cancel".to_owned()),
+                checked: None,
+                disabled: None,
+            },
+        ];
+        let result = compute_diff(&old, &new);
+        assert!(result.added.is_empty());
+        assert!(result.removed.is_empty());
+        assert!(result.changed.is_empty());
+    }
+}

--- a/crates/tauri-plugin-pilot/src/diff.rs
+++ b/crates/tauri-plugin-pilot/src/diff.rs
@@ -105,28 +105,30 @@ pub fn compute_diff(old: &[SnapshotElement], new: &[SnapshotElement]) -> DiffRes
         }
     }
 
-    let removed: Vec<SnapshotElement> = old
+    let mut removed: Vec<SnapshotElement> = old
         .iter()
         .enumerate()
         .filter(|(i, _)| !matched_old[*i])
         .map(|(_, el)| el.clone())
         .collect();
 
-    let added: Vec<SnapshotElement> = new
+    let mut added: Vec<SnapshotElement> = new
         .iter()
         .enumerate()
         .filter(|(i, _)| !matched_new[*i])
         .map(|(_, el)| el.clone())
         .collect();
 
-    // Sort changed entries for deterministic output (HashMap iteration is unordered)
-    changed.sort_by(|a, b| {
-        a.new
-            .depth
-            .cmp(&b.new.depth)
-            .then_with(|| a.new.role.cmp(&b.new.role))
-            .then_with(|| a.new.name.cmp(&b.new.name))
-    });
+    // Sort all result arrays for deterministic output (HashMap iteration is unordered)
+    let sort_key = |a: &SnapshotElement, b: &SnapshotElement| {
+        a.depth
+            .cmp(&b.depth)
+            .then_with(|| a.role.cmp(&b.role))
+            .then_with(|| a.name.cmp(&b.name))
+    };
+    added.sort_by(sort_key);
+    removed.sort_by(sort_key);
+    changed.sort_by(|a, b| sort_key(&a.new, &b.new));
 
     DiffResult {
         added,

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -26,6 +26,7 @@ type PendingMap = HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>
 pub(crate) struct EvalEngine {
     pending: Arc<Mutex<PendingMap>>,
     next_id: Arc<AtomicU64>,
+    last_snapshot: Arc<Mutex<Option<serde_json::Value>>>,
 }
 
 impl EvalEngine {
@@ -33,7 +34,24 @@ impl EvalEngine {
         Self {
             pending: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU64::new(1)),
+            last_snapshot: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Store the last snapshot result for later diff comparison.
+    pub fn store_snapshot(&self, value: &serde_json::Value) {
+        *self
+            .last_snapshot
+            .lock()
+            .expect("last_snapshot lock poisoned") = Some(value.clone());
+    }
+
+    /// Retrieve the last stored snapshot, if any.
+    pub fn get_last_snapshot(&self) -> Option<serde_json::Value> {
+        self.last_snapshot
+            .lock()
+            .expect("last_snapshot lock poisoned")
+            .clone()
     }
 
     /// Register a pending eval request. Returns the ID and a receiver.
@@ -193,5 +211,20 @@ mod tests {
         assert!(script.contains("__callback"));
         assert!(script.contains("try"));
         assert!(script.contains("catch"));
+    }
+
+    #[test]
+    fn test_get_last_snapshot_none_initially() {
+        let engine = EvalEngine::new();
+        assert!(engine.get_last_snapshot().is_none());
+    }
+
+    #[test]
+    fn test_store_and_retrieve_snapshot() {
+        let engine = EvalEngine::new();
+        let value = json!({"elements": [{"ref": "e1", "role": "button", "depth": 1}]});
+        engine.store_snapshot(&value);
+        let retrieved = engine.get_last_snapshot();
+        assert_eq!(retrieved, Some(value));
     }
 }

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -39,6 +39,10 @@ impl EvalEngine {
     }
 
     /// Store the last snapshot result for later diff comparison.
+    ///
+    /// Note: `store_snapshot` and `get_last_snapshot` each acquire the lock independently.
+    /// Concurrent snapshot/diff calls may observe non-deterministic ordering — acceptable
+    /// for this single-connection CLI debugging tool.
     pub fn store_snapshot(&self, value: &serde_json::Value) {
         *self
             .last_snapshot

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -64,12 +64,21 @@ async fn handle_diff(
         })?
     };
 
-    // Take a new snapshot using the bridge
-    let script = build_bridge_call("snapshot", params).map_err(|msg| RpcError {
-        code: -32602,
-        message: msg,
-        data: None,
-    })?;
+    // Take a new snapshot using the bridge — strip "reference" to avoid embedding
+    // the entire old snapshot in the JS eval string (the bridge doesn't use it).
+    let snapshot_params = params.map(|p| {
+        let mut cleaned = p.clone();
+        if let Some(obj) = cleaned.as_object_mut() {
+            obj.remove("reference");
+        }
+        cleaned
+    });
+    let script =
+        build_bridge_call("snapshot", snapshot_params.as_ref()).map_err(|msg| RpcError {
+            code: -32602,
+            message: msg,
+            data: None,
+        })?;
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,3 +1,4 @@
+use crate::diff;
 use crate::eval::EvalEngine;
 use crate::protocol::RpcError;
 use crate::server::EvalFn;
@@ -15,11 +16,15 @@ pub(crate) async fn dispatch(
 ) -> Result<serde_json::Value, RpcError> {
     match method {
         "ping" => Ok(serde_json::json!({"status": "ok"})),
-        "snapshot" | "click" | "fill" | "type" | "press" | "select" | "check" | "scroll"
-        | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
-        | "state" | "wait" | "screenshot" => {
-            handle_eval_method(method, params, engine, eval_fn).await
+        "snapshot" => {
+            let result = handle_eval_method("snapshot", params, engine, eval_fn).await?;
+            engine.store_snapshot(&result);
+            Ok(result)
         }
+        "diff" => handle_diff(params, engine, eval_fn).await,
+        "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" | "text" | "html"
+        | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state" | "wait"
+        | "screenshot" => handle_eval_method(method, params, engine, eval_fn).await,
         "console.getLogs" => handle_eval_method("consoleLogs", params, engine, eval_fn).await,
         "console.clear" => handle_eval_method("clearLogs", params, engine, eval_fn).await,
         "network.getRequests" => {
@@ -32,6 +37,93 @@ pub(crate) async fn dispatch(
             data: None,
         }),
     }
+}
+
+/// Handle the "diff" method: take a new snapshot, compare with the reference, and return `DiffResult`.
+async fn handle_diff(
+    params: Option<&serde_json::Value>,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+) -> Result<serde_json::Value, RpcError> {
+    let eval_fn = eval_fn.ok_or_else(|| RpcError {
+        code: -32603,
+        message: "No webview available for eval".to_owned(),
+        data: None,
+    })?;
+
+    // Determine reference snapshot: from params["reference"] or last stored snapshot
+    let reference = if let Some(ref_val) = params.and_then(|p| p.get("reference")) {
+        ref_val.clone()
+    } else {
+        engine.get_last_snapshot().ok_or_else(|| RpcError {
+            code: -32602,
+            message:
+                "No previous snapshot available. Run `snapshot` first or use `diff --ref <file>`"
+                    .to_owned(),
+            data: None,
+        })?
+    };
+
+    // Take a new snapshot using the bridge
+    let script = build_bridge_call("snapshot", params).map_err(|msg| RpcError {
+        code: -32602,
+        message: msg,
+        data: None,
+    })?;
+    let (id, rx) = engine.register();
+    let wrapped = EvalEngine::wrap_script(id, &script);
+
+    if let Err(e) = eval_fn(wrapped) {
+        engine.resolve(id, Err(format!("Eval failed: {e}")));
+        return Err(RpcError {
+            code: -32603,
+            message: format!("Eval failed: {e}"),
+            data: None,
+        });
+    }
+
+    let result = engine
+        .wait(id, rx, DEFAULT_TIMEOUT)
+        .await
+        .map_err(|e| RpcError {
+            code: -32603,
+            message: format!("Eval error: {e}"),
+            data: None,
+        })?;
+
+    // Parse both snapshots: extract "elements" arrays
+    let old_elements: Vec<diff::SnapshotElement> = reference
+        .get("elements")
+        .map(|v| serde_json::from_value(v.clone()))
+        .transpose()
+        .map_err(|e| RpcError {
+            code: -32602,
+            message: format!("Failed to parse reference snapshot elements: {e}"),
+            data: None,
+        })?
+        .unwrap_or_default();
+
+    let new_elements: Vec<diff::SnapshotElement> = result
+        .get("elements")
+        .map(|v| serde_json::from_value(v.clone()))
+        .transpose()
+        .map_err(|e| RpcError {
+            code: -32603,
+            message: format!("Failed to parse new snapshot elements: {e}"),
+            data: None,
+        })?
+        .unwrap_or_default();
+
+    let diff_result = diff::compute_diff(&old_elements, &new_elements);
+
+    // Store the new snapshot for subsequent diffs
+    engine.store_snapshot(&result);
+
+    serde_json::to_value(&diff_result).map_err(|e| RpcError {
+        code: -32603,
+        message: format!("Serialization error: {e}"),
+        data: None,
+    })
 }
 
 /// Handle a method that requires JS evaluation via the bridge.
@@ -162,6 +254,34 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_diff_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("diff", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_diff_without_previous_snapshot() {
+        let engine = EvalEngine::new();
+        // Provide a dummy eval_fn that always succeeds (won't be called because we fail before)
+        // Actually diff needs eval_fn first, then checks reference.
+        // We need an eval_fn that returns something, but there's no previous snapshot.
+        // Use an eval_fn that will block forever — but we check reference before eval.
+        // Wait: handle_diff checks eval_fn first, then reference.
+        // So with eval_fn but no previous snapshot, we get -32602 after eval completes.
+        // Let's use a sync eval_fn and resolve manually.
+        // Actually the reference check happens BEFORE the eval call, so we can check:
+        // eval_fn present + no reference in params + no last_snapshot → -32602
+        let eval_fn: crate::server::EvalFn = std::sync::Arc::new(|_script| Ok(()));
+        let result = dispatch("diff", None, &engine, Some(&eval_fn)).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert!(err.message.contains("No previous snapshot"));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod diff;
 mod error;
 #[allow(dead_code)]
 pub(crate) mod eval;


### PR DESCRIPTION
## Summary

Closes #8

- Add `tauri-pilot diff` command that compares the current page state with the previous snapshot and displays only differences (added/removed/changed elements)
- Add `tauri-pilot snapshot --save <file>` to persist snapshots to disk for later comparison
- Add `tauri-pilot diff --ref <file>` to diff against a saved snapshot file
- Tree diff algorithm matches elements by `(role, name, depth)` with position-order tiebreaker for duplicates
- Colored output: green `+` added, red `-` removed, yellow `~` changed with field-level detail
- Plugin stores last snapshot automatically after each `snapshot` call

### Files changed

| Crate | File | Change |
|-------|------|--------|
| plugin | `src/diff.rs` | **NEW** — diff algorithm + types (SnapshotElement, DiffResult, compute_diff) |
| plugin | `src/eval.rs` | Add `last_snapshot` storage to EvalEngine |
| plugin | `src/handler.rs` | Add `diff` dispatch + store snapshot after each snapshot call |
| plugin | `src/lib.rs` | Add `pub mod diff` |
| cli | `src/cli.rs` | Add `Diff` command + `--save` flag on `Snapshot` |
| cli | `src/main.rs` | Handle diff command, file save/load with validation |
| cli | `src/output.rs` | Add `format_diff()` with colored +/-/~ output |

## Test plan

- [x] 94 tests passing (47 CLI + 47 plugin), 20 new tests added
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Adversarial review: 4 findings resolved (deserialization error propagation, deterministic sort, file size limit, structural validation)
- [ ] Manual test: `tauri-pilot snapshot` then `tauri-pilot diff` on a live app
- [ ] Manual test: `tauri-pilot snapshot --save before.snap` then interact then `tauri-pilot diff --ref before.snap`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tauri-pilot diff` to compare the current page with a previous snapshot and print only what changed. Supports saving/loading snapshots and defaults to the last snapshot for quick diffs.

- **New Features**
  - New `diff` JSON-RPC method and `tauri-pilot diff` with `--ref`, `--interactive`, `--selector`, `--depth`.
  - `tauri-pilot snapshot --save <file>` to persist snapshots for later comparison.
  - Element matching by `(role, name, depth)` with position-order tie-breaker; colored output with green `+`, red `-`, yellow `~`.

- **Bug Fixes**
  - Strip `reference` from params before building the JS eval string to reduce payload size.
  - Sanitize diff output by removing ANSI sequences from user-provided values.
  - Deterministic sorting of added/removed/changed entries for stable output.

<sup>Written for commit 3670f705e60f3fe8f2f3687736eb616569bf7a96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tauri-pilot diff` to compare snapshots with `--ref FILE`, `--interactive`, `--selector`, and `--depth` options.
  * `snapshot` gained `--save FILE` to persist snapshots for later comparison.
  * CLI now shows colored diffs (green `+`, red `-`, yellow `~`) with field-level change details.
  * Snapshots are retained (last snapshot kept) to enable subsequent diffs.
* **Documentation**
  * CHANGELOG updated with the Snapshot diff command entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->