### PR TITLE
feat: DOM watch — observe changes without polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-04-03
+### Added
+
+- **DOM watch command** — observe DOM mutations with MutationObserver, debounce until stable, and return a change summary ([#10])
+  - `tauri-pilot watch` — block until any DOM change, print summary
+  - `--timeout` timeout in ms, `--selector` scope to subtree, `--stable` debounce duration
+  - Uses `MutationObserver` with `childList`, `subtree`, `attributes`, `characterData`
 
 ## [0.1.0] - 2026-04-03
 
@@ -81,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
 [#9]: https://github.com/mpiton/tauri-pilot/issues/9

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -105,6 +105,18 @@ pub(crate) enum Command {
         #[arg(long, default_value = "10000")]
         timeout: u64,
     },
+    /// Watch for DOM mutations and report changes.
+    Watch {
+        /// CSS selector to scope observation to a subtree.
+        #[arg(long)]
+        selector: Option<String>,
+        /// Timeout in ms (reject if no changes).
+        #[arg(long, default_value = "10000")]
+        timeout: u64,
+        /// Wait until DOM is stable for N ms (no new mutations).
+        #[arg(long, default_value = "300")]
+        stable: u64,
+    },
     /// Display or stream captured console logs.
     Logs {
         /// Filter by log level (log, info, warn, error).
@@ -332,6 +344,51 @@ mod tests {
             assert_eq!(expected, "/dashboard");
         } else {
             panic!("Expected Assert Url command");
+        }
+    }
+
+    #[test]
+    fn test_parse_watch_command() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "watch",
+            "--selector",
+            ".results",
+            "--timeout",
+            "5000",
+            "--stable",
+            "500",
+        ]);
+        if let Command::Watch {
+            selector,
+            timeout,
+            stable,
+        } = cli.command
+        {
+            assert_eq!(selector, Some(".results".to_owned()));
+            assert_eq!(timeout, 5000);
+            assert_eq!(stable, 500);
+        } else {
+            panic!("Expected Watch command");
+        }
+    }
+
+    #[test]
+    fn test_parse_watch_defaults() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "watch"]);
+        if let Command::Watch {
+            selector,
+            timeout,
+            stable,
+        } = cli.command
+        {
+            assert_eq!(selector, None);
+            assert_eq!(timeout, 10000);
+            assert_eq!(stable, 300);
+        } else {
+            panic!("Expected Watch command");
         }
     }
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<()> {
     let is_diff = matches!(args.command, Command::Diff { .. });
     let is_logs = matches!(args.command, Command::Logs { .. });
     let is_network = matches!(args.command, Command::Network { .. });
+    let is_watch = matches!(args.command, Command::Watch { .. });
 
     // Handle --follow mode: loop forever polling for new entries
     if let Command::Logs {
@@ -103,6 +104,8 @@ async fn main() -> Result<()> {
         } else {
             print!("{}", output::format_network(&result));
         }
+    } else if is_watch {
+        output::format_watch(&result);
     } else {
         output::format_text(&result);
     }
@@ -267,6 +270,21 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
                         "timeout": timeout,
                     })),
                 )
