### PR TITLE
chore: set up crates.io publishing and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
-      - name: Install Rust 1.94.1
+      - name: Install Rust 1.94.0
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.94.0"
           components: clippy, rustfmt
 
       - name: Cache cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo publish -p tauri-plugin-pilot 2>&1 || {
-            if cargo publish -p tauri-plugin-pilot 2>&1 | grep -q "already uploaded"; then
-              echo "tauri-plugin-pilot already published, skipping"
-            else
-              exit 1
-            fi
-          }
+          set +e
+          OUTPUT=$(cargo publish -p tauri-plugin-pilot 2>&1)
+          STATUS=$?
+          set -e
+          if [ $STATUS -eq 0 ]; then
+            echo "tauri-plugin-pilot published successfully"
+          elif echo "$OUTPUT" | grep -q "already uploaded"; then
+            echo "tauri-plugin-pilot already published, skipping"
+          else
+            echo "$OUTPUT"
+            exit 1
+          fi
 
       - name: Wait for crates.io index to update
         env:
@@ -107,13 +112,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo publish -p tauri-pilot-cli 2>&1 || {
-            if cargo publish -p tauri-pilot-cli 2>&1 | grep -q "already uploaded"; then
-              echo "tauri-pilot-cli already published, skipping"
-            else
-              exit 1
-            fi
-          }
+          set +e
+          OUTPUT=$(cargo publish -p tauri-pilot-cli 2>&1)
+          STATUS=$?
+          set -e
+          if [ $STATUS -eq 0 ]; then
+            echo "tauri-pilot-cli published successfully"
+          elif echo "$OUTPUT" | grep -q "already uploaded"; then
+            echo "tauri-pilot-cli already published, skipping"
+          else
+            echo "$OUTPUT"
+            exit 1
+          fi
 
       - name: Extract changelog for this version
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Publish & Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for creating GitHub Releases
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Install Rust 1.94.1
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: release-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches Cargo.toml versions
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          for toml in crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml; do
+            CARGO_VERSION=$(grep '^version' "$toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+            if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+              echo "ERROR: Tag v$TAG_VERSION does not match $toml version $CARGO_VERSION"
+              exit 1
+            fi
+          done
+          echo "All Cargo.toml versions match tag v$TAG_VERSION"
+
+      - name: Verify CHANGELOG.md has entry for this version
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          if ! grep -q "## \[$TAG_VERSION\]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no entry for version $TAG_VERSION"
+            exit 1
+          fi
+          echo "CHANGELOG.md contains entry for $TAG_VERSION"
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Publish tauri-plugin-pilot
+        run: cargo publish -p tauri-plugin-pilot
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index propagation
+        run: sleep 30
+
+      - name: Publish tauri-pilot-cli
+        run: cargo publish -p tauri-pilot-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          # Extract content between this version header and the next version header (or EOF)
+          BODY=$(sed -n "/^## \[$TAG_VERSION\]/,/^## \[/{/^## \[$TAG_VERSION\]/d;/^## \[/d;p}" CHANGELOG.md)
+          # Use GitHub Actions multiline output
+          {
+            echo "body<<CHANGELOG_EOF"
+            echo "$BODY"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
-      - name: Install Rust 1.94.1
+      - name: Install Rust 1.94.0
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.94.0"
           components: clippy, rustfmt
 
       - name: Cache cargo
@@ -75,17 +75,45 @@ jobs:
         run: cargo test --workspace
 
       - name: Publish tauri-plugin-pilot
-        run: cargo publish -p tauri-plugin-pilot
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish -p tauri-plugin-pilot 2>&1 || {
+            if cargo publish -p tauri-plugin-pilot 2>&1 | grep -q "already uploaded"; then
+              echo "tauri-plugin-pilot already published, skipping"
+            else
+              exit 1
+            fi
+          }
 
-      - name: Wait for crates.io index propagation
-        run: sleep 30
+      - name: Wait for crates.io index to update
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "Waiting for tauri-plugin-pilot $TAG_VERSION to appear on crates.io..."
+          for i in $(seq 1 12); do
+            if cargo search tauri-plugin-pilot 2>/dev/null | grep -q "\"$TAG_VERSION\""; then
+              echo "Found tauri-plugin-pilot $TAG_VERSION on crates.io"
+              break
+            fi
+            if [ "$i" -eq 12 ]; then
+              echo "WARNING: tauri-plugin-pilot $TAG_VERSION not yet visible after 120s, proceeding anyway"
+            fi
+            echo "  Attempt $i/12 — waiting 10s..."
+            sleep 10
+          done
 
       - name: Publish tauri-pilot-cli
-        run: cargo publish -p tauri-pilot-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish -p tauri-pilot-cli 2>&1 || {
+            if cargo publish -p tauri-pilot-cli 2>&1 | grep -q "already uploaded"; then
+              echo "tauri-pilot-cli already published, skipping"
+            else
+              exit 1
+            fi
+          }
 
       - name: Extract changelog for this version
         id: changelog
@@ -93,19 +121,24 @@ jobs:
           TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Extract content between this version header and the next version header (or EOF)
-          BODY=$(sed -n "/^## \[$TAG_VERSION\]/,/^## \[/{/^## \[$TAG_VERSION\]/d;/^## \[/d;p}" CHANGELOG.md)
-          # Use GitHub Actions multiline output
-          {
-            echo "body<<CHANGELOG_EOF"
-            echo "$BODY"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
+          sed -n "/^## \[$TAG_VERSION\]/,/^## \[/{/^## \[$TAG_VERSION\]/d;/^## \[/d;p}" CHANGELOG.md > /tmp/release-body.md
+
+      - name: Detect prerelease
+        id: prerelease
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if echo "$TAG_NAME" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-.+'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body: "${{ steps.changelog.outputs.body }}"
+          body_path: /tmp/release-body.md
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches Cargo.toml versions
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG_VERSION="${{ steps.version.outputs.version }}"
           for toml in crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml; do
             CARGO_VERSION=$(grep '^version' "$toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
             if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
@@ -55,8 +56,9 @@ jobs:
           echo "All Cargo.toml versions match tag v$TAG_VERSION"
 
       - name: Verify CHANGELOG.md has entry for this version
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG_VERSION="${{ steps.version.outputs.version }}"
           if ! grep -q "## \[$TAG_VERSION\]" CHANGELOG.md; then
             echo "ERROR: CHANGELOG.md has no entry for version $TAG_VERSION"
             exit 1
@@ -87,8 +89,9 @@ jobs:
 
       - name: Extract changelog for this version
         id: changelog
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG_VERSION="${{ steps.version.outputs.version }}"
           # Extract content between this version header and the next version header (or EOF)
           BODY=$(sed -n "/^## \[$TAG_VERSION\]/,/^## \[/{/^## \[$TAG_VERSION\]/d;/^## \[/d;p}" CHANGELOG.md)
           # Use GitHub Actions multiline output
@@ -103,6 +106,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body: ${{ steps.changelog.outputs.body }}
+          body: "${{ steps.changelog.outputs.body }}"
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-04-03
 
 ### Added
 
@@ -76,6 +79,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
 [#9]: https://github.com/mpiton/tauri-pilot/issues/9
 [#1]: https://github.com/mpiton/tauri-pilot/pull/1
 [#2]: https://github.com/mpiton/tauri-pilot/pull/2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = ["crates/tauri-plugin-pilot", "crates/tauri-pilot-cli"]
 edition = "2024"
 license = "MIT"
 rust-version = "1.94.0"
+authors = ["Mathieu Piton <contact@mathieu-piton.com>"]
+repository = "https://github.com/mpiton/tauri-pilot"
+homepage = "https://github.com/mpiton/tauri-pilot"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "CLI for interactive testing and automation of Tauri v2 applications"
+keywords = ["tauri", "cli", "testing", "automation", "accessibility"]
+categories = ["command-line-utilities", "development-tools::testing"]
+readme = "README.md"
 
 [[bin]]
 name = "tauri-pilot"

--- a/crates/tauri-pilot-cli/README.md
+++ b/crates/tauri-pilot-cli/README.md
@@ -1,0 +1,5 @@
+# tauri-pilot
+
+CLI for interactive testing and automation of Tauri v2 applications.
+
+See the [main repository](https://github.com/mpiton/tauri-pilot) for full documentation.

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Tauri v2 plugin for runtime UI testing and automation via Unix socket JSON-RPC"
+keywords = ["tauri", "plugin", "testing", "automation", "accessibility"]
+categories = ["development-tools::testing", "gui"]
+readme = "README.md"
 links = "tauri-plugin-pilot"
 
 [lints]

--- a/crates/tauri-plugin-pilot/README.md
+++ b/crates/tauri-plugin-pilot/README.md
@@ -1,0 +1,5 @@
+# tauri-plugin-pilot
+
+Tauri v2 plugin for runtime UI testing and automation via Unix socket JSON-RPC.
+
+See the [main repository](https://github.com/mpiton/tauri-pilot) for full documentation.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/release.sh 0.2.0
+# Bumps version in all Cargo.toml files, updates CHANGELOG.md,
+# commits, tags, and pushes to trigger the release workflow.
+
+VERSION="${1:-}"
+
+# Validate argument
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.2.0"
+  exit 1
+fi
+
+# Validate semver format
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "Error: '$VERSION' is not a valid semver version"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "Releasing v$VERSION..."
+
+# Update [package].version in all crate Cargo.toml files
+for toml in crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml; do
+  sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$toml"
+  echo "  Updated $toml"
+done
+
+# Update CHANGELOG.md
+TODAY=$(date +%Y-%m-%d)
+# Replace "## [Unreleased]" with "## [Unreleased]\n\n## [$VERSION] - $TODAY"
+sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $TODAY/" CHANGELOG.md
+
+# Update comparison links at bottom of CHANGELOG
+# Add new unreleased comparison link and version link
+if grep -q "\[Unreleased\]:.*compare" CHANGELOG.md; then
+  sed -i "s|\[Unreleased\]:.*|[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD|" CHANGELOG.md
+else
+  echo "" >> CHANGELOG.md
+  echo "[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD" >> CHANGELOG.md
+fi
+
+# Add version link if not present
+if ! grep -q "\[$VERSION\]:" CHANGELOG.md; then
+  echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/releases/tag/v$VERSION" >> CHANGELOG.md
+fi
+
+echo "  Updated CHANGELOG.md"
+
+# Verify compilation
+echo "Running cargo check..."
+cargo check --workspace
+
+echo "Running cargo fmt..."
+cargo fmt --all
+
+# Git operations
+git add crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml CHANGELOG.md
+git commit -m "chore: release v$VERSION"
+git tag -a "v$VERSION" -m "Release v$VERSION"
+
+echo ""
+echo "Release v$VERSION prepared. Run the following to publish:"
+echo ""
+echo "  git push && git push --tags"
+echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,23 +24,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Preflight: ensure clean worktree
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working tree is not clean. Commit or stash changes before releasing."
+  git status --short
+  exit 1
+fi
+
 echo "Releasing v$VERSION..."
 
 # Update [package].version in all crate Cargo.toml files
 for toml in crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml; do
-  sed -i "s/^version = \".*\"/version = \"$VERSION\"/" "$toml"
+  perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" "$toml"
   echo "  Updated $toml"
 done
 
 # Update CHANGELOG.md
 TODAY=$(date +%Y-%m-%d)
 # Replace "## [Unreleased]" with "## [Unreleased]\n\n## [$VERSION] - $TODAY"
-sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $TODAY/" CHANGELOG.md
+perl -i -pe "s/^## \\[Unreleased\\]/## [Unreleased]\n\n## [$VERSION] - $TODAY/" CHANGELOG.md
 
 # Update comparison links at bottom of CHANGELOG
 # Add new unreleased comparison link and version link
 if grep -q "\[Unreleased\]:.*compare" CHANGELOG.md; then
-  sed -i "s|\[Unreleased\]:.*|[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD|" CHANGELOG.md
+  perl -i -pe "s|\[Unreleased\]:.*|[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD|" CHANGELOG.md
 else
   echo "" >> CHANGELOG.md
   echo "[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD" >> CHANGELOG.md
@@ -53,15 +60,21 @@ fi
 
 echo "  Updated CHANGELOG.md"
 
-# Verify compilation
+# Verify compilation and quality
 echo "Running cargo check..."
 cargo check --workspace
+
+echo "Running cargo clippy..."
+cargo clippy --workspace -- -D warnings
+
+echo "Running cargo test..."
+cargo test --workspace
 
 echo "Running cargo fmt..."
 cargo fmt --all
 
-# Git operations
-git add crates/tauri-plugin-pilot/Cargo.toml crates/tauri-pilot-cli/Cargo.toml CHANGELOG.md
+# Git operations — stage all changes (release files + any fmt-touched files)
+git add -A
 git commit -m "chore: release v$VERSION"
 git tag -a "v$VERSION" -m "Release v$VERSION"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Usage: ./scripts/release.sh 0.2.0
 # Bumps version in all Cargo.toml files, updates CHANGELOG.md,
-# commits, tags, and pushes to trigger the release workflow.
+# commits and tags the release; push separately to trigger the release workflow.
 
 VERSION="${1:-}"
 
@@ -31,6 +31,12 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
+# Preflight: ensure tag does not already exist
+if git rev-parse -q --verify "refs/tags/v$VERSION" > /dev/null 2>&1; then
+  echo "Error: tag v$VERSION already exists"
+  exit 1
+fi
+
 echo "Releasing v$VERSION..."
 
 # Update [package].version in all crate Cargo.toml files
@@ -42,7 +48,17 @@ done
 # Update CHANGELOG.md
 TODAY=$(date +%Y-%m-%d)
 # Replace "## [Unreleased]" with "## [Unreleased]\n\n## [$VERSION] - $TODAY"
+if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+  echo "Error: CHANGELOG.md is missing '## [Unreleased]' header"
+  exit 1
+fi
 perl -i -pe "s/^## \\[Unreleased\\]/## [Unreleased]\n\n## [$VERSION] - $TODAY/" CHANGELOG.md
+
+# Verify the version section was created
+if ! grep -q "## \[$VERSION\] - " CHANGELOG.md; then
+  echo "Error: failed to create version section in CHANGELOG.md"
+  exit 1
+fi
 
 # Update comparison links at bottom of CHANGELOG
 # Add new unreleased comparison link and version link


### PR DESCRIPTION
## Summary

- Add all required crates.io metadata to workspace and crate `Cargo.toml` files (authors, description, keywords, categories, repository, homepage, readme)
- Create per-crate `README.md` files for crates.io display
- Version `CHANGELOG.md` — move all entries from `[Unreleased]` to `[0.1.0] - 2026-04-03`
- Add GitHub Actions release workflow (`.github/workflows/release.yml`) triggered on `v*` tags: verifies version consistency, runs CI checks, publishes crates in dependency order, creates GitHub Release with changelog body
- Add `scripts/release.sh` version bump helper: validates semver, updates all `Cargo.toml` files, finalizes changelog, commits and tags
- Update `CLAUDE.md` with release process documentation (local only, not committed)
- Security: use `env:` vars instead of direct `${{ }}` interpolation in workflow shell steps

## Verification

- `cargo publish --dry-run --allow-dirty` passes for both crates
- `cargo test --workspace` — 50 tests pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Test plan

- [ ] Verify `cargo publish --dry-run -p tauri-plugin-pilot` passes in CI
- [ ] Verify `cargo publish --dry-run -p tauri-pilot-cli` passes in CI
- [ ] After merge, test release flow with `./scripts/release.sh 0.1.0` (or a test tag)
- [ ] Verify `CARGO_REGISTRY_TOKEN` secret is configured in GitHub repo settings before first real release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up crates.io publishing with a tag-driven GitHub Actions release for the Rust workspace. Prepares `tauri-plugin-pilot` and `tauri-pilot-cli` for v0.1.0, automates publishing and GitHub Releases, and aligns CI with Rust 1.94.0.

- **New Features**
  - Added crates.io metadata (workspace + crates) and per-crate `README.md` for `tauri-plugin-pilot` and `tauri-pilot-cli`.
  - Versioned `CHANGELOG.md` to `0.1.0` with SemVer note and comparison links.
  - Added `.github/workflows/release.yml` triggered by `v*` tags: validates versions/changelog, runs fmt/clippy/tests, publishes plugin then CLI with crates.io polling and idempotent handling (fixed double-execution), creates GitHub Release from extracted changelog, detects prereleases; uses env vars and `body_path`.
  - Added `scripts/release.sh`: semver + clean worktree and tag-exists preflights, portable edits, bumps versions and changelog links, verifies changelog rewrite, runs clippy/tests/fmt, commits and tags.
  - CI pinned to Rust `1.94.0`.

- **Migration**
  - Set `CARGO_REGISTRY_TOKEN` in repository secrets.
  - To cut a release: run `./scripts/release.sh <version>`, then `git push && git push --tags`.

<sup>Written for commit 3cdd9900337ddf4dde63763a7c18f0a445059ba4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated release workflow that publishes packages and creates GitHub releases from version tags.
  * Command-line release script to prepare versioned releases, update changelog, run checks, and create tags/commits.

* **Documentation**
  * Added README files for CLI and plugin.
  * Updated project metadata (authors, repository, homepage).
  * Enhanced changelog with Semantic Versioning and a new 0.1.0 entry.

* **Chores**
  * Pinned CI Rust toolchain to 1.94.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->