### PR TITLE
feat: form dump — get all form fields at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[#13]: https://github.com/mpiton/tauri-pilot/issues/13
 [#12]: https://github.com/mpiton/tauri-pilot/issues/12
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Form dump** — get all form fields at once instead of calling `value` on each input individually ([#13])
+  - `tauri-pilot forms` — dump all forms on the page
+  - `tauri-pilot forms --selector "#login-form"` — target a specific form
+  - Shows field name, type, value, and checked state
 - **Storage access** — read and write browser localStorage/sessionStorage from the CLI ([#12])
   - `tauri-pilot storage get "key"` — read a single key
   - `tauri-pilot storage set "key" "value"` — write a key-value pair

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -178,6 +178,8 @@ pub(crate) enum Command {
     Assert(AssertKind),
     /// Read and write browser storage (localStorage/sessionStorage).
     Storage(StorageArgs),
+    /// Dump all form fields on the page.
+    Forms(FormsArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -207,6 +209,13 @@ pub(crate) struct StorageArgs {
     pub session: bool,
     #[command(subcommand)]
     pub action: StorageAction,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct FormsArgs {
+    /// Target a specific form by CSS selector.
+    #[arg(long)]
+    pub selector: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -594,6 +603,33 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn test_parse_forms_command() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "forms"]);
+        if let Command::Forms(FormsArgs { selector }) = cli.command {
+            assert_eq!(selector, None);
+        } else {
+            panic!("Expected Forms command");
+        }
+    }
+
+    #[test]
+    fn test_parse_forms_with_selector() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "forms",
+            "--selector",
+            "#login",
+        ]);
+        if let Command::Forms(FormsArgs { selector }) = cli.command {
+            assert_eq!(selector, Some("#login".to_owned()));
+        } else {
+            panic!("Expected Forms command with selector");
+        }
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -12,7 +12,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use cli::{AssertKind, Cli, Command, StorageAction, StorageArgs, Target, parse_target};
+use cli::{AssertKind, Cli, Command, FormsArgs, StorageAction, StorageArgs, Target, parse_target};
 use client::Client;
 
 #[tokio::main]
@@ -34,6 +34,7 @@ async fn main() -> Result<()> {
     let is_network = matches!(args.command, Command::Network { .. });
     let is_watch = matches!(args.command, Command::Watch { .. });
     let is_storage = matches!(args.command, Command::Storage(..));
+    let is_forms = matches!(args.command, Command::Forms(..));
 
     // Handle --follow mode: loop forever polling for new entries
     if let Command::Logs {
@@ -117,6 +118,8 @@ async fn main() -> Result<()> {
         } else {
             output::format_text(&result);
         }
+    } else if is_forms {
+        output::format_forms(&result);
     } else {
         output::format_text(&result);
     }
@@ -313,6 +316,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
         } => run_network_command(client, filter, failed, last, clear, follow).await,
         Command::Assert(kind) => run_assert_command(client, kind).await,
         Command::Storage(storage_args) => run_storage_command(client, storage_args).await,
+        Command::Forms(args) => run_forms_command(client, args).await,
         Command::Drop { target, file } => run_drop_command(client, &target, file).await,
         cmd => run_dom_command(client, cmd).await,
     }
@@ -579,6 +583,11 @@ async fn run_network_command(
             Some(serde_json::Value::Object(params)),
         )
         .await
+}
+
+async fn run_forms_command(client: &mut Client, args: FormsArgs) -> Result<serde_json::Value> {
+    let params = args.selector.map(|s| json!({"selector": s}));
+    client.call("forms.dump", params).await
 }
 
 async fn run_storage_command(client: &mut Client, args: StorageArgs) -> Result<serde_json::Value> {

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -276,6 +276,109 @@ pub(crate) fn format_storage(value: &serde_json::Value) {
     }
 }
 
+/// Format form fields dumped from the page.
+///
+/// Expects `{forms: [{id, name, action, method, fields: [{tag, type, name, value, checked}]}]}`
+pub(crate) fn format_forms(value: &serde_json::Value) {
+    let Some(forms) = value.get("forms").and_then(|f| f.as_array()) else {
+        println!("{}", crate::style::dim("(no forms found)"));
+        return;
+    };
+    if forms.is_empty() {
+        println!("{}", crate::style::dim("(no forms found)"));
+        return;
+    }
+    for form in forms {
+        let id = form
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let name = form
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let mut header = String::from("form");
+        if !id.is_empty() {
+            let _ = write!(header, "#{}", strip_ansi(id));
+        } else if !name.is_empty() {
+            let _ = write!(header, "[name=\"{}\"]", strip_ansi(name));
+        }
+        header.push(':');
+        println!("{}", crate::style::bold(&header));
+
+        if let Some(fields) = form.get("fields").and_then(|f| f.as_array()) {
+            for field in fields {
+                let field_name = strip_ansi(
+                    field
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or(""),
+                );
+                let display_name = if field_name.is_empty() {
+                    "(unnamed)".to_owned()
+                } else {
+                    field_name
+                };
+                let field_type = strip_ansi(
+                    field
+                        .get("type")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or(""),
+                );
+                let field_value_raw = field.get("value");
+                let field_value = match field_value_raw {
+                    Some(serde_json::Value::Array(arr)) => arr
+                        .iter()
+                        .filter_map(|v| v.as_str())
+                        .map(strip_ansi)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    _ => strip_ansi(
+                        field_value_raw
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or(""),
+                    ),
+                };
+                let checked = field
+                    .get("checked")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+
+                let mut line = format!("  {display_name}");
+                if !field_type.is_empty() {
+                    let _ = write!(
+                        line,
+                        " {}",
+                        crate::style::dim(format!("[type={field_type}]"))
+                    );
+                }
+                if field_type == "checkbox" || field_type == "radio" {
+                    if checked {
+                        let _ = write!(line, " = checked");
+                    } else {
+                        let _ = write!(line, " = {}", crate::style::dim("unchecked"));
+                    }
+                } else if field_type == "password" {
+                    if field_value.is_empty() {
+                        let _ = write!(line, " = \"\"");
+                    } else {
+                        let _ = write!(line, " = {}", crate::style::dim("[redacted]"));
+                    }
+                } else {
+                    let _ = write!(line, " = \"{field_value}\"");
+                }
+                println!("{line}");
+            }
+        }
+    }
+    if value.get("truncated").and_then(serde_json::Value::as_bool) == Some(true) {
+        println!(
+            "{}",
+            crate::style::warn("(output truncated — more forms exist)")
+        );
+    }
+}
+
 /// Format watch result showing DOM mutations grouped by type.
 pub(crate) fn format_watch(value: &serde_json::Value) {
     let added = value.get("added").and_then(|v| v.as_array());
@@ -839,5 +942,33 @@ mod tests {
             }]
         });
         format_diff(&diff);
+    }
+
+    #[test]
+    fn test_format_forms_basic() {
+        let value = json!({
+            "forms": [{
+                "id": "login-form",
+                "name": "",
+                "action": "/login",
+                "method": "post",
+                "fields": [
+                    {"tag": "input", "type": "email", "name": "email", "value": "user@example.com", "checked": false},
+                    {"tag": "input", "type": "password", "name": "password", "value": "", "checked": false},
+                    {"tag": "input", "type": "checkbox", "name": "remember", "value": "", "checked": true},
+                ]
+            }]
+        });
+        format_forms(&value);
+    }
+
+    #[test]
+    fn test_format_forms_empty() {
+        format_forms(&json!({"forms": []}));
+    }
+
+    #[test]
+    fn test_format_forms_no_forms_key() {
+        format_forms(&json!({}));
     }
 }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -276,6 +276,68 @@ pub(crate) fn format_storage(value: &serde_json::Value) {
     }
 }
 
