### PR TITLE
feat: drag & drop support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Drag & drop support** — simulate drag interactions and file drops for kanban boards, sortable lists, and drop zones ([#11])
+  - `tauri-pilot drag @e5 @e6` — drag element to another element
+  - `tauri-pilot drag @e5 --offset 0,100` — drag by pixel offset
+  - `tauri-pilot drop @e3 --file ./test.png` — simulate file drop on element
+  - Dispatches full HTML5 drag event sequence: `dragstart`, `dragenter`, `dragover`, `drop`, `dragend`
 - **DOM watch command** — observe DOM mutations with MutationObserver, debounce until stable, and return a change summary ([#10])
   - `tauri-pilot watch` — block until any DOM change, print summary
   - `--timeout` timeout in ms, `--selector` scope to subtree, `--stable` debounce duration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/mpiton/tauri-pilot/actions/workflows/ci.yml"><img src="https://github.com/mpiton/tauri-pilot/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://crates.io/crates/tauri-plugin-pilot"><img src="https://img.shields.io/crates/v/tauri-plugin-pilot.svg" alt="crates.io"></a>
   <a href="https://github.com/mpiton/tauri-pilot/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/rust-1.94.1+-orange.svg" alt="Rust 1.94.1+">
   <img src="https://img.shields.io/badge/platform-linux-lightgrey.svg" alt="Platform: Linux">
@@ -123,6 +124,8 @@ tauri-pilot wait --selector ".success-message"
 | `select` | Select a dropdown option |
 | `check` | Toggle a checkbox |
 | `scroll` | Scroll page or element |
+| `drag` | Drag element to element or by offset |
+| `drop` | Simulate file drop on element |
 | `text` | Get element text content |
 | `html` | Get element innerHTML |
 | `value` | Get input value |
@@ -134,6 +137,7 @@ tauri-pilot wait --selector ".success-message"
 | `navigate` | Change the WebView URL |
 | `state` | Get URL, title, viewport, scroll |
 | `assert` | One-step verification (text, visible, hidden, value, count, checked, contains, url) |
+| `watch` | Watch for DOM mutations |
 | `logs` | Capture and display console output |
 | `network` | Capture and display network requests |
 
@@ -157,6 +161,13 @@ Use `--json` for structured output when parsing programmatically.
 - **Linux** (WebKitGTK) — macOS/Windows planned
 - **Tauri v2** (v1 not supported)
 - **Rust 1.94.1+** (LTS, edition 2024)
+
+## Who uses this?
+
+Are you using tauri-pilot? [Open a PR](https://github.com/mpiton/tauri-pilot/pulls) to add your project here!
+
+<!-- Add your project below -->
+<!-- | [Project Name](https://github.com/...) | Short description | -->
 
 ## License
 

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -70,16 +70,17 @@ pub(crate) enum Command {
     /// Drag an element to another element or by offset.
     Drag {
         source: String,
+        #[arg(conflicts_with = "offset")]
         target: Option<String>,
         /// Pixel offset as X,Y (e.g., "0,100").
-        #[arg(long, value_name = "X,Y")]
+        #[arg(long, value_name = "X,Y", conflicts_with = "target")]
         offset: Option<String>,
     },
     /// Simulate a file drop on an element.
     Drop {
         target: String,
         /// File(s) to drop. Can be repeated.
-        #[arg(long)]
+        #[arg(long, required = true)]
         file: Vec<std::path::PathBuf>,
     },
     /// Get text content of an element.
@@ -470,6 +471,27 @@ mod tests {
         } else {
             panic!("expected Drop command");
         }
+    }
+
+    #[test]
+    fn test_parse_drag_rejects_both_target_and_offset() {
+        let result = Cli::try_parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "drag",
+            "@e5",
+            "@e6",
+            "--offset",
+            "0,100",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_drop_requires_file() {
+        let result = Cli::try_parse_from(["tauri-pilot", "--socket", "/tmp/t.sock", "drop", "@e3"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -67,6 +67,21 @@ pub(crate) enum Command {
         #[arg(long)]
         r#ref: Option<String>,
     },
+    /// Drag an element to another element or by offset.
+    Drag {
+        source: String,
+        target: Option<String>,
+        /// Pixel offset as X,Y (e.g., "0,100").
+        #[arg(long, value_name = "X,Y")]
+        offset: Option<String>,
+    },
+    /// Simulate a file drop on an element.
+    Drop {
+        target: String,
+        /// File(s) to drop. Can be repeated.
+        #[arg(long)]
+        file: Vec<std::path::PathBuf>,
+    },
     /// Get text content of an element.
     Text { target: String },
     /// Get inner HTML (of an element, or full page).
@@ -389,6 +404,71 @@ mod tests {
             assert_eq!(stable, 300);
         } else {
             panic!("Expected Watch command");
+        }
+    }
+
+    #[test]
+    fn test_parse_drag_to_element() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "drag",
+            "@e5",
+            "@e6",
+        ]);
+        assert!(
+            matches!(cli.command, Command::Drag { ref source, target: Some(_), .. } if source == "@e5")
+        );
+    }
+
+    #[test]
+    fn test_parse_drag_with_offset() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "drag",
+            "@e5",
+            "--offset",
+            "0,100",
+        ]);
+        assert!(
+            matches!(cli.command, Command::Drag { ref source, offset: Some(ref off), .. } if source == "@e5" && off == "0,100")
+        );
+    }
+
+    #[test]
+    fn test_parse_drop_with_file() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "drop",
+            "@e3",
+            "--file",
+            "test.png",
+        ]);
+        assert!(matches!(cli.command, Command::Drop { ref target, .. } if target == "@e3"));
+    }
+
+    #[test]
+    fn test_parse_drop_multiple_files() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "drop",
+            "@e3",
+            "--file",
+            "a.png",
+            "--file",
+            "b.txt",
+        ]);
+        if let Command::Drop { file, .. } = cli.command {
+            assert_eq!(file.len(), 2);
+        } else {
+            panic!("expected Drop command");
         }
     }
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -569,7 +569,8 @@ async fn run_network_command(
         .await
 }
 