+                .await
+        }
+        Command::Watch {
+            selector,
+            timeout,
+            stable,
+        } => {
+            let mut params = serde_json::Map::new();
+            params.insert("timeout".into(), json!(timeout));
+            params.insert("stable".into(), json!(stable));
+            if let Some(sel) = selector {
+                params.insert("selector".into(), json!(sel));
+            }
+            client
+                .call("watch", Some(serde_json::Value::Object(params)))
                 .await
         }
         Command::Logs {

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -262,38 +262,73 @@ pub(crate) fn format_watch(value: &serde_json::Value) {
     {
         println!("{}", crate::style::warn("Modified:"));
         for el in entries {
-            let tag = el.get("tag").and_then(|t| t.as_str()).unwrap_or("?");
+            let tag = strip_ansi(el.get("tag").and_then(|t| t.as_str()).unwrap_or("?"));
             if let Some(attr) = el.get("attribute").and_then(|a| a.as_str()) {
-                let val = el.get("value").and_then(|v| v.as_str()).unwrap_or("");
-                println!(
-                    "  {} {} = {}",
-                    crate::style::info(tag),
-                    attr,
-                    crate::style::dim(format!("\"{val}\""))
-                );
+                let attr_safe = strip_ansi(attr);
+                let is_removed = el
+                    .get("removed")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                if is_removed {
+                    println!(
+                        "  {} {} {}",
+                        crate::style::info(&tag),
+                        attr_safe,
+                        crate::style::dim("<removed>")
+                    );
+                } else {
+                    let val = strip_ansi(el.get("value").and_then(|v| v.as_str()).unwrap_or(""));
+                    println!(
+                        "  {} {} = {}",
+                        crate::style::info(&tag),
+                        attr_safe,
+                        crate::style::dim(format!("\"{val}\""))
+                    );
+                }
             } else if let Some(text) = el.get("text").and_then(|t| t.as_str()) {
+                let text_safe = strip_ansi(text);
                 println!(
                     "  {} {}",
-                    crate::style::info(tag),
-                    crate::style::dim(format!("\"{text}\""))
+                    crate::style::info(&tag),
+                    crate::style::dim(format!("\"{text_safe}\""))
+                );
+            } else {
+                println!(
+                    "  {} {}",
+                    crate::style::info(&tag),
+                    crate::style::dim("(unknown change)")
                 );
             }
         }
     }
+
+    if value
+        .get("truncated")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        println!(
+            "{}",
+            crate::style::warn("(some entries truncated — mutation buffer limit reached)")
+        );
+    }
 }
 
 fn format_mutation_entry(el: &serde_json::Value) -> String {
-    let tag = el.get("tag").and_then(|t| t.as_str()).unwrap_or("?");
-    let mut desc = crate::style::info(tag).clone();
+    let tag = strip_ansi(el.get("tag").and_then(|t| t.as_str()).unwrap_or("?"));
+    let mut desc = crate::style::info(&tag);
     if let Some(id) = el.get("id").and_then(|i| i.as_str()) {
-        let _ = write!(desc, "#{id}");
+        let id_safe = strip_ansi(id);
+        let _ = write!(desc, "#{id_safe}");
     }
     if let Some(class) = el.get("class").and_then(|c| c.as_str()) {
-        let first = class.split_whitespace().next().unwrap_or("");
+        let class_safe = strip_ansi(class);
+        let first = class_safe.split_whitespace().next().unwrap_or("");
         let _ = write!(desc, ".{first}");
     }
     if let Some(text) = el.get("text").and_then(|t| t.as_str()) {
-        let _ = write!(desc, " {}", crate::style::dim(format!("\"{text}\"")));
+        let text_safe = strip_ansi(text);
+        let _ = write!(desc, " {}", crate::style::dim(format!("\"{text_safe}\"")));
     }
     desc
 }
@@ -682,7 +717,13 @@ mod tests {
         let result = json!({
             "added": [{"tag": "div", "id": "new", "text": "New item"}],
             "removed": [{"tag": "span", "class": "old"}],
-            "modified": [{"tag": "div", "attribute": "class", "value": "active"}]
+            "modified": [
+                {"tag": "div", "attribute": "class", "value": "active"},
+                {"tag": "div", "attribute": "data-old", "removed": true},
+                {"tag": "p", "text": "updated text"},
+                {"tag": "section"}
+            ],
+            "truncated": true
         });
         format_watch(&result);
     }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -224,6 +224,80 @@ pub(crate) fn format_network(value: &serde_json::Value) -> String {
     output
 }
 
