### PR TITLE
feat: localStorage/sessionStorage access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[#12]: https://github.com/mpiton/tauri-pilot/issues/12
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Storage access** — read and write browser localStorage/sessionStorage from the CLI ([#12])
+  - `tauri-pilot storage get "key"` — read a single key
+  - `tauri-pilot storage set "key" "value"` — write a key-value pair
+  - `tauri-pilot storage list` — dump all key-value pairs
+  - `tauri-pilot storage clear` — clear all storage
+  - `--session` flag to use sessionStorage instead of localStorage
 - **Drag & drop support** — simulate drag interactions and file drops for kanban boards, sortable lists, and drop zones ([#11])
   - `tauri-pilot drag @e5 @e6` — drag element to another element
   - `tauri-pilot drag @e5 --offset 0,100` — drag by pixel offset

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ tauri-pilot wait --selector ".success-message"
 | `state` | Get URL, title, viewport, scroll |
 | `assert` | One-step verification (text, visible, hidden, value, count, checked, contains, url) |
 | `watch` | Watch for DOM mutations |
+| `storage` | Read/write localStorage and sessionStorage (`--session`) |
 | `logs` | Capture and display console output |
 | `network` | Capture and display network requests |
 

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -176,6 +176,8 @@ pub(crate) enum Command {
     /// Assert element state
     #[command(subcommand)]
     Assert(AssertKind),
+    /// Read and write browser storage (localStorage/sessionStorage).
+    Storage(StorageArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -196,6 +198,27 @@ pub(crate) enum AssertKind {
     Contains { target: String, expected: String },
     /// Assert current URL contains string
     Url { expected: String },
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct StorageArgs {
+    /// Use sessionStorage instead of localStorage.
+    #[arg(long)]
+    pub session: bool,
+    #[command(subcommand)]
+    pub action: StorageAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum StorageAction {
+    /// Get a value by key.
+    Get { key: String },
+    /// Set a key-value pair.
+    Set { key: String, value: String },
+    /// List all key-value pairs.
+    List,
+    /// Clear all storage.
+    Clear,
 }
 
 /// Parsed target for element-targeting commands.
@@ -492,6 +515,85 @@ mod tests {
     fn test_parse_drop_requires_file() {
         let result = Cli::try_parse_from(["tauri-pilot", "--socket", "/tmp/t.sock", "drop", "@e3"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_storage_get() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "storage",
+            "get",
+            "auth_token",
+        ]);
+        if let Command::Storage(StorageArgs {
+            session,
+            action: StorageAction::Get { key },
+        }) = cli.command
+        {
+            assert!(!session);
+            assert_eq!(key, "auth_token");
+        } else {
+            panic!("Expected Storage Get command");
+        }
+    }
+
+    #[test]
+    fn test_parse_storage_set() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "storage",
+            "set",
+            "theme",
+            "dark",
+        ]);
+        if let Command::Storage(StorageArgs {
+            session,
+            action: StorageAction::Set { key, value },
+        }) = cli.command
+        {
+            assert!(!session);
+            assert_eq!(key, "theme");
+            assert_eq!(value, "dark");
+        } else {
+            panic!("Expected Storage Set command");
+        }
+    }
+
+    #[test]
+    fn test_parse_storage_list_session() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/t.sock",
+            "storage",
+            "--session",
+            "list",
+        ]);
+        if let Command::Storage(StorageArgs {
+            session,
+            action: StorageAction::List,
+        }) = cli.command
+        {
+            assert!(session);
+        } else {
+            panic!("Expected Storage List command with session flag");
+        }
+    }
+
+    #[test]
+    fn test_parse_storage_clear() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/t.sock", "storage", "clear"]);
+        assert!(matches!(
+            cli.command,
+            Command::Storage(StorageArgs {
+                action: StorageAction::Clear,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<()> {
     } else if is_storage {
         if result.get("cleared").is_some() {
             output::format_text(&result);
-        } else if result.as_array().is_some() {
+        } else if result.get("entries").is_some() {
             output::format_storage(&result);
         } else if result.get("found").is_some() {
             output::format_storage_value(&result);

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -12,7 +12,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use cli::{AssertKind, Cli, Command, Target, parse_target};
+use cli::{AssertKind, Cli, Command, StorageAction, StorageArgs, Target, parse_target};
 use client::Client;
 
 #[tokio::main]
@@ -33,6 +33,7 @@ async fn main() -> Result<()> {
     let is_logs = matches!(args.command, Command::Logs { .. });
     let is_network = matches!(args.command, Command::Network { .. });
     let is_watch = matches!(args.command, Command::Watch { .. });
+    let is_storage = matches!(args.command, Command::Storage(..));
 
     // Handle --follow mode: loop forever polling for new entries
     if let Command::Logs {
@@ -106,6 +107,16 @@ async fn main() -> Result<()> {
         }
     } else if is_watch {
         output::format_watch(&result);
+    } else if is_storage {
+        if result.get("cleared").is_some() {
+            output::format_text(&result);
+        } else if result.as_array().is_some() {
+            output::format_storage(&result);
+        } else if result.get("found").is_some() {
+            output::format_storage_value(&result);
+        } else {
+            output::format_text(&result);
+        }
     } else {
         output::format_text(&result);
     }
@@ -301,6 +312,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             follow,
         } => run_network_command(client, filter, failed, last, clear, follow).await,
         Command::Assert(kind) => run_assert_command(client, kind).await,
+        Command::Storage(storage_args) => run_storage_command(client, storage_args).await,
         Command::Drop { target, file } => run_drop_command(client, &target, file).await,
         cmd => run_dom_command(client, cmd).await,
     }
@@ -567,6 +579,35 @@ async fn run_network_command(
             Some(serde_json::Value::Object(params)),
         )
         .await
+}
+
+async fn run_storage_command(client: &mut Client, args: StorageArgs) -> Result<serde_json::Value> {
+    let session = args.session;
+    match args.action {
+        StorageAction::Get { key } => {
+            client
+                .call("storage.get", Some(json!({"key": key, "session": session})))
+                .await
+        }
+        StorageAction::Set { key, value } => {
+            client
+                .call(
+                    "storage.set",
+                    Some(json!({"key": key, "value": value, "session": session})),
+                )
+                .await
+        }
+        StorageAction::List => {
+            client
+                .call("storage.list", Some(json!({"session": session})))
+                .await
+        }
+        StorageAction::Clear => {
+            client
+                .call("storage.clear", Some(json!({"session": session})))
+                .await
+        }
+    }
 }
 
 const MAX_DROP_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB per file

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -224,6 +224,50 @@ pub(crate) fn format_network(value: &serde_json::Value) -> String {
     output
 }
 
+/// Format a single storage value (from `storage get`).
+pub(crate) fn format_storage_value(value: &serde_json::Value) {
+    let found = value
+        .get("found")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !found {
+        println!("{}", crate::style::dim("(not found)"));
+        return;
+    }
+    if let Some(val) = value.get("value").and_then(serde_json::Value::as_str) {
+        println!("{}", strip_ansi(val));
+    } else {
+        println!("{}", crate::style::dim("(not found)"));
+    }
+}
+
+/// Format storage entries as key = value pairs.
+pub(crate) fn format_storage(value: &serde_json::Value) {
+    let Some(entries) = value.as_array() else {
+        println!("{}", crate::style::dim("(empty storage)"));
+        return;
+    };
+    if entries.is_empty() {
+        println!("{}", crate::style::dim("(empty storage)"));
+        return;
+    }
+    for entry in entries {
+        let key = entry.get("key").and_then(|k| k.as_str()).unwrap_or("?");
+        let val = entry
+            .get("value")
+            .and_then(|v| v.as_str())
+            .unwrap_or("null");
+        let key_safe = strip_ansi(key);
+        let val_safe = strip_ansi(val);
+        println!(
+            "{} {} {}",
+            crate::style::bold(&key_safe),
+            crate::style::dim("="),
+            val_safe
+        );
+    }
+}
+
 /// Format watch result showing DOM mutations grouped by type.
 pub(crate) fn format_watch(value: &serde_json::Value) {
     let added = value.get("added").and_then(|v| v.as_array());
@@ -726,6 +770,45 @@ mod tests {
             "truncated": true
         });
         format_watch(&result);
+    }
+
+    #[test]
+    fn test_format_storage_empty_array() {
+        // Should not panic and display "(empty storage)"
+        format_storage(&json!([]));
+    }
+
+    #[test]
+    fn test_format_storage_with_entries() {
+        // Should not panic and display key = value pairs
+        format_storage(&json!([
+            {"key": "auth_token", "value": "abc123"},
+            {"key": "theme", "value": "dark"},
+        ]));
+    }
+
+    #[test]
+    fn test_format_storage_non_array() {
+        // Non-array input should not panic
+        format_storage(&json!(null));
+    }
+
+    #[test]
+    fn test_format_storage_value_found() {
+        format_storage_value(&json!({"found": true, "value": "abc123"}));
+    }
+
+    #[test]
+    fn test_format_storage_value_not_found() {
+        format_storage_value(&json!({"found": false}));
+    }
+
+    #[test]
+    fn test_format_storage_strips_ansi() {
+        // Key and value with ANSI escape sequences should be stripped
+        format_storage(&json!([
+            {"key": "\x1b[31mmalicious\x1b[0m", "value": "\x1b[2J\x1b[Hinjected"},
+        ]));
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -242,8 +242,10 @@ pub(crate) fn format_storage_value(value: &serde_json::Value) {
 }
 
 /// Format storage entries as key = value pairs.
+///
+/// Expects `{entries: [{key, value}, ...], truncated: bool}` from `storageList`.
 pub(crate) fn format_storage(value: &serde_json::Value) {
-    let Some(entries) = value.as_array() else {
+    let Some(entries) = value.get("entries").and_then(|e| e.as_array()) else {
         println!("{}", crate::style::dim("(empty storage)"));
         return;
     };
@@ -264,6 +266,12 @@ pub(crate) fn format_storage(value: &serde_json::Value) {
             crate::style::bold(&key_safe),
             crate::style::dim("="),
             val_safe
+        );
+    }
+    if value.get("truncated").and_then(serde_json::Value::as_bool) == Some(true) {
+        println!(
+            "{}",
+            crate::style::warn("(output truncated — more entries exist)")
         );
     }
 }
@@ -775,21 +783,21 @@ mod tests {
     #[test]
     fn test_format_storage_empty_array() {
         // Should not panic and display "(empty storage)"
-        format_storage(&json!([]));
+        format_storage(&json!({"entries": [], "truncated": false}));
     }
 
     #[test]
     fn test_format_storage_with_entries() {
         // Should not panic and display key = value pairs
-        format_storage(&json!([
+        format_storage(&json!({"entries": [
             {"key": "auth_token", "value": "abc123"},
             {"key": "theme", "value": "dark"},
-        ]));
+        ], "truncated": false}));
     }
 
     #[test]
-    fn test_format_storage_non_array() {
-        // Non-array input should not panic
+    fn test_format_storage_non_object() {
+        // Non-object input should not panic
         format_storage(&json!(null));
     }
 
@@ -806,9 +814,17 @@ mod tests {
     #[test]
     fn test_format_storage_strips_ansi() {
         // Key and value with ANSI escape sequences should be stripped
-        format_storage(&json!([
+        format_storage(&json!({"entries": [
             {"key": "\x1b[31mmalicious\x1b[0m", "value": "\x1b[2J\x1b[Hinjected"},
-        ]));
+        ], "truncated": false}));
+    }
+
+    #[test]
+    fn test_format_storage_truncated() {
+        // Should not panic and display truncation warning
+        format_storage(&json!({"entries": [
+            {"key": "a", "value": "1"},
+        ], "truncated": true}));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -818,6 +818,9 @@
   }
 
   function storageGet(params) {
+    if (typeof params.key !== "string") {
+      throw new Error("storageGet requires a string key");
+    }
     var storage = params.session ? sessionStorage : localStorage;
     var val = storage.getItem(params.key);
     if (val === null) {
@@ -835,10 +838,13 @@
     return { ok: true };
   }
 
+  var MAX_STORAGE_ENTRIES = 500;
+
   function storageList(params) {
     var storage = params.session ? sessionStorage : localStorage;
+    var len = Math.min(storage.length, MAX_STORAGE_ENTRIES);
     var entries = [];
-    for (var i = 0; i < storage.length; i++) {
+    for (var i = 0; i < len; i++) {
       var key = storage.key(i);
       entries.push({ key: key, value: storage.getItem(key) });
     }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -842,7 +842,8 @@
 
   function storageList(params) {
     var storage = params.session ? sessionStorage : localStorage;
-    var len = Math.min(storage.length, MAX_STORAGE_ENTRIES);
+    var total = storage.length;
+    var len = Math.min(total, MAX_STORAGE_ENTRIES);
     var entries = [];
     for (var i = 0; i < len; i++) {
       var key = storage.key(i);
@@ -851,7 +852,7 @@
     entries.sort(function (a, b) {
       return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
     });
-    return entries;
+    return { entries: entries, truncated: total > MAX_STORAGE_ENTRIES };
   }
 
   function storageClear(params) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -817,6 +817,43 @@
     return dataUrl;
   }
 
+  function storageGet(params) {
+    var storage = params.session ? sessionStorage : localStorage;
+    var val = storage.getItem(params.key);
+    if (val === null) {
+      return { found: false };
+    }
+    return { found: true, value: val };
+  }
+
+  function storageSet(params) {
+    if (typeof params.key !== "string" || typeof params.value !== "string") {
+      throw new Error("storageSet requires string key and value");
+    }
+    var storage = params.session ? sessionStorage : localStorage;
+    storage.setItem(params.key, params.value);
+    return { ok: true };
+  }
+
+  function storageList(params) {
+    var storage = params.session ? sessionStorage : localStorage;
+    var entries = [];
+    for (var i = 0; i < storage.length; i++) {
+      var key = storage.key(i);
+      entries.push({ key: key, value: storage.getItem(key) });
+    }
+    entries.sort(function (a, b) {
+      return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+    });
+    return entries;
+  }
+
+  function storageClear(params) {
+    var storage = params.session ? sessionStorage : localStorage;
+    storage.clear();
+    return { cleared: true };
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
@@ -848,5 +885,9 @@
     watch: watch,
     drag: drag,
     drop: drop,
+    storageGet: storageGet,
+    storageSet: storageSet,
+    storageList: storageList,
+    storageClear: storageClear,
   };
 })();

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -55,6 +55,18 @@ pub(crate) async fn dispatch(
         "network.clear" => {
             handle_eval_method("clearNetwork", params, engine, eval_fn, DEFAULT_TIMEOUT).await
         }
+        "storage.get" => {
+            handle_eval_method("storageGet", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
+        "storage.set" => {
+            handle_eval_method("storageSet", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
+        "storage.list" => {
+            handle_eval_method("storageList", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
+        "storage.clear" => {
+            handle_eval_method("storageClear", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
@@ -487,5 +499,77 @@ mod tests {
         let params = json!({"ref": "e3", "files": []});
         let script = build_bridge_call("drop", Some(&params)).unwrap();
         assert!(script.starts_with("window.__PILOT__.drop("));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_storage_get_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("storage.get", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_storage_set_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("storage.set", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_storage_list_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("storage.list", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_storage_clear_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("storage.clear", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_storage_get() {
+        let params = json!({"key": "auth_token", "session": false});
+        let script = build_bridge_call("storageGet", Some(&params)).unwrap();
+        assert_eq!(
+            script,
+            r#"window.__PILOT__.storageGet({"key":"auth_token","session":false})"#
+        );
+    }
+
+    #[test]
+    fn test_build_bridge_call_storage_set() {
+        let params = json!({"key": "theme", "value": "dark", "session": false});
+        let script = build_bridge_call("storageSet", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.storageSet("));
+        assert!(script.contains("\"key\":\"theme\""));
+        assert!(script.contains("\"value\":\"dark\""));
+        assert!(script.contains("\"session\":false"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_storage_list() {
+        let params = json!({"session": true});
+        let script = build_bridge_call("storageList", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.storageList("));
+        assert!(script.contains("\"session\":true"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_storage_clear() {
+        let params = json!({"session": false});
+        let script = build_bridge_call("storageClear", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.storageClear("));
+        assert!(script.contains("\"session\":false"));
     }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -894,7 +894,7 @@ tauri-pilot storage <subcommand> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--session` | Use `sessionStorage` instead of `localStorage` (default) |
+| `--session` | Use `sessionStorage` instead of `localStorage` |
 
 **Examples:**
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -873,6 +873,77 @@ $ tauri-pilot network --clear
 
 ---
 
+### `storage`
+
+Read and write browser storage (`localStorage` or `sessionStorage`) from the CLI. Useful for AI agents inspecting persisted state, auth tokens, or modifying app configuration during testing.
+
+```bash
+tauri-pilot storage <subcommand> [OPTIONS]
+```
+
+**Subcommands:**
+
+| Subcommand | Arguments | Description |
+|------------|-----------|-------------|
+| `get` | `<key>` | Read a single key |
+| `set` | `<key> <value>` | Write a key-value pair |
+| `list` | | Dump all key-value pairs |
+| `clear` | | Clear all storage |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--session` | Use `sessionStorage` instead of `localStorage` (default) |
+
+**Examples:**
+
+```bash
+# Read a key from localStorage
+$ tauri-pilot storage get "auth_token"
+eyJhbGciOiJIUzI1NiJ9...
+
+# Write a key
+$ tauri-pilot storage set "theme" "dark"
+✓ ok
+
+# List all localStorage entries
+$ tauri-pilot storage list
+auth_token = eyJhbGciOiJIUzI1NiJ9...
+theme      = dark
+locale     = en
+
+# Clear localStorage
+$ tauri-pilot storage clear
+✓ cleared
+
+# Use sessionStorage instead
+$ tauri-pilot storage --session list
+$ tauri-pilot storage --session get "csrf_token"
+
+# JSON output
+$ tauri-pilot storage list --json
+[{"key":"auth_token","value":"eyJ..."},{"key":"theme","value":"dark"}]
+```
+
+**JSON-RPC examples:**
+
+```json
+// Get a key
+{"jsonrpc":"2.0","id":1,"method":"storage.get","params":{"key":"auth_token","session":false}}
+
+// Set a key
+{"jsonrpc":"2.0","id":2,"method":"storage.set","params":{"key":"theme","value":"dark","session":false}}
+
+// List all
+{"jsonrpc":"2.0","id":3,"method":"storage.list","params":{"session":false}}
+
+// Clear
+{"jsonrpc":"2.0","id":4,"method":"storage.clear","params":{"session":false}}
+```
+
+---
+
 ## JSON-RPC Protocol
 
 The CLI communicates with the plugin over a Unix socket using a hand-rolled JSON-RPC 2.0 protocol with newline-delimited framing (`\n`).


### PR DESCRIPTION
## Summary

Implements #12 — read and write browser `localStorage`/`sessionStorage` from the CLI.

- **4 new bridge functions** (`storageGet`, `storageSet`, `storageList`, `storageClear`) in the JS bridge
- **4 handler dispatch routes** (`storage.get`, `storage.set`, `storage.list`, `storage.clear`) in the plugin
- **`Storage` CLI subcommand** with `get`, `set`, `list`, `clear` sub-commands and `--session` flag
- **Output formatting** with `format_storage` (key=value list) and `format_storage_value` (single value with not-found handling)
- **Security hardening**: ANSI escape sequence sanitization on all storage output, input validation on `storageSet`
- **141 tests pass**, clippy clean

### CLI Usage

```bash
tauri-pilot storage get "auth_token"           # read a key
tauri-pilot storage set "theme" "dark"          # write a key
tauri-pilot storage list                        # dump all keys
tauri-pilot storage clear                       # clear all
tauri-pilot storage --session list              # use sessionStorage
tauri-pilot storage list --json                 # structured output
```

## Test plan

- [x] `cargo test --workspace` — 141 tests pass (77 CLI + 64 plugin)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual test with a live Tauri app: `storage set`, `storage get`, `storage list`, `storage clear`
- [ ] Verify `--session` flag switches to sessionStorage
- [ ] Verify `--json` output is valid JSON
- [ ] Verify missing key prints `(not found)` instead of empty output

Closes #12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CLI access to browser storage so you can read and write `localStorage` and `sessionStorage` from the terminal. Implements #12.

- **New Features**
  - `storage` CLI with `get`, `set`, `list`, `clear` and `--session` to target `sessionStorage`.
  - Plugin routes: `storage.get`, `storage.set`, `storage.list`, `storage.clear` with JS bridge functions `storageGet`, `storageSet`, `storageList`, `storageClear`.
  - Output: key=value listing, clear feedback, not-found handling, `--json` support, and `list` returns `{entries, truncated}` with a truncation warning when over 500 entries.
  - Safety and limits: strip ANSI in keys/values; validate string input on `set` and `get`; list is alphabetically sorted and capped at 500 entries.

<sup>Written for commit 81ddfdd570f4c5c4ade46171c494b26138819ac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `storage` CLI command: `get <key>`, `set <key> <value>`, `list`, `clear`.
  * `--session` flag targets `sessionStorage` (defaults to `localStorage`).
  * Human-readable outputs: value/not-found hints, cleared/ok confirmations, and a truncated warning when listings exceed limit.

* **Documentation**
  * Updated README and CLI reference with usage examples, `--session` details, and JSON-RPC examples for storage commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->