-const MAX_DROP_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
+const MAX_DROP_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB per file
+const MAX_TOTAL_DROP_SIZE: usize = 100 * 1024 * 1024; // 100 MB total base64 payload
 
 async fn run_drop_command(
     client: &mut Client,
@@ -578,17 +579,24 @@ async fn run_drop_command(
 ) -> Result<serde_json::Value> {
     let mut p = target_params(target);
     let mut files = Vec::new();
+    let mut total_encoded = 0usize;
     for path in &file {
         let meta = std::fs::metadata(path)
             .with_context(|| format!("Failed to stat file: {}", path.display()))?;
+        anyhow::ensure!(meta.is_file(), "Not a regular file: {}", path.display());
+        let data = std::fs::read(path)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
         anyhow::ensure!(
-            meta.len() <= MAX_DROP_FILE_SIZE,
+            data.len() as u64 <= MAX_DROP_FILE_SIZE,
             "File too large (>50 MB): {}",
             path.display()
         );
-        let data = std::fs::read(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
         let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+        total_encoded += encoded.len();
+        anyhow::ensure!(
+            total_encoded <= MAX_TOTAL_DROP_SIZE,
+            "Total drop payload exceeds 100 MB limit"
+        );
         let name = path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
@@ -609,7 +617,11 @@ fn target_params(raw: &str) -> serde_json::Value {
 }
 
 fn mime_from_ext(path: &std::path::Path) -> &'static str {
-    match path.extension().and_then(|e| e.to_str()) {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    match ext.as_deref() {
         Some("png") => "image/png",
         Some("jpg" | "jpeg") => "image/jpeg",
         Some("gif") => "image/gif",
@@ -709,6 +721,19 @@ mod tests {
         assert_eq!(
             mime_from_ext(std::path::Path::new("Makefile")),
             "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn test_mime_from_ext_case_insensitive() {
+        assert_eq!(
+            mime_from_ext(std::path::Path::new("PHOTO.PNG")),
+            "image/png"
+        );
+        assert_eq!(mime_from_ext(std::path::Path::new("file.PnG")), "image/png");
+        assert_eq!(
+            mime_from_ext(std::path::Path::new("doc.PDF")),
+            "application/pdf"
         );
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -584,13 +584,13 @@ async fn run_drop_command(
         let meta = std::fs::metadata(path)
             .with_context(|| format!("Failed to stat file: {}", path.display()))?;
         anyhow::ensure!(meta.is_file(), "Not a regular file: {}", path.display());
-        let data = std::fs::read(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
         anyhow::ensure!(
-            data.len() as u64 <= MAX_DROP_FILE_SIZE,
+            meta.len() <= MAX_DROP_FILE_SIZE,
             "File too large (>50 MB): {}",
             path.display()
         );
+        let data = std::fs::read(path)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
         let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
         total_encoded += encoded.len();
         anyhow::ensure!(

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -301,6 +301,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             follow,
         } => run_network_command(client, filter, failed, last, clear, follow).await,
         Command::Assert(kind) => run_assert_command(client, kind).await,
+        Command::Drop { target, file } => run_drop_command(client, &target, file).await,
         cmd => run_dom_command(client, cmd).await,
     }
 }
@@ -378,6 +379,25 @@ async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_
         Command::Value { target } => client.call("value", Some(target_params(&target))).await,
         Command::Attrs { target } => client.call("attrs", Some(target_params(&target))).await,
         Command::Eval { script } => client.call("eval", Some(json!({"script": script}))).await,
+        Command::Drag {
+            source,
+            target,
+            offset,
+        } => {
+            let mut p = json!({"source": target_params(&source)});
+            if let Some(t) = target {
+                p["target"] = target_params(&t);
+            } else if let Some(off) = offset {
+                let parts: Vec<&str> = off.split(',').collect();
+                anyhow::ensure!(parts.len() == 2, "offset must be X,Y (e.g., '0,100')");
+                let x: f64 = parts[0].trim().parse().context("invalid offset X value")?;
+                let y: f64 = parts[1].trim().parse().context("invalid offset Y value")?;
+                p["offset"] = json!({"x": x, "y": y});
+            } else {
+                anyhow::bail!("drag requires either a target element or --offset");
+            }
+            client.call("drag", Some(p)).await
+        }
         _ => anyhow::bail!("unexpected command in run_dom_command"),
     }
 }
@@ -549,11 +569,62 @@ async fn run_network_command(
         .await
 }
 
+const MAX_DROP_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
+
+async fn run_drop_command(
+    client: &mut Client,
+    target: &str,
+    file: Vec<std::path::PathBuf>,
+) -> Result<serde_json::Value> {
+    let mut p = target_params(target);
+    let mut files = Vec::new();
+    for path in &file {
+        let meta = std::fs::metadata(path)
+            .with_context(|| format!("Failed to stat file: {}", path.display()))?;
+        anyhow::ensure!(
+            meta.len() <= MAX_DROP_FILE_SIZE,
+            "File too large (>50 MB): {}",
+            path.display()
+        );
+        let data = std::fs::read(path)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let mime = mime_from_ext(path);
+        files.push(json!({"name": name, "type": mime, "data": encoded}));
+    }
+    p["files"] = json!(files);
+    client.call("drop", Some(p)).await
+}
+
 fn target_params(raw: &str) -> serde_json::Value {
     match parse_target(raw) {
         Target::Ref(r) => json!({"ref": r}),
         Target::Selector(s) => json!({"selector": s}),
         Target::Coords(x, y) => json!({"x": x, "y": y}),
+    }
+}
+
+fn mime_from_ext(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("png") => "image/png",
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("svg") => "image/svg+xml",
+        Some("webp") => "image/webp",
+        Some("pdf") => "application/pdf",
+        Some("json") => "application/json",
+        Some("txt") => "text/plain",
+        Some("html" | "htm") => "text/html",
+        Some("css") => "text/css",
+        Some("js") => "application/javascript",
+        Some("csv") => "text/csv",
+        Some("xml") => "application/xml",
+        Some("zip") => "application/zip",
+        _ => "application/octet-stream",
     }
 }
 
@@ -605,4 +676,39 @@ fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
     candidates
         .pop()
         .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mime_from_ext_png() {
+        assert_eq!(
+            mime_from_ext(std::path::Path::new("photo.png")),
+            "image/png"
+        );
+    }
+
+    #[test]
+    fn test_mime_from_ext_jpeg_variants() {
+        assert_eq!(mime_from_ext(std::path::Path::new("a.jpg")), "image/jpeg");
+        assert_eq!(mime_from_ext(std::path::Path::new("b.jpeg")), "image/jpeg");
+    }
+
+    #[test]
+    fn test_mime_from_ext_unknown_defaults_to_octet_stream() {
+        assert_eq!(
+            mime_from_ext(std::path::Path::new("data.bin")),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn test_mime_from_ext_no_extension() {
+        assert_eq!(
+            mime_from_ext(std::path::Path::new("Makefile")),
+            "application/octet-stream"
+        );
+    }
 }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -531,13 +531,14 @@
       throw new Error("drag requires target or offset");
     }
 
-    var dt = new DataTransfer();
+    var dt = typeof DataTransfer === "function" ? new DataTransfer() : new ClipboardEvent("").clipboardData;
     source.dispatchEvent(new MouseEvent("mousedown", { clientX: startX, clientY: startY, bubbles: true }));
     source.dispatchEvent(new DragEvent("dragstart", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
+    source.dispatchEvent(new DragEvent("dragleave", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     dropTarget.dispatchEvent(new DragEvent("dragenter", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     dropTarget.dispatchEvent(new DragEvent("dragover", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     dropTarget.dispatchEvent(new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
-    source.dispatchEvent(new DragEvent("dragend", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
+    source.dispatchEvent(new DragEvent("dragend", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     return { ok: true };
   }
 
@@ -546,7 +547,7 @@
     var rect = el.getBoundingClientRect();
     var x = rect.left + rect.width / 2;
     var y = rect.top + rect.height / 2;
-    var dt = new DataTransfer();
+    var dt = typeof DataTransfer === "function" ? new DataTransfer() : new ClipboardEvent("").clipboardData;
 
     if (params.files) {
       for (var i = 0; i < params.files.length; i++) {
@@ -562,6 +563,7 @@
     el.dispatchEvent(new DragEvent("dragenter", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
     el.dispatchEvent(new DragEvent("dragover", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
     el.dispatchEvent(new DragEvent("drop", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
+    el.dispatchEvent(new DragEvent("dragend", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
     return { ok: true };
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -526,7 +526,8 @@
     } else if (params.offset) {
       endX = startX + (params.offset.x || 0);
       endY = startY + (params.offset.y || 0);
-      dropTarget = document.elementFromPoint(endX, endY) || source;
+      dropTarget = document.elementFromPoint(endX, endY);
+      if (!dropTarget) throw new Error("No element at offset (" + params.offset.x + "," + params.offset.y + ")");
     } else {
       throw new Error("drag requires target or offset");
     }
@@ -535,9 +536,9 @@
     source.dispatchEvent(new MouseEvent("mousedown", { clientX: startX, clientY: startY, bubbles: true }));
     source.dispatchEvent(new DragEvent("dragstart", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
     source.dispatchEvent(new DragEvent("dragleave", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
-    dropTarget.dispatchEvent(new DragEvent("dragenter", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
-    dropTarget.dispatchEvent(new DragEvent("dragover", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
-    dropTarget.dispatchEvent(new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
+    dropTarget.dispatchEvent(new DragEvent("dragenter", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
+    dropTarget.dispatchEvent(new DragEvent("dragover", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
+    dropTarget.dispatchEvent(new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
     source.dispatchEvent(new DragEvent("dragend", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     return { ok: true };
   }
@@ -560,10 +561,9 @@
       }
     }
 
-    el.dispatchEvent(new DragEvent("dragenter", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
-    el.dispatchEvent(new DragEvent("dragover", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
-    el.dispatchEvent(new DragEvent("drop", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
-    el.dispatchEvent(new DragEvent("dragend", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
+    el.dispatchEvent(new DragEvent("dragenter", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true, cancelable: true }));
+    el.dispatchEvent(new DragEvent("dragover", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true, cancelable: true }));
+    el.dispatchEvent(new DragEvent("drop", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true, cancelable: true }));
     return { ok: true };
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -510,6 +510,61 @@
     return { ok: true };
   }
 
+  function drag(params) {
+    var source = resolveTarget(params.source || params);
+    var sourceRect = source.getBoundingClientRect();
+    var startX = sourceRect.left + sourceRect.width / 2;
+    var startY = sourceRect.top + sourceRect.height / 2;
+
+    var endX, endY, dropTarget;
+
+    if (params.target) {
+      dropTarget = resolveTarget(params.target);
+      var targetRect = dropTarget.getBoundingClientRect();
+      endX = targetRect.left + targetRect.width / 2;
+      endY = targetRect.top + targetRect.height / 2;
+    } else if (params.offset) {
+      endX = startX + (params.offset.x || 0);
+      endY = startY + (params.offset.y || 0);
+      dropTarget = document.elementFromPoint(endX, endY) || source;
+    } else {
+      throw new Error("drag requires target or offset");
+    }
+
+    var dt = new DataTransfer();
+    source.dispatchEvent(new MouseEvent("mousedown", { clientX: startX, clientY: startY, bubbles: true }));
+    source.dispatchEvent(new DragEvent("dragstart", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
+    dropTarget.dispatchEvent(new DragEvent("dragenter", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
+    dropTarget.dispatchEvent(new DragEvent("dragover", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
+    dropTarget.dispatchEvent(new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
+    source.dispatchEvent(new DragEvent("dragend", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
+    return { ok: true };
+  }
+
+  function drop(params) {
+    var el = resolveTarget(params);
+    var rect = el.getBoundingClientRect();
+    var x = rect.left + rect.width / 2;
+    var y = rect.top + rect.height / 2;
+    var dt = new DataTransfer();
+
+    if (params.files) {
+      for (var i = 0; i < params.files.length; i++) {
+        var f = params.files[i];
+        var binary = atob(f.data);
+        var bytes = new Uint8Array(binary.length);
+        for (var j = 0; j < binary.length; j++) bytes[j] = binary.charCodeAt(j);
+        var file = new File([bytes], f.name, { type: f.type || "application/octet-stream" });
+        dt.items.add(file);
+      }
+    }
+
+    el.dispatchEvent(new DragEvent("dragenter", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
+    el.dispatchEvent(new DragEvent("dragover", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
+    el.dispatchEvent(new DragEvent("drop", { clientX: x, clientY: y, dataTransfer: dt, bubbles: true }));
+    return { ok: true };
+  }
+
   function text(params) {
     return resolveTarget(params).textContent || "";
   }
@@ -789,5 +844,7 @@
     count: count,
     checked: checked,
     watch: watch,
+    drag: drag,
+    drop: drop,
   };
 })();

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -27,9 +27,9 @@ pub(crate) async fn dispatch(
             Ok(result)
         }
         "diff" => handle_diff(params, engine, eval_fn).await,
-        "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" | "text" | "html"
-        | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state" | "wait"
-        | "visible" | "count" | "checked" => {
+        "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" | "drag" | "drop"
+        | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
+        | "state" | "wait" | "visible" | "count" | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, DEFAULT_TIMEOUT).await
         }
         "watch" => {
@@ -457,5 +457,35 @@ mod tests {
         let script = build_bridge_call("watch", Some(&params)).unwrap();
         assert!(script.starts_with("window.__PILOT__.watch("));
         assert!(script.contains("\"timeout\":5000"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_drag_routes_to_eval() {
+        let engine = EvalEngine::new();
+        let result = dispatch("drag", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_ne!(err.code, -32601);
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_drop_routes_to_eval() {
+        let engine = EvalEngine::new();
+        let result = dispatch("drop", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_ne!(err.code, -32601);
+    }
+
+    #[test]
+    fn test_build_bridge_call_drag() {
+        let params = json!({"source": {"ref": "e5"}, "target": {"ref": "e6"}});
+        let script = build_bridge_call("drag", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.drag("));
+    }
+
+    #[test]
+    fn test_build_bridge_call_drop() {
+        let params = json!({"ref": "e3", "files": []});
+        let script = build_bridge_call("drop", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.drop("));
     }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -369,6 +369,138 @@ tauri-pilot scroll up --ref @e4
 
 ---
 
+### `drag`
+
+Drag an element to another element or by a pixel offset. Dispatches the full HTML5 drag event sequence: `mousedown` → `dragstart` → `dragleave` → `dragenter` → `dragover` → `drop` → `dragend`.
+
+```bash
+tauri-pilot drag <source> [target] [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<source>` | Element to drag (ref, selector, or coordinates) |
+| `[target]` | Element to drop onto (mutually exclusive with `--offset`) |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--offset <X,Y>` | Drag by pixel offset instead of to an element (mutually exclusive with `[target]`) |
+
+**Examples:**
+
+```bash
+# Drag a card to a column (kanban board)
+tauri-pilot drag "#card-1" "#col-done"
+
+# Drag by ref (after snapshot)
+tauri-pilot drag @e5 @e8
+
+# Drag a slider thumb by pixel offset
+tauri-pilot drag "#slider-thumb" --offset "150,0"
+
+# Drag to coordinates
+tauri-pilot drag @e5 "400,200"
+```
+
+**JSON-RPC example:**
+
+```json
+// Element-to-element drag
+{"jsonrpc":"2.0","id":1,"method":"drag","params":{"source":{"ref":"e5"},"target":{"ref":"e8"}}}
+
+// Offset drag
+{"jsonrpc":"2.0","id":1,"method":"drag","params":{"source":{"selector":"#thumb"},"offset":{"x":150,"y":0}}}
+```
+
+---
+
+### `drop`
+
+Simulate a file drop on an element. Reads files from disk, base64-encodes them, and creates `DataTransfer` + `File` objects in the WebView. Useful for testing file upload zones, import features, and drag-from-OS scenarios.
+
+```bash
+tauri-pilot drop <target> --file <path> [--file <path>...]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<target>` | Element to drop files onto (ref, selector, or coordinates) |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--file <path>` | File to drop (required, can be repeated for multiple files) |
+
+**Limits:** 50 MB per file, 100 MB total payload.
+
+**Examples:**
+
+```bash
+# Drop a single file
+tauri-pilot drop "#file-zone" --file ./photo.png
+
+# Drop multiple files
+tauri-pilot drop @e3 --file ./doc.pdf --file ./data.csv
+```
+
+**JSON-RPC example:**
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"drop","params":{
+  "selector":"#file-zone",
+  "files":[{"name":"photo.png","type":"image/png","data":"iVBORw0KGgo..."}]
+}}
+```
+
+---
+
+### `watch`
+
+Watch for DOM mutations using `MutationObserver`. Blocks until changes are detected (or timeout), then returns a summary of what changed. Useful for waiting on async UI updates without polling snapshots.
+
+```bash
+tauri-pilot watch [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--selector <sel>` | Scope observation to a subtree matching this CSS selector |
+| `--timeout <ms>` | Maximum wait time in milliseconds (default: 10000) |
+| `--stable <ms>` | Wait until DOM is stable (no new mutations) for N ms (default: 300) |
+
+**Examples:**
+
+```bash
+# Wait for any DOM change
+tauri-pilot watch
+
+# Watch a specific subtree
+tauri-pilot watch --selector "#results-list"
+
+# Short timeout
+tauri-pilot watch --timeout 3000
+
+# Wait for DOM to settle after animations
+tauri-pilot watch --stable 500
+```
+
+**JSON-RPC example:**
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"watch","params":{"selector":"#results","timeout":5000,"stable":300}}
+```
+
+---
+
 ### `text`
 
 Get the text content of an element.


### PR DESCRIPTION
## Summary

- Add `drag` command for element-to-element and offset-based drag interactions
- Add `drop` command for simulating file drops on drop zones
- Full HTML5 drag event sequence: `mousedown` → `dragstart` → `dragenter` → `dragover` → `drop` → `dragend`
- File drop reads files from disk, base64 encodes, and creates `DataTransfer` + `File` objects in the webview

## Changes

- **bridge.js**: New `drag()` and `drop()` functions with DataTransfer and DragEvent dispatch
- **handler.rs**: Register `"drag"` and `"drop"` methods in dispatch match + 4 unit tests
- **cli.rs**: `Drag` and `Drop` command variants with clap derive + 4 parsing tests
- **main.rs**: Command routing, file reading with 50 MB size limit, `mime_from_ext()` helper + 4 mime tests
- **CHANGELOG.md**: Document new feature under [Unreleased]

## Test plan

- [x] 120/120 workspace tests passing
- [x] Clippy clean (`-D warnings`)
- [x] Security review: file size limit added, no CRITICAL issues
- [x] Logic review: `dragend` coords fixed to source position, offset parsing trims whitespace

Closes #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add drag & drop support with CLI commands to simulate HTML5 drag interactions and file drops in Tauri apps. Aligns event dispatch with the spec, adds safer file handling, and documents the commands in the README and CLI reference. Implements #11.

- **New Features**
  - `tauri-pilot drag <source> <target>` or `--offset X,Y` (mutually exclusive). Dispatches `mousedown → dragstart → dragleave → dragenter → dragover → drop → dragend`; throws if offset hits no element; includes a WebKit `DataTransfer` fallback.
  - `tauri-pilot drop <target> --file <path>`; requires at least one `--file`; builds `DataTransfer`/`File` objects; `dragover`/`drop` are cancelable; no `dragend` for external drops; limits: 50 MB per file and 100 MB total; case-insensitive MIME detection; size checked before read.

<sup>Written for commit 2ca33d1e687ecb67991a68b27854cea855f3cf1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulate drag-and-drop: drag a source to a target or by pixel offset (dispatches full HTML5 drag sequence).
  * Simulate file drops: attach one or multiple files with per-file and total size validation and MIME-type detection.
  * New CLI commands to invoke drag, drop, and a DOM-watch action.

* **Documentation**
  * Changelog, CLI reference, and README updated with examples and usage notes for drag, drop, and watch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->