+/// Format a single form field for display.
+fn format_form_field(field: &serde_json::Value) {
+    let field_name = strip_ansi(
+        field
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(""),
+    );
+    let display_name = if field_name.is_empty() {
+        "(unnamed)".to_owned()
+    } else {
+        field_name
+    };
+    let field_type = strip_ansi(
+        field
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(""),
+    );
+    let field_value_raw = field.get("value");
+    let field_value = match field_value_raw {
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(strip_ansi)
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => strip_ansi(
+            field_value_raw
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+        ),
+    };
+    let checked = field.get("checked").and_then(serde_json::Value::as_bool);
+
+    let mut line = format!("  {display_name}");
+    if !field_type.is_empty() {
+        let _ = write!(
+            line,
+            " {}",
+            crate::style::dim(format!("[type={field_type}]"))
+        );
+    }
+    if field_type == "password" {
+        if field_value.is_empty() {
+            let _ = write!(line, " = \"\"");
+        } else {
+            let _ = write!(line, " = {}", crate::style::dim("[redacted]"));
+        }
+    } else if let Some(is_checked) = checked {
+        let _ = write!(line, " = \"{field_value}\"");
+        if is_checked {
+            let _ = write!(line, " {}", crate::style::success("checked"));
+        } else {
+            let _ = write!(line, " {}", crate::style::dim("unchecked"));
+        }
+    } else {
+        let _ = write!(line, " = \"{field_value}\"");
+    }
+    println!("{line}");
+}
+
 /// Format form fields dumped from the page.
 ///
 /// Expects `{forms: [{id, name, action, method, fields: [{tag, type, name, value, checked}]}]}`