+/// Format watch result showing DOM mutations grouped by type.
+pub(crate) fn format_watch(value: &serde_json::Value) {
+    let added = value.get("added").and_then(|v| v.as_array());
+    let removed = value.get("removed").and_then(|v| v.as_array());
+    let modified = value.get("modified").and_then(|v| v.as_array());
+
+    let is_empty = added.is_none_or(Vec::is_empty)
+        && removed.is_none_or(Vec::is_empty)
+        && modified.is_none_or(Vec::is_empty);
+
+    if is_empty {
+        println!("{}", crate::style::dim("No DOM changes detected."));
+        return;
+    }
+
+    if let Some(entries) = added
+        && !entries.is_empty()
+    {
+        println!("{}", crate::style::success("Added:"));
+        for el in entries {
+            println!("  {}", format_mutation_entry(el));
+        }
+    }
+
+    if let Some(entries) = removed
+        && !entries.is_empty()
+    {
+        println!("{}", crate::style::error("Removed:"));
+        for el in entries {
+            println!("  {}", format_mutation_entry(el));
+        }
+    }
+
+    if let Some(entries) = modified
+        && !entries.is_empty()
+    {
+        println!("{}", crate::style::warn("Modified:"));
+        for el in entries {
+            let tag = el.get("tag").and_then(|t| t.as_str()).unwrap_or("?");
+            if let Some(attr) = el.get("attribute").and_then(|a| a.as_str()) {
+                let val = el.get("value").and_then(|v| v.as_str()).unwrap_or("");
+                println!(
+                    "  {} {} = {}",
+                    crate::style::info(tag),
+                    attr,
+                    crate::style::dim(format!("\"{val}\""))
+                );
+            } else if let Some(text) = el.get("text").and_then(|t| t.as_str()) {
+                println!(
+                    "  {} {}",
+                    crate::style::info(tag),
+                    crate::style::dim(format!("\"{text}\""))
+                );
+            }
+        }
+    }
+}
+
+fn format_mutation_entry(el: &serde_json::Value) -> String {
+    let tag = el.get("tag").and_then(|t| t.as_str()).unwrap_or("?");
+    let mut desc = crate::style::info(tag).clone();
+    if let Some(id) = el.get("id").and_then(|i| i.as_str()) {
+        let _ = write!(desc, "#{id}");
+    }
+    if let Some(class) = el.get("class").and_then(|c| c.as_str()) {
+        let first = class.split_whitespace().next().unwrap_or("");
+        let _ = write!(desc, ".{first}");
+    }
+    if let Some(text) = el.get("text").and_then(|t| t.as_str()) {
+        let _ = write!(desc, " {}", crate::style::dim(format!("\"{text}\"")));
+    }
+    desc
+}
+
 /// Format a diff result showing added, removed, and changed elements.
 pub(crate) fn format_diff(value: &serde_json::Value) {
     let added = value.get("added").and_then(|v| v.as_array());
@@ -585,6 +659,32 @@ mod tests {
             }]
         });
         format_diff(&diff);
+    }
+
+    #[test]
+    fn test_format_watch_no_changes() {
+        format_watch(&json!({"added": [], "removed": [], "modified": []}));
+        format_watch(&json!({}));
+    }
+
+    #[test]
+    fn test_format_watch_added() {
+        let result = json!({
+            "added": [{"tag": "div", "class": "result", "text": "Hello"}],
+            "removed": [],
+            "modified": []
+        });
+        format_watch(&result);
+    }
+
+    #[test]
+    fn test_format_watch_mixed() {
+        let result = json!({
+            "added": [{"tag": "div", "id": "new", "text": "New item"}],
+            "removed": [{"tag": "span", "class": "old"}],
+            "modified": [{"tag": "div", "attribute": "class", "value": "active"}]
+        });
+        format_watch(&result);
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -630,6 +630,104 @@
     });
   }
 
+  function summarizeNode(node) {
+    var entry = { tag: node.tagName.toLowerCase() };
+    if (node.id) entry.id = node.id;
+    if (node.className && typeof node.className === 'string' && node.className.trim()) entry.class = node.className.trim();
+    var text = (node.textContent || '').replace(/\s+/g, ' ').trim();
+    if (text) entry.text = text.substring(0, 80);
+    return entry;
+  }
+
+  function watch(options) {
+    var selector = options && options.selector;
+    var timeout = (options && options.timeout != null) ? options.timeout : 10000;
+    var stable = (options && options.stable != null) ? options.stable : 300;
+
+    var root;
+    if (selector) {
+      root = document.querySelector(selector);
+      if (!root) throw new Error("watch: no element matches selector: " + selector);
+    } else {
+      root = document.body;
+    }
+
+    return new Promise(function (res, rej) {
+      var changes = { added: [], removed: [], modified: [] };
+      var stableTimer = null;
+      var timeoutTimer = null;
+      var settled = false;
+
+      function finish() {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutTimer);
+        observer.disconnect();
+        res(changes);
+      }
+
+      function resetStableTimer() {
+        clearTimeout(stableTimer);
+        stableTimer = setTimeout(finish, stable);
+      }
+
+      timeoutTimer = setTimeout(function () {
+        if (settled) return;
+        settled = true;
+        clearTimeout(stableTimer);
+        observer.disconnect();
+        if (changes.added.length > 0 || changes.removed.length > 0 || changes.modified.length > 0) {
+          res(changes);
+        } else {
+          rej(new Error("watch timeout: no DOM changes within " + timeout + "ms"));
+        }
+      }, timeout);
+
+      var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+          var mutation = mutations[i];
+          if (mutation.type === 'childList') {
+            for (var j = 0; j < mutation.addedNodes.length; j++) {
+              var node = mutation.addedNodes[j];
+              if (node.nodeType === Node.ELEMENT_NODE) {
+                changes.added.push(summarizeNode(node));
+              }
+            }
+            for (var k = 0; k < mutation.removedNodes.length; k++) {
+              var removed = mutation.removedNodes[k];
+              if (removed.nodeType === Node.ELEMENT_NODE) {
+                changes.removed.push(summarizeNode(removed));
+              }
+            }
+          } else if (mutation.type === 'attributes') {
+            var target = mutation.target;
+            changes.modified.push({
+              tag: target.tagName.toLowerCase(),
+              attribute: mutation.attributeName,
+              value: target.getAttribute(mutation.attributeName),
+            });
+          } else if (mutation.type === 'characterData') {
+            var parent = mutation.target.parentElement;
+            if (parent) {
+              changes.modified.push({
+                tag: parent.tagName.toLowerCase(),
+                text: (mutation.target.textContent || '').replace(/\s+/g, ' ').trim().substring(0, 80),
+              });
+            }
+          }
+        }
+        resetStableTimer();
+      });
+
+      observer.observe(root, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+    });
+  }
+
   async function screenshot(options) {
     var selector = options && options.selector;
     var el = selector ? document.querySelector(selector) : document.documentElement;
@@ -669,5 +767,6 @@
     visible: visible,
     count: count,
     checked: checked,
+    watch: watch,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -630,11 +630,18 @@
     });
   }
 