@@ -308,66 +370,17 @@ pub(crate) fn format_forms(value: &serde_json::Value) {
 
         if let Some(fields) = form.get("fields").and_then(|f| f.as_array()) {
             for field in fields {
-                let field_name = strip_ansi(
-                    field
-                        .get("name")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or(""),
+                format_form_field(field);
+            }
+            if form
+                .get("fieldsTruncated")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                println!(
+                    "  {}",
+                    crate::style::warn("(fields truncated — more fields exist)")
                 );
-                let display_name = if field_name.is_empty() {
-                    "(unnamed)".to_owned()
-                } else {
-                    field_name
-                };
-                let field_type = strip_ansi(
-                    field
-                        .get("type")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or(""),
-                );
-                let field_value_raw = field.get("value");
-                let field_value = match field_value_raw {
-                    Some(serde_json::Value::Array(arr)) => arr
-                        .iter()
-                        .filter_map(|v| v.as_str())
-                        .map(strip_ansi)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    _ => strip_ansi(
-                        field_value_raw
-                            .and_then(serde_json::Value::as_str)
-                            .unwrap_or(""),
-                    ),
-                };
-                let checked = field
-                    .get("checked")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(false);
-
-                let mut line = format!("  {display_name}");
-                if !field_type.is_empty() {
-                    let _ = write!(
-                        line,
-                        " {}",
-                        crate::style::dim(format!("[type={field_type}]"))
-                    );
-                }
-                if field_type == "checkbox" || field_type == "radio" {
-                    if checked {
-                        let _ = write!(line, " = checked");
-                    } else {
-                        let _ = write!(line, " = {}", crate::style::dim("unchecked"));
-                    }
-                } else if field_type == "password" {
-                    if field_value.is_empty() {
-                        let _ = write!(line, " = \"\"");
-                    } else {
-                        let _ = write!(line, " = {}", crate::style::dim("[redacted]"));
-                    }
-                } else {
-                    let _ = write!(line, " = \"{field_value}\"");
-                }
-                println!("{line}");
             }
         }
     }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -861,6 +861,74 @@
     return { cleared: true };
   }
 