+  var MAX_WATCH_ENTRIES = 200;
+
   function summarizeNode(node) {
     var entry = { tag: node.tagName.toLowerCase() };
     if (node.id) entry.id = node.id;
     if (node.className && typeof node.className === 'string' && node.className.trim()) entry.class = node.className.trim();
-    var text = (node.textContent || '').replace(/\s+/g, ' ').trim();
+    var text = Array.from(node.childNodes)
+      .filter(function(n) { return n.nodeType === Node.TEXT_NODE; })
+      .map(function(n) { return n.textContent || ''; })
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
     if (text) entry.text = text.substring(0, 80);
     return entry;
   }
@@ -653,7 +660,7 @@
     }
 
     return new Promise(function (res, rej) {
-      var changes = { added: [], removed: [], modified: [] };
+      var changes = { added: [], removed: [], modified: [], truncated: false };
       var stableTimer = null;
       var timeoutTimer = null;
       var settled = false;
@@ -683,6 +690,14 @@
         }
       }, timeout);
 
+      function pushCapped(arr, entry) {
+        if (arr.length < MAX_WATCH_ENTRIES) {
+          arr.push(entry);
+        } else {
+          changes.truncated = true;
+        }
+      }
+
       var observer = new MutationObserver(function (mutations) {
         for (var i = 0; i < mutations.length; i++) {
           var mutation = mutations[i];
@@ -690,26 +705,32 @@
             for (var j = 0; j < mutation.addedNodes.length; j++) {
               var node = mutation.addedNodes[j];
               if (node.nodeType === Node.ELEMENT_NODE) {
-                changes.added.push(summarizeNode(node));
+                pushCapped(changes.added, summarizeNode(node));
               }
             }
             for (var k = 0; k < mutation.removedNodes.length; k++) {
-              var removed = mutation.removedNodes[k];
-              if (removed.nodeType === Node.ELEMENT_NODE) {
-                changes.removed.push(summarizeNode(removed));
+              var removedNode = mutation.removedNodes[k];
+              if (removedNode.nodeType === Node.ELEMENT_NODE) {
+                pushCapped(changes.removed, summarizeNode(removedNode));
               }
             }
           } else if (mutation.type === 'attributes') {
             var target = mutation.target;
-            changes.modified.push({
+            var attrValue = target.getAttribute(mutation.attributeName);
+            var entry = {
               tag: target.tagName.toLowerCase(),
               attribute: mutation.attributeName,
-              value: target.getAttribute(mutation.attributeName),
-            });
+            };
+            if (attrValue === null) {
+              entry.removed = true;
+            } else {
+              entry.value = attrValue;
+            }
+            pushCapped(changes.modified, entry);
           } else if (mutation.type === 'characterData') {
             var parent = mutation.target.parentElement;
             if (parent) {
-              changes.modified.push({
+              pushCapped(changes.modified, {
                 tag: parent.tagName.toLowerCase(),
                 text: (mutation.target.textContent || '').replace(/\s+/g, ' ').trim().substring(0, 80),
               });

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -7,6 +7,9 @@ use std::time::Duration;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extra headroom added to the JS-side watch timeout so the Rust oneshot channel
+/// doesn't expire before the JS `MutationObserver` can resolve/reject.
+const WATCH_BUFFER_MS: u64 = 2_000;
 
 /// Dispatch a JSON-RPC method call to the appropriate handler.
 pub(crate) async fn dispatch(
@@ -28,6 +31,14 @@ pub(crate) async fn dispatch(
         | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state" | "wait"
         | "visible" | "count" | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
+        "watch" => {
+            let timeout_ms = params
+                .and_then(|p| p.get("timeout"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(10_000);
+            let timeout = Duration::from_millis(timeout_ms.saturating_add(WATCH_BUFFER_MS));
+            handle_eval_method(method, params, engine, eval_fn, timeout).await
         }
         "screenshot" => {
             handle_eval_method(method, params, engine, eval_fn, SCREENSHOT_TIMEOUT).await
@@ -429,5 +440,22 @@ mod tests {
         let script = build_bridge_call("checked", Some(&params)).unwrap();
         assert!(script.starts_with("window.__PILOT__.checked("));
         assert!(script.contains("\"ref\":\"el-2\""));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_watch_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("watch", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_watch() {
+        let params = json!({"timeout": 5000, "selector": ".results", "stable": 500});
+        let script = build_bridge_call("watch", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.watch("));
+        assert!(script.contains("\"timeout\":5000"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `tauri-pilot watch` command using `MutationObserver` to observe DOM mutations without polling
- Buffer mutations (added/removed/modified), debounce via `--stable` param, timeout via `--timeout`
- Scope observation with `--selector` to a CSS subtree
- Colored CLI output: Added (green), Removed (red), Modified (yellow)

Closes #10

## Changes

| File | Change |
|------|--------|
| `js/bridge.js` | `summarizeNode()` helper + `watch()` function with MutationObserver |
| `handler.rs` | `"watch"` dispatch with dynamic timeout + `WATCH_BUFFER_MS` constant |
| `cli.rs` | `Watch` command variant with `--selector`, `--timeout`, `--stable` |
| `main.rs` | `Watch` dispatch + `is_watch` formatting branch |
| `output.rs` | `format_watch()` + `format_mutation_entry()` |
| `CHANGELOG.md` | Entry under [Unreleased] |

## CLI Usage

```bash
tauri-pilot watch                        # block until any DOM change, print summary
tauri-pilot watch --timeout 5000         # timeout in ms
tauri-pilot watch --selector ".results"  # scope to subtree
tauri-pilot watch --stable 500           # wait until stable for 500ms
```

## Adversarial Review Findings (resolved)

- Fixed `||` → nullish check for `timeout=0` / `stable=0` edge case
- Invalid `--selector` now rejects with error instead of silent fallback
- Added `settled` guard to prevent Promise double-settle race
- Truncated `characterData` text to 80 chars (consistency)
- Named magic constant `WATCH_BUFFER_MS` with doc comment
- Used `saturating_add` to prevent u64 overflow

## Test plan

- [x] 108 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] 7 new tests: handler dispatch, bridge call, CLI parsing (2), output formatting (3)
- [ ] Manual: run against a Tauri app, trigger DOM changes, verify output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tauri-pilot watch` command that observes DOM mutations with `MutationObserver`, debounces until stable, and prints a grouped summary. Helps scripts wait for UI updates without polling. Closes #10.

- **New Features**
  - Watch DOM mutations with `tauri-pilot watch`; groups Added (green), Removed (red), Modified (yellow).
  - Options: `--selector` to scope, `--stable` to wait for N ms of no changes, `--timeout` to fail if nothing happens.
  - Validates selectors and honors `0` for `--timeout`/`--stable`.

- **Bug Fixes**
  - Caps mutation lists at 200 entries; sets `truncated` and shows a CLI warning when hit.
  - Safer output and summaries: only direct text nodes included, detect removed attributes, sanitize strings before printing, and handle unknown modified entries gracefully.

<sup>Written for commit 12e07795a07d90bebd1b83ea2a3b281310a2f3bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `tauri-pilot watch` command and corresponding in-page API that monitors DOM mutations and returns grouped change summaries (added, removed, modified). Supports `--selector`, `--timeout` (default 10000 ms), and `--stable` (default 300 ms).
  * CLI output now prints grouped, styled sections for changes, a dim "No DOM changes detected." message when empty, and a warning when results are truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->