+  var MAX_FORMS = 100;
+  var MAX_FIELDS_PER_FORM = 500;
+
+  function formDump(params) {
+    var forms;
+    if (params && params.selector) {
+      var found = document.querySelector(params.selector);
+      if (!found) {
+        throw new Error("Form not found: " + params.selector);
+      }
+      forms = [found];
+    } else {
+      var all = document.querySelectorAll("form");
+      forms = [];
+      var formLimit = Math.min(all.length, MAX_FORMS);
+      for (var fi = 0; fi < formLimit; fi++) {
+        forms.push(all[fi]);
+      }
+    }
+
+    var result = [];
+    for (var i = 0; i < forms.length; i++) {
+      var form = forms[i];
+      var fields = [];
+      var elements = form.querySelectorAll("input, select, textarea");
+      var fieldLimit = Math.min(elements.length, MAX_FIELDS_PER_FORM);
+      for (var j = 0; j < fieldLimit; j++) {
+        var el = elements[j];
+        var tag = el.tagName.toLowerCase();
+        var elType = el.type || null;
+        var fieldVal;
+        if (tag === "select" && el.multiple) {
+          var selected = [];
+          for (var k = 0; k < el.options.length; k++) {
+            if (el.options[k].selected) {
+              selected.push(el.options[k].value);
+            }
+          }
+          fieldVal = selected;
+        } else if (elType === "checkbox" || elType === "radio") {
+          fieldVal = el.checked;
+        } else {
+          fieldVal = el.value;
+        }
+        var field = {
+          tag: tag,
+          type: elType,
+          name: el.name || "",
+          value: fieldVal,
+        };
+        if (elType === "checkbox" || elType === "radio") {
+          field.checked = el.checked;
+        }
+        fields.push(field);
+      }
+      result.push({
+        id: form.id || "",
+        name: form.getAttribute("name") || "",
+        action: form.action || "",
+        method: form.method || "get",
+        fields: fields,
+      });
+    }
+    var totalForms = params && params.selector ? 1 : document.querySelectorAll("form").length;
+    var truncated = totalForms > MAX_FORMS;
+    return { forms: result, truncated: truncated };
+  }
+
   window.__PILOT__ = {
     snapshot: snapshot,
     resolve: resolve,
@@ -896,5 +964,6 @@
     storageSet: storageSet,
     storageList: storageList,
     storageClear: storageClear,
+    formDump: formDump,
   };
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -866,16 +866,22 @@
 
   function formDump(params) {
     var forms;
+    var totalForms;
     if (params && params.selector) {
       var found = document.querySelector(params.selector);
       if (!found) {
         throw new Error("Form not found: " + params.selector);
       }
+      if (found.tagName.toLowerCase() !== "form") {
+        throw new Error("Selector matched a <" + found.tagName.toLowerCase() + ">, expected a <form>");
+      }
       forms = [found];
+      totalForms = 1;
     } else {
       var all = document.querySelectorAll("form");
+      totalForms = all.length;
       forms = [];
-      var formLimit = Math.min(all.length, MAX_FORMS);
+      var formLimit = Math.min(totalForms, MAX_FORMS);
       for (var fi = 0; fi < formLimit; fi++) {
         forms.push(all[fi]);
       }
@@ -900,8 +906,6 @@
             }
           }
           fieldVal = selected;
-        } else if (elType === "checkbox" || elType === "radio") {
-          fieldVal = el.checked;
         } else {
           fieldVal = el.value;
         }
@@ -916,15 +920,18 @@
         }
         fields.push(field);
       }
-      result.push({
+      var formEntry = {
         id: form.id || "",
         name: form.getAttribute("name") || "",
         action: form.action || "",
         method: form.method || "get",
         fields: fields,
-      });
+      };
+      if (elements.length > MAX_FIELDS_PER_FORM) {
+        formEntry.fieldsTruncated = true;
+      }
+      result.push(formEntry);
     }
-    var totalForms = params && params.selector ? 1 : document.querySelectorAll("form").length;
     var truncated = totalForms > MAX_FORMS;
     return { forms: result, truncated: truncated };
   }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -67,6 +67,9 @@ pub(crate) async fn dispatch(
         "storage.clear" => {
             handle_eval_method("storageClear", params, engine, eval_fn, DEFAULT_TIMEOUT).await
         }
+        "forms.dump" => {
+            handle_eval_method("formDump", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+        }
         _ => Err(RpcError {
             code: -32601,
             message: format!("Method not found: {method}"),
@@ -571,5 +574,28 @@ mod tests {
         let script = build_bridge_call("storageClear", Some(&params)).unwrap();
         assert!(script.starts_with("window.__PILOT__.storageClear("));
         assert!(script.contains("\"session\":false"));
+    }
+
+    #[test]
+    fn test_build_bridge_call_form_dump() {
+        let script = build_bridge_call("formDump", None).unwrap();
+        assert_eq!(script, "window.__PILOT__.formDump({})");
+    }
+
+    #[test]
+    fn test_build_bridge_call_form_dump_with_selector() {
+        let params = json!({"selector": "#login-form"});
+        let script = build_bridge_call("formDump", Some(&params)).unwrap();
+        assert!(script.starts_with("window.__PILOT__.formDump("));
+        assert!(script.contains("\"selector\":\"#login-form\""));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_forms_dump_without_eval_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("forms.dump", None, &engine, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
     }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -958,6 +958,12 @@ tauri-pilot forms [OPTIONS]
 |--------|-------------|
 | `--selector <css>` | Target a specific form by CSS selector |
 
+**Notes:**
+
+- Password fields display `[redacted]` in human-readable output (raw values are available in `--json` mode)
+- Output is limited to 100 forms and 500 fields per form; a truncation warning appears if exceeded
+- The `--selector` must match a `<form>` element; other elements are rejected with an error
+
 **Examples:**
 
 ```bash

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -944,6 +944,45 @@ $ tauri-pilot storage list --json
 
 ---
 
+### `forms`
+
+Dump all form fields on the page in a single command. Useful for AI agents inspecting form state, pre-filled values, or verifying form structure without calling `value` on each input individually.
+
+```bash
+tauri-pilot forms [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--selector <css>` | Target a specific form by CSS selector |
+
+**Examples:**
+
+```bash
+# Dump all forms on the page
+$ tauri-pilot forms
+
+# Target a specific form
+$ tauri-pilot forms --selector "#login-form"
+
+# JSON output
+$ tauri-pilot forms --json
+```
+
+**JSON-RPC:**
+
+```jsonc
+// Dump all forms
+{"jsonrpc":"2.0","id":1,"method":"forms.dump"}
+
+// Dump specific form
+{"jsonrpc":"2.0","id":2,"method":"forms.dump","params":{"selector":"#login-form"}}
+```
+
+---
+
 ## JSON-RPC Protocol
 
 The CLI communicates with the plugin over a Unix socket using a hand-rolled JSON-RPC 2.0 protocol with newline-delimited framing (`\n`).


### PR DESCRIPTION
## Summary

- Add `tauri-pilot forms` command that extracts all form fields from the page in a single request
- `--selector` option to target a specific form by CSS selector
- `--json` for raw JSON output
- Password fields are redacted in human-readable output
- `<select multiple>` values displayed as comma-separated list
- Safety limits: 100 forms max, 500 fields per form (with truncation indicator)
- ANSI escape sequence sanitization on all output fields

## Changes

| File | Description |
|------|-------------|
| `bridge.js` | `formDump()` JS function — walks forms, collects field metadata |
| `handler.rs` | `"forms.dump"` dispatch + 3 tests |
| `cli.rs` | `FormsArgs` struct + `Command::Forms` variant + 2 parsing tests |
| `main.rs` | Detection, dispatch, `run_forms_command()`, output routing |
| `output.rs` | `format_forms()` with password redaction + 3 tests |
| `cli.md` | CLI reference documentation |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `cargo test --workspace` — 83 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual test: `tauri-pilot forms` on a page with forms
- [ ] Manual test: `tauri-pilot forms --selector "#login-form"`
- [ ] Manual test: `tauri-pilot forms --json`
- [ ] Verify password fields show `[redacted]`

Closes #13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tauri-pilot forms` to dump all form fields in one call, reducing many `value` requests into a single operation. Includes selector validation, JSON output, safe formatting, and truncation warnings.

- **New Features**
  - `tauri-pilot forms` with `--selector "<css>"` and `--json` (selector must match a `<form>`, non-form matches error)
  - Plugin method `forms.dump` via JS bridge `formDump()` collects `tag`, `type`, `name`, `value`, and `checked` (preserves checkbox/radio values; handles `<select multiple>`)
  - Human-readable output: password redaction, checked/unchecked labels, ANSI sanitization
  - Safety limits: 100 forms and 500 fields per form; shows per-form and overall truncation warnings
  - Docs and CLI reference updated (selector rules, redaction, limits)

<sup>Written for commit 77f6efc6d3c4b8299583ecc8d366d31cbc37a8d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `forms` command to dump and inspect form fields across a page, with optional `--selector` to target a specific form.
  * Output reports per-field name, type, value, and checkbox/radio checked state; password values are redacted for safety.
  * Results indicate when form or overall output is truncated (limits applied) and return an error if a selector doesn't match a `<form>`.

* **Documentation**
  * CLI docs and examples updated for the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->