### PR TITLE
feat: multi-window support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge functions accept params object (not positional arguments)
 - `build.rs` + permissions for `__callback` IPC command
 
+[#14]: https://github.com/mpiton/tauri-pilot/issues/14
 [#13]: https://github.com/mpiton/tauri-pilot/issues/13
 [#12]: https://github.com/mpiton/tauri-pilot/issues/12
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-window support** — `windows` command lists all windows, `--window` flag targets specific window ([#14])
 - **Form dump** — get all form fields at once instead of calling `value` on each input individually ([#13])
   - `tauri-pilot forms` — dump all forms on the page
   - `tauri-pilot forms --selector "#login-form"` — target a specific form

--- a/SKILL.md
+++ b/SKILL.md
@@ -110,7 +110,7 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 | `storage set <key> <value>` | Write to localStorage |
 | `storage list` | Dump all key-value pairs |
 | `storage clear` | Clear all storage |
-| `storage --session get <key>` | Use sessionStorage instead |
+| `storage --session <command>` | Use sessionStorage instead (applies to all storage commands) |
 | `forms` | Dump all form fields on the page |
 | `forms --selector "#login"` | Target a specific form |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,11 +35,12 @@ Three target formats, auto-detected:
 
 ## Commands
 
-### Connectivity & State
+### Connectivity & Windows
 
 | Command | Description |
 |---------|-------------|
 | `ping` | Check connectivity |
+| `windows` | List all open windows (label, URL, title) |
 | `state` | Get app state (URL, title, viewport, scroll) |
 | `url` | Get current URL |
 | `title` | Get page title |
@@ -52,6 +53,9 @@ Three target formats, auto-detected:
 | `snapshot -i` | Interactive elements only |
 | `snapshot -s ".panel"` | Scope to CSS selector |
 | `snapshot -d 3` | Limit tree depth |
+| `snapshot --save file.snap` | Save snapshot to file |
+| `diff` | Show changes since last snapshot |
+| `diff --ref file.snap` | Diff against a saved snapshot |
 | `text <target>` | Get text content |
 | `html [target]` | Get innerHTML (page if no target) |
 | `value <target>` | Get input value |
@@ -68,6 +72,8 @@ Three target formats, auto-detected:
 | `select <target> <value>` | `select @e5 "opt1"` |
 | `check <target>` | `check @e6` |
 | `scroll <dir> [amount] [--ref <target>]` | `scroll down 500` |
+| `drag <source> [target] [--offset X,Y]` | `drag @e5 @e8` |
+| `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 
 ### Assertions
 
@@ -93,6 +99,20 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 | `wait --selector ".loaded"` | Wait for CSS selector |
 | `wait --gone @e3` | Wait for element to disappear |
 | `wait --timeout 5000` | Custom timeout (default: 10000ms) |
+| `watch [--selector ".el"]` | Watch for DOM mutations (MutationObserver) |
+| `watch --timeout 3000 --stable 500` | Custom timeout and stability window |
+
+### Storage & Forms
+
+| Command | Description |
+|---------|-------------|
+| `storage get <key>` | Read from localStorage |
+| `storage set <key> <value>` | Write to localStorage |
+| `storage list` | Dump all key-value pairs |
+| `storage clear` | Clear all storage |
+| `storage --session get <key>` | Use sessionStorage instead |
+| `forms` | Dump all form fields on the page |
+| `forms --selector "#login"` | Target a specific form |
 
 ### Debugging
 
@@ -118,6 +138,7 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 | Flag | Description |
 |------|-------------|
 | `--socket <path>` | Explicit socket path (auto-detected by default) |
+| `--window <label>` | Target a specific window (env: `TAURI_PILOT_WINDOW`). Default: `main` or first available |
 | `--json` | Raw JSON output |
 
 ## Socket Auto-Detection
@@ -152,4 +173,10 @@ tauri-pilot logs --level error
 
 # IPC call
 tauri-pilot ipc greet --args '{"name":"World"}'
+
+# Multi-window app
+tauri-pilot windows
+tauri-pilot --window settings snapshot -i
+tauri-pilot --window settings fill @e2 "dark"
+tauri-pilot --window settings click @e3
 ```

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -34,3 +34,4 @@ indicatif = "0.17"
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 assert_cmd = "2"
+serial_test = "3.4.0"

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -659,14 +659,14 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_window_flag_env() {
-        // SAFETY: single-threaded test, no concurrent env access
+        // SAFETY: test is serialized via #[serial] to prevent parallel env access
         unsafe {
             std::env::set_var("TAURI_PILOT_WINDOW", "main");
         }
         let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "ping"]);
         assert_eq!(cli.window, Some("main".to_owned()));
-        // SAFETY: single-threaded test, no concurrent env access
         unsafe {
             std::env::remove_var("TAURI_PILOT_WINDOW");
         }

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -12,12 +12,18 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Target a specific window by label
+    #[arg(long, env = "TAURI_PILOT_WINDOW", global = true)]
+    pub window: Option<String>,
+
     #[command(subcommand)]
     pub command: Command,
 }
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
+    /// List all open windows
+    Windows,
     /// Check connectivity with a running Tauri app.
     Ping,
     /// Get app state (url, title, ready).
@@ -629,6 +635,40 @@ mod tests {
             assert_eq!(selector, Some("#login".to_owned()));
         } else {
             panic!("Expected Forms command with selector");
+        }
+    }
+
+    #[test]
+    fn test_windows_command() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "windows"]);
+        assert!(matches!(cli.command, Command::Windows));
+    }
+
+    #[test]
+    fn test_window_flag_with_command() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "--window",
+            "settings",
+            "snapshot",
+        ]);
+        assert_eq!(cli.window, Some("settings".to_owned()));
+        assert!(matches!(cli.command, Command::Snapshot { .. }));
+    }
+
+    #[test]
+    fn test_window_flag_env() {
+        // SAFETY: single-threaded test, no concurrent env access
+        unsafe {
+            std::env::set_var("TAURI_PILOT_WINDOW", "main");
+        }
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "ping"]);
+        assert_eq!(cli.window, Some("main".to_owned()));
+        // SAFETY: single-threaded test, no concurrent env access
+        unsafe {
+            std::env::remove_var("TAURI_PILOT_WINDOW");
         }
     }
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -28,14 +28,6 @@ async fn main() -> Result<()> {
     let socket = resolve_socket(args.socket)?;
     let mut client = Client::connect(&socket).await?;
 
-    let is_snapshot = matches!(args.command, Command::Snapshot { .. });
-    let is_diff = matches!(args.command, Command::Diff { .. });
-    let is_logs = matches!(args.command, Command::Logs { .. });
-    let is_network = matches!(args.command, Command::Network { .. });
-    let is_watch = matches!(args.command, Command::Watch { .. });
-    let is_storage = matches!(args.command, Command::Storage(..));
-    let is_forms = matches!(args.command, Command::Forms(..));
-
     // Handle --follow mode: loop forever polling for new entries
     if let Command::Logs {
         follow: true,
@@ -44,7 +36,14 @@ async fn main() -> Result<()> {
         ..
     } = args.command
     {
-        follow_logs(&mut client, args.json, level.as_deref(), *last).await?;
+        follow_logs(
+            &mut client,
+            args.json,
+            level.as_deref(),
+            *last,
+            args.window.as_deref(),
+        )
+        .await?;
     } else if let Command::Network {
         follow: true,
         ref filter,
@@ -53,7 +52,15 @@ async fn main() -> Result<()> {
         ..
     } = args.command
     {
-        follow_network(&mut client, args.json, filter.as_deref(), *last, failed).await?;
+        follow_network(
+            &mut client,
+            args.json,
+            filter.as_deref(),
+            *last,
+            failed,
+            args.window.as_deref(),
+        )
+        .await?;
     }
 
     let screenshot_path = if let Command::Screenshot { ref path, .. } = args.command {
@@ -62,15 +69,17 @@ async fn main() -> Result<()> {
         None
     };
     let is_screenshot = matches!(args.command, Command::Screenshot { .. });
+    // Capture output kind before command is consumed by run_command
+    let output_kind = OutputKind::from(&args.command);
     let result = if is_screenshot && !args.json && std::io::stdout().is_terminal() {
         let spinner = indicatif::ProgressBar::new_spinner();
         spinner.enable_steady_tick(Duration::from_millis(80));
         spinner.set_message("Taking screenshot...");
-        let res = run_command(&mut client, args.command).await;
+        let res = run_command(&mut client, args.command, args.window.as_deref()).await;
         spinner.finish_and_clear();
         res?
     } else {
-        run_command(&mut client, args.command).await?
+        run_command(&mut client, args.command, args.window.as_deref()).await?
     };
 
     // Screenshot save-to-file: decode base64 data URL and write PNG
@@ -87,43 +96,76 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    if args.json {
-        output::format_json(&result)?;
-    } else if is_snapshot {
-        output::format_snapshot(&result);
-    } else if is_diff {
-        output::format_diff(&result);
-    } else if is_logs {
-        // console.clear returns {"cleared": true}, not an array
-        if result.get("cleared").is_some() {
-            output::format_text(&result);
-        } else {
-            print!("{}", output::format_logs(&result));
-        }
-    } else if is_network {
-        if result.get("cleared").is_some() {
-            output::format_text(&result);
-        } else {
-            print!("{}", output::format_network(&result));
-        }
-    } else if is_watch {
-        output::format_watch(&result);
-    } else if is_storage {
-        if result.get("cleared").is_some() {
-            output::format_text(&result);
-        } else if result.get("entries").is_some() {
-            output::format_storage(&result);
-        } else if result.get("found").is_some() {
-            output::format_storage_value(&result);
-        } else {
-            output::format_text(&result);
-        }
-    } else if is_forms {
-        output::format_forms(&result);
-    } else {
-        output::format_text(&result);
-    }
+    format_result(output_kind, &result, args.json)?;
+    Ok(())
+}
 
+#[derive(Copy, Clone)]
+enum OutputKind {
+    Snapshot,
+    Diff,
+    Logs,
+    Network,
+    Watch,
+    Storage,
+    Forms,
+    Windows,
+    Text,
+}
+
+impl From<&Command> for OutputKind {
+    fn from(cmd: &Command) -> Self {
+        match cmd {
+            Command::Snapshot { .. } => OutputKind::Snapshot,
+            Command::Diff { .. } => OutputKind::Diff,
+            Command::Logs { .. } => OutputKind::Logs,
+            Command::Network { .. } => OutputKind::Network,
+            Command::Watch { .. } => OutputKind::Watch,
+            Command::Storage(..) => OutputKind::Storage,
+            Command::Forms(..) => OutputKind::Forms,
+            Command::Windows => OutputKind::Windows,
+            _ => OutputKind::Text,
+        }
+    }
+}
+
+fn format_result(kind: OutputKind, result: &serde_json::Value, emit_json: bool) -> Result<()> {
+    if emit_json {
+        return output::format_json(result);
+    }
+    match kind {
+        OutputKind::Snapshot => output::format_snapshot(result),
+        OutputKind::Diff => output::format_diff(result),
+        OutputKind::Logs => {
+            if result.get("cleared").is_some() {
+                output::format_text(result);
+            } else {
+                print!("{}", output::format_logs(result));
+            }
+        }
+        OutputKind::Network => {
+            if result.get("cleared").is_some() {
+                output::format_text(result);
+            } else {
+                print!("{}", output::format_network(result));
+            }
+        }
+        OutputKind::Watch => output::format_watch(result),
+        OutputKind::Storage => {
+            if result.get("cleared").is_some() {
+                output::format_text(result);
+            } else if result.get("entries").is_some() {
+                output::format_storage(result);
+            } else if result.get("found").is_some() {
+                output::format_storage_value(result);
+            } else {
+                output::format_text(result);
+            }
+        }
+        OutputKind::Forms => output::format_forms(result),
+        OutputKind::Windows => output::format_windows(result),
+        OutputKind::Text => output::format_text(result),
+    }
     Ok(())
 }
 
@@ -132,6 +174,7 @@ async fn follow_logs(
     emit_json: bool,
     level: Option<&str>,
     last: Option<usize>,
+    window: Option<&str>,
 ) -> Result<()> {
     let mut last_seen_id: u64 = 0;
     let mut first_poll = true;
@@ -150,7 +193,10 @@ async fn follow_logs(
             first_poll = false;
         }
         let result = client
-            .call("console.getLogs", Some(Value::Object(params)))
+            .call(
+                "console.getLogs",
+                with_window(Some(Value::Object(params)), window),
+            )
             .await?;
         if let Some(entries) = result.as_array()
             && !entries.is_empty()
@@ -179,6 +225,7 @@ async fn follow_network(
     filter: Option<&str>,
     last: Option<usize>,
     failed: bool,
+    window: Option<&str>,
 ) -> Result<()> {
     let mut last_seen_id: u64 = 0;
     let mut first_poll = true;
@@ -200,7 +247,10 @@ async fn follow_network(
             first_poll = false;
         }
         let result = client
-            .call("network.getRequests", Some(Value::Object(params)))
+            .call(
+                "network.getRequests",
+                with_window(Some(Value::Object(params)), window),
+            )
             .await?;
         if let Some(entries) = result.as_array()
             && !entries.is_empty()
@@ -222,52 +272,56 @@ async fn follow_network(
     }
 }
 
-async fn run_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {
+fn with_window(params: Option<Value>, window: Option<&str>) -> Option<Value> {
+    match (params, window) {
+        (Some(Value::Object(mut map)), Some(w)) => {
+            map.insert("window".to_string(), json!(w));
+            Some(Value::Object(map))
+        }
+        (None, Some(w)) => Some(json!({"window": w})),
+        (params, _) => params,
+    }
+}
+
+async fn run_command(
+    client: &mut Client,
+    command: Command,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
     match command {
-        Command::Ping => client.call("ping", None).await,
-        Command::State => client.call("state", None).await,
+        Command::Windows => client.call("windows.list", None).await,
+        Command::Ping => client.call("ping", with_window(None, window)).await,
+        Command::State => client.call("state", with_window(None, window)).await,
         Command::Snapshot {
             interactive,
             selector,
             depth,
             save,
-        } => {
-            let result = client
-                .call(
-                    "snapshot",
-                    Some(json!({
-                        "interactive": interactive,
-                        "selector": selector,
-                        "depth": depth,
-                    })),
-                )
-                .await?;
-            if let Some(ref path) = save {
-                let json = serde_json::to_string_pretty(&result)?;
-                std::fs::write(path, &json)
-                    .with_context(|| format!("Failed to save snapshot to {}", path.display()))?;
-                eprintln!("Snapshot saved to {}", path.display());
-            }
-            Ok(result)
-        }
+        } => run_snapshot_command(client, interactive, selector, depth, save, window).await,
         Command::Diff {
             r#ref: ref_path,
             interactive,
             selector,
             depth,
-        } => run_diff_command(client, ref_path, interactive, selector, depth).await,
-        Command::Ipc { command, args } => run_ipc_command(client, &command, args.as_deref()).await,
+        } => run_diff_command(client, ref_path, interactive, selector, depth, window).await,
+        Command::Ipc { command, args } => {
+            run_ipc_command(client, &command, args.as_deref(), window).await
+        }
         Command::Screenshot { path, selector } => {
             client
                 .call(
                     "screenshot",
-                    Some(json!({"path": path, "selector": selector})),
+                    with_window(Some(json!({"path": path, "selector": selector})), window),
                 )
                 .await
         }
-        Command::Navigate { url } => client.call("navigate", Some(json!({"url": url}))).await,
-        Command::Url => client.call("url", None).await,
-        Command::Title => client.call("title", None).await,
+        Command::Navigate { url } => {
+            client
+                .call("navigate", with_window(Some(json!({"url": url})), window))
+                .await
+        }
+        Command::Url => client.call("url", with_window(None, window)).await,
+        Command::Title => client.call("title", with_window(None, window)).await,
         Command::Wait {
             target,
             selector,
@@ -277,12 +331,15 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             client
                 .call(
                     "wait",
-                    Some(json!({
-                        "target": target,
-                        "selector": selector,
-                        "gone": gone,
-                        "timeout": timeout,
-                    })),
+                    with_window(
+                        Some(json!({
+                            "target": target,
+                            "selector": selector,
+                            "gone": gone,
+                            "timeout": timeout,
+                        })),
+                        window,
+                    ),
                 )
                 .await
         }
@@ -290,17 +347,7 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             selector,
             timeout,
             stable,
-        } => {
-            let mut params = serde_json::Map::new();
-            params.insert("timeout".into(), json!(timeout));
-            params.insert("stable".into(), json!(stable));
-            if let Some(sel) = selector {
-                params.insert("selector".into(), json!(sel));
-            }
-            client
-                .call("watch", Some(serde_json::Value::Object(params)))
-                .await
-        }
+        } => run_watch_command(client, selector, timeout, stable, window).await,
         Command::Logs {
             level,
             last,
@@ -314,12 +361,59 @@ async fn run_command(client: &mut Client, command: Command) -> Result<serde_json
             clear,
             follow,
         } => run_network_command(client, filter, failed, last, clear, follow).await,
-        Command::Assert(kind) => run_assert_command(client, kind).await,
-        Command::Storage(storage_args) => run_storage_command(client, storage_args).await,
-        Command::Forms(args) => run_forms_command(client, args).await,
-        Command::Drop { target, file } => run_drop_command(client, &target, file).await,
-        cmd => run_dom_command(client, cmd).await,
+        Command::Assert(kind) => run_assert_command(client, kind, window).await,
+        Command::Storage(storage_args) => run_storage_command(client, storage_args, window).await,
+        Command::Forms(args) => run_forms_command(client, args, window).await,
+        Command::Drop { target, file } => run_drop_command(client, &target, file, window).await,
+        cmd => run_dom_command(client, cmd, window).await,
     }
+}
+
+async fn run_snapshot_command(
+    client: &mut Client,
+    interactive: bool,
+    selector: Option<String>,
+    depth: Option<u8>,
+    save: Option<std::path::PathBuf>,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
+    let params = with_window(
+        Some(json!({
+            "interactive": interactive,
+            "selector": selector,
+            "depth": depth,
+        })),
+        window,
+    );
+    let result = client.call("snapshot", params).await?;
+    if let Some(ref path) = save {
+        let json = serde_json::to_string_pretty(&result)?;
+        std::fs::write(path, &json)
+            .with_context(|| format!("Failed to save snapshot to {}", path.display()))?;
+        eprintln!("Snapshot saved to {}", path.display());
+    }
+    Ok(result)
+}
+
+async fn run_watch_command(
+    client: &mut Client,
+    selector: Option<String>,
+    timeout: u64,
+    stable: u64,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
+    let mut params = serde_json::Map::new();
+    params.insert("timeout".into(), json!(timeout));
+    params.insert("stable".into(), json!(stable));
+    if let Some(sel) = selector {
+        params.insert("selector".into(), json!(sel));
+    }
+    client
+        .call(
+            "watch",
+            with_window(Some(serde_json::Value::Object(params)), window),
+        )
+        .await
 }
 
 async fn run_diff_command(
@@ -328,6 +422,7 @@ async fn run_diff_command(
     interactive: bool,
     selector: Option<String>,
     depth: Option<u8>,
+    window: Option<&str>,
 ) -> Result<serde_json::Value> {
     let mut params = json!({
         "interactive": interactive,
@@ -352,29 +447,45 @@ async fn run_diff_command(
         );
         params["reference"] = reference;
     }
-    client.call("diff", Some(params)).await
+    client.call("diff", with_window(Some(params), window)).await
 }
 
-async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_json::Value> {
+async fn run_dom_command(
+    client: &mut Client,
+    command: Command,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
     match command {
-        Command::Click { target } => client.call("click", Some(target_params(&target))).await,
+        Command::Click { target } => {
+            client
+                .call("click", with_window(Some(target_params(&target)), window))
+                .await
+        }
         Command::Fill { target, value } => {
             let mut p = target_params(&target);
             p["value"] = json!(value);
-            client.call("fill", Some(p)).await
+            client.call("fill", with_window(Some(p), window)).await
         }
         Command::Type { target, text } => {
             let mut p = target_params(&target);
             p["text"] = json!(text);
-            client.call("type", Some(p)).await
+            client.call("type", with_window(Some(p), window)).await
         }
-        Command::Press { key } => client.call("press", Some(json!({"key": key}))).await,
+        Command::Press { key } => {
+            client
+                .call("press", with_window(Some(json!({"key": key})), window))
+                .await
+        }
         Command::Select { target, value } => {
             let mut p = target_params(&target);
             p["value"] = json!(value);
-            client.call("select", Some(p)).await
+            client.call("select", with_window(Some(p), window)).await
         }
-        Command::Check { target } => client.call("check", Some(target_params(&target))).await,
+        Command::Check { target } => {
+            client
+                .call("check", with_window(Some(target_params(&target)), window))
+                .await
+        }
         Command::Scroll {
             direction,
             amount,
@@ -383,18 +494,37 @@ async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_
             client
                 .call(
                     "scroll",
-                    Some(json!({"direction": direction, "amount": amount, "ref": r#ref})),
+                    with_window(
+                        Some(json!({"direction": direction, "amount": amount, "ref": r#ref})),
+                        window,
+                    ),
                 )
                 .await
         }
-        Command::Text { target } => client.call("text", Some(target_params(&target))).await,
+        Command::Text { target } => {
+            client
+                .call("text", with_window(Some(target_params(&target)), window))
+                .await
+        }
         Command::Html { target } => {
             let params = target.map(|t| target_params(&t));
-            client.call("html", params).await
+            client.call("html", with_window(params, window)).await
         }
-        Command::Value { target } => client.call("value", Some(target_params(&target))).await,
-        Command::Attrs { target } => client.call("attrs", Some(target_params(&target))).await,
-        Command::Eval { script } => client.call("eval", Some(json!({"script": script}))).await,
+        Command::Value { target } => {
+            client
+                .call("value", with_window(Some(target_params(&target)), window))
+                .await
+        }
+        Command::Attrs { target } => {
+            client
+                .call("attrs", with_window(Some(target_params(&target)), window))
+                .await
+        }
+        Command::Eval { script } => {
+            client
+                .call("eval", with_window(Some(json!({"script": script})), window))
+                .await
+        }
         Command::Drag {
             source,
             target,
@@ -412,7 +542,7 @@ async fn run_dom_command(client: &mut Client, command: Command) -> Result<serde_
             } else {
                 anyhow::bail!("drag requires either a target element or --offset");
             }
-            client.call("drag", Some(p)).await
+            client.call("drag", with_window(Some(p), window)).await
         }
         _ => anyhow::bail!("unexpected command in run_dom_command"),
     }
@@ -437,10 +567,16 @@ fn assert_fail(msg: &str) -> ! {
     std::process::exit(1)
 }
 
-async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<serde_json::Value> {
+async fn run_assert_command(
+    client: &mut Client,
+    kind: AssertKind,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
     match kind {
         AssertKind::Text { target, expected } => {
-            let result = client.call("text", Some(target_params(&target))).await?;
+            let result = client
+                .call("text", with_window(Some(target_params(&target)), window))
+                .await?;
             let actual = require_str(&result)?;
             if actual != expected {
                 assert_fail(&format!("expected text \"{expected}\", got \"{actual}\""));
@@ -448,7 +584,9 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
         }
         AssertKind::Visible { target } => {
             let visible = require_bool_field(
-                &client.call("visible", Some(target_params(&target))).await?,
+                &client
+                    .call("visible", with_window(Some(target_params(&target)), window))
+                    .await?,
                 "visible",
             )?;
             if !visible {
@@ -457,7 +595,9 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
         }
         AssertKind::Hidden { target } => {
             let visible = require_bool_field(
-                &client.call("visible", Some(target_params(&target))).await?,
+                &client
+                    .call("visible", with_window(Some(target_params(&target)), window))
+                    .await?,
                 "visible",
             )?;
             if visible {
@@ -465,7 +605,9 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
             }
         }
         AssertKind::Value { target, expected } => {
-            let result = client.call("value", Some(target_params(&target))).await?;
+            let result = client
+                .call("value", with_window(Some(target_params(&target)), window))
+                .await?;
             let actual = require_str(&result)?;
             if actual != expected {
                 assert_fail(&format!("expected value \"{expected}\", got \"{actual}\""));
@@ -473,7 +615,10 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
         }
         AssertKind::Count { selector, expected } => {
             let result = client
-                .call("count", Some(json!({"selector": selector})))
+                .call(
+                    "count",
+                    with_window(Some(json!({"selector": selector})), window),
+                )
                 .await?;
             let actual = result
                 .get("count")
@@ -485,7 +630,9 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
         }
         AssertKind::Checked { target } => {
             let checked = require_bool_field(
-                &client.call("checked", Some(target_params(&target))).await?,
+                &client
+                    .call("checked", with_window(Some(target_params(&target)), window))
+                    .await?,
                 "checked",
             )?;
             if !checked {
@@ -493,7 +640,9 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
             }
         }
         AssertKind::Contains { target, expected } => {
-            let result = client.call("text", Some(target_params(&target))).await?;
+            let result = client
+                .call("text", with_window(Some(target_params(&target)), window))
+                .await?;
             let actual = require_str(&result)?;
             if !actual.contains(&expected) {
                 assert_fail(&format!(
@@ -502,7 +651,7 @@ async fn run_assert_command(client: &mut Client, kind: AssertKind) -> Result<ser
             }
         }
         AssertKind::Url { expected } => {
-            let result = client.call("url", None).await?;
+            let result = client.call("url", with_window(None, window)).await?;
             let actual = require_str(&result)?;
             if !actual.contains(&expected) {
                 assert_fail(&format!(
@@ -518,12 +667,16 @@ async fn run_ipc_command(
     client: &mut Client,
     command: &str,
     args: Option<&str>,
+    window: Option<&str>,
 ) -> Result<serde_json::Value> {
     let parsed_args: Option<serde_json::Value> = args.map(serde_json::from_str).transpose()?;
     client
         .call(
             "ipc",
-            Some(json!({"command": command, "args": parsed_args})),
+            with_window(
+                Some(json!({"command": command, "args": parsed_args})),
+                window,
+            ),
         )
         .await
 }
@@ -585,35 +738,55 @@ async fn run_network_command(
         .await
 }
 
-async fn run_forms_command(client: &mut Client, args: FormsArgs) -> Result<serde_json::Value> {
+async fn run_forms_command(
+    client: &mut Client,
+    args: FormsArgs,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
     let params = args.selector.map(|s| json!({"selector": s}));
-    client.call("forms.dump", params).await
+    client.call("forms.dump", with_window(params, window)).await
 }
 
-async fn run_storage_command(client: &mut Client, args: StorageArgs) -> Result<serde_json::Value> {
+async fn run_storage_command(
+    client: &mut Client,
+    args: StorageArgs,
+    window: Option<&str>,
+) -> Result<serde_json::Value> {
     let session = args.session;
     match args.action {
         StorageAction::Get { key } => {
             client
-                .call("storage.get", Some(json!({"key": key, "session": session})))
+                .call(
+                    "storage.get",
+                    with_window(Some(json!({"key": key, "session": session})), window),
+                )
                 .await
         }
         StorageAction::Set { key, value } => {
             client
                 .call(
                     "storage.set",
-                    Some(json!({"key": key, "value": value, "session": session})),
+                    with_window(
+                        Some(json!({"key": key, "value": value, "session": session})),
+                        window,
+                    ),
                 )
                 .await
         }
         StorageAction::List => {
             client
-                .call("storage.list", Some(json!({"session": session})))
+                .call(
+                    "storage.list",
+                    with_window(Some(json!({"session": session})), window),
+                )
                 .await
         }
         StorageAction::Clear => {
             client
-                .call("storage.clear", Some(json!({"session": session})))
+                .call(
+                    "storage.clear",
+                    with_window(Some(json!({"session": session})), window),
+                )
                 .await
         }
     }
@@ -626,6 +799,7 @@ async fn run_drop_command(
     client: &mut Client,
     target: &str,
     file: Vec<std::path::PathBuf>,
+    window: Option<&str>,
 ) -> Result<serde_json::Value> {
     let mut p = target_params(target);
     let mut files = Vec::new();
@@ -655,7 +829,7 @@ async fn run_drop_command(
         files.push(json!({"name": name, "type": mime, "data": encoded}));
     }
     p["files"] = json!(files);
-    client.call("drop", Some(p)).await
+    client.call("drop", with_window(Some(p), window)).await
 }
 
 fn target_params(raw: &str) -> serde_json::Value {
@@ -785,5 +959,34 @@ mod tests {
             mime_from_ext(std::path::Path::new("doc.PDF")),
             "application/pdf"
         );
+    }
+
+    #[test]
+    fn test_with_window_no_window_returns_params_unchanged() {
+        let params = Some(json!({"selector": "#btn"}));
+        let result = with_window(params.clone(), None);
+        assert_eq!(result, params);
+    }
+
+    #[test]
+    fn test_with_window_none_params_none_window_returns_none() {
+        let result = with_window(None, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_with_window_injects_into_existing_object() {
+        let params = Some(json!({"selector": "#btn"}));
+        let result = with_window(params, Some("settings"));
+        assert_eq!(
+            result,
+            Some(json!({"selector": "#btn", "window": "settings"}))
+        );
+    }
+
+    #[test]
+    fn test_with_window_none_params_creates_object() {
+        let result = with_window(None, Some("main"));
+        assert_eq!(result, Some(json!({"window": "main"})));
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -353,14 +353,14 @@ async fn run_command(
             last,
             clear,
             follow,
-        } => run_logs_command(client, level, last, clear, follow).await,
+        } => run_logs_command(client, level, last, clear, follow, window).await,
         Command::Network {
             filter,
             failed,
             last,
             clear,
             follow,
-        } => run_network_command(client, filter, failed, last, clear, follow).await,
+        } => run_network_command(client, filter, failed, last, clear, follow, window).await,
         Command::Assert(kind) => run_assert_command(client, kind, window).await,
         Command::Storage(storage_args) => run_storage_command(client, storage_args, window).await,
         Command::Forms(args) => run_forms_command(client, args, window).await,
@@ -687,12 +687,15 @@ async fn run_logs_command(
     last: Option<usize>,
     clear: bool,
     follow: bool,
+    window: Option<&str>,
 ) -> Result<serde_json::Value> {
     if follow {
         anyhow::bail!("follow mode must be handled before run_command");
     }
     if clear {
-        return client.call("console.clear", None).await;
+        return client
+            .call("console.clear", with_window(None, window))
+            .await;
     }
     let mut params = serde_json::Map::new();
     if let Some(l) = level {
@@ -702,7 +705,10 @@ async fn run_logs_command(
         params.insert("last".into(), json!(n));
     }
     client
-        .call("console.getLogs", Some(serde_json::Value::Object(params)))
+        .call(
+            "console.getLogs",
+            with_window(Some(serde_json::Value::Object(params)), window),
+        )
         .await
 }
 
@@ -713,12 +719,15 @@ async fn run_network_command(
     last: Option<usize>,
     clear: bool,
     follow: bool,
+    window: Option<&str>,
 ) -> Result<serde_json::Value> {
     if follow {
         anyhow::bail!("follow mode must be handled before run_command");
     }
     if clear {
-        return client.call("network.clear", None).await;
+        return client
+            .call("network.clear", with_window(None, window))
+            .await;
     }
     let mut params = serde_json::Map::new();
     if let Some(f) = filter {
@@ -733,7 +742,7 @@ async fn run_network_command(
     client
         .call(
             "network.getRequests",
-            Some(serde_json::Value::Object(params)),
+            with_window(Some(serde_json::Value::Object(params)), window),
         )
         .await
 }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -647,10 +647,12 @@ pub(crate) fn format_windows(value: &serde_json::Value) {
     let max_label = windows
         .iter()
         .map(|w| {
-            w.get("label")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("")
-                .len()
+            strip_ansi(
+                w.get("label")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            )
+            .len()
         })
         .max()
         .unwrap_or(0);
@@ -658,10 +660,12 @@ pub(crate) fn format_windows(value: &serde_json::Value) {
     let max_url = windows
         .iter()
         .map(|w| {
-            w.get("url")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("")
-                .len()
+            strip_ansi(
+                w.get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            )
+            .len()
         })
         .max()
         .unwrap_or(0);
@@ -696,7 +700,8 @@ pub(crate) fn format_windows(value: &serde_json::Value) {
     }
 }
 
-/// Strip ANSI escape sequences from a string to prevent terminal injection.
+/// Strip ANSI escape sequences and C0 control characters from a string
+/// to prevent terminal injection.
 fn strip_ansi(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
@@ -729,6 +734,8 @@ fn strip_ansi(input: &str) -> String {
                 // Skip single-char escape (ESC + one char)
                 chars.next();
             }
+        } else if c.is_control() && c != '\n' && c != '\t' && c != '\r' {
+            // Strip C0/C1 control characters (except common whitespace)
         } else {
             result.push(c);
         }

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -631,6 +631,71 @@ fn format_diff_entry(
     line
 }
 
+/// Format the list of open windows.
+///
+/// Expects `{"windows": [{"label": "main", "url": "http://...", "title": "My App"}]}`
+pub(crate) fn format_windows(value: &serde_json::Value) {
+    let Some(windows) = value.get("windows").and_then(|w| w.as_array()) else {
+        println!("{}", crate::style::dim("No windows found"));
+        return;
+    };
+    if windows.is_empty() {
+        println!("{}", crate::style::dim("No windows found"));
+        return;
+    }
+
+    let max_label = windows
+        .iter()
+        .map(|w| {
+            w.get("label")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .len()
+        })
+        .max()
+        .unwrap_or(0);
+
+    let max_url = windows
+        .iter()
+        .map(|w| {
+            w.get("url")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .len()
+        })
+        .max()
+        .unwrap_or(0);
+
+    for window in windows {
+        let label = strip_ansi(
+            window
+                .get("label")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+        );
+        let url = strip_ansi(
+            window
+                .get("url")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+        );
+        let title = strip_ansi(
+            window
+                .get("title")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+        );
+        let padded_label = format!("{label:<max_label$}");
+        let padded_url = format!("{url:<max_url$}");
+        println!(
+            "{}   {}   {}",
+            crate::style::bold(&padded_label),
+            crate::style::dim(&padded_url),
+            title,
+        );
+    }
+}
+
 /// Strip ANSI escape sequences from a string to prevent terminal injection.
 fn strip_ansi(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
@@ -983,5 +1048,48 @@ mod tests {
     #[test]
     fn test_format_forms_no_forms_key() {
         format_forms(&json!({}));
+    }
+
+    #[test]
+    fn test_format_windows_empty() {
+        format_windows(&json!({"windows": []}));
+    }
+
+    #[test]
+    fn test_format_windows_single() {
+        let value = json!({
+            "windows": [
+                {"label": "main", "url": "http://localhost:1420/", "title": "My Tauri App"}
+            ]
+        });
+        format_windows(&value);
+    }
+
+    #[test]
+    fn test_format_windows_multiple() {
+        let value = json!({
+            "windows": [
+                {"label": "main", "url": "http://localhost:1420/", "title": "My Tauri App"},
+                {"label": "settings", "url": "http://localhost:1420/settings", "title": "Settings"},
+            ]
+        });
+        format_windows(&value);
+    }
+
+    #[test]
+    fn test_format_windows_missing_fields() {
+        let value = json!({
+            "windows": [
+                {"label": "main"},
+                {"url": "http://localhost:1420/"},
+                {},
+            ]
+        });
+        format_windows(&value);
+    }
+
+    #[test]
+    fn test_format_windows_no_windows_key() {
+        format_windows(&json!({}));
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,7 +1,7 @@
 use crate::diff;
 use crate::eval::EvalEngine;
 use crate::protocol::RpcError;
-use crate::server::EvalFn;
+use crate::server::{EvalFn, ListWindowsFn};
 
 use std::time::Duration;
 
@@ -11,26 +11,68 @@ const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
 /// doesn't expire before the JS `MutationObserver` can resolve/reject.
 const WATCH_BUFFER_MS: u64 = 2_000;
 
+/// Extract and remove the optional `"window"` key from params.
+///
+/// Returns `(window_label, cleaned_params)`:
+/// - When `"window"` is present: `cleaned_params` is `Some(...)` with the key stripped.
+/// - When `"window"` is absent: `cleaned_params` is `None` — the caller must fall back
+///   to the original `params` reference (e.g. via `.as_ref().or(params)`).
+fn extract_window(
+    params: Option<&serde_json::Value>,
+) -> (Option<String>, Option<serde_json::Value>) {
+    let window = params
+        .and_then(|o| o.get("window"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    match (window, params) {
+        (Some(w), Some(p)) => {
+            let mut cleaned = p.clone();
+            if let Some(obj) = cleaned.as_object_mut() {
+                obj.remove("window");
+            }
+            (Some(w), Some(cleaned))
+        }
+        (w, _) => (w, None),
+    }
+}
+
 /// Dispatch a JSON-RPC method call to the appropriate handler.
 pub(crate) async fn dispatch(
     method: &str,
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
+    list_fn: Option<&ListWindowsFn>,
 ) -> Result<serde_json::Value, RpcError> {
+    let (window, owned_params) = extract_window(params);
+    let params = owned_params.as_ref().or(params);
+    let win = window.as_deref();
+
     match method {
         "ping" => Ok(serde_json::json!({"status": "ok"})),
+        "windows.list" => {
+            if let Some(f) = list_fn {
+                Ok(f())
+            } else {
+                Err(RpcError {
+                    code: -32603,
+                    message: "No window manager available".to_owned(),
+                    data: None,
+                })
+            }
+        }
         "snapshot" => {
             let result =
-                handle_eval_method("snapshot", params, engine, eval_fn, DEFAULT_TIMEOUT).await?;
+                handle_eval_method("snapshot", params, engine, eval_fn, win, DEFAULT_TIMEOUT)
+                    .await?;
             engine.store_snapshot(&result);
             Ok(result)
         }
-        "diff" => handle_diff(params, engine, eval_fn).await,
+        "diff" => handle_diff(params, engine, eval_fn, win).await,
         "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" | "drag" | "drop"
         | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
         | "state" | "wait" | "visible" | "count" | "checked" => {
-            handle_eval_method(method, params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "watch" => {
             let timeout_ms = params
@@ -38,37 +80,61 @@ pub(crate) async fn dispatch(
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or(10_000);
             let timeout = Duration::from_millis(timeout_ms.saturating_add(WATCH_BUFFER_MS));
-            handle_eval_method(method, params, engine, eval_fn, timeout).await
+            handle_eval_method(method, params, engine, eval_fn, win, timeout).await
         }
         "screenshot" => {
-            handle_eval_method(method, params, engine, eval_fn, SCREENSHOT_TIMEOUT).await
+            handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
         }
         "console.getLogs" => {
-            handle_eval_method("consoleLogs", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("consoleLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "console.clear" => {
-            handle_eval_method("clearLogs", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("clearLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "network.getRequests" => {
-            handle_eval_method("networkRequests", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method(
+                "networkRequests",
+                params,
+                engine,
+                eval_fn,
+                win,
+                DEFAULT_TIMEOUT,
+            )
+            .await
         }
         "network.clear" => {
-            handle_eval_method("clearNetwork", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method(
+                "clearNetwork",
+                params,
+                engine,
+                eval_fn,
+                win,
+                DEFAULT_TIMEOUT,
+            )
+            .await
         }
         "storage.get" => {
-            handle_eval_method("storageGet", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("storageGet", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "storage.set" => {
-            handle_eval_method("storageSet", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("storageSet", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "storage.list" => {
-            handle_eval_method("storageList", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("storageList", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "storage.clear" => {
-            handle_eval_method("storageClear", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method(
+                "storageClear",
+                params,
+                engine,
+                eval_fn,
+                win,
+                DEFAULT_TIMEOUT,
+            )
+            .await
         }
         "forms.dump" => {
-            handle_eval_method("formDump", params, engine, eval_fn, DEFAULT_TIMEOUT).await
+            handle_eval_method("formDump", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         _ => Err(RpcError {
             code: -32601,
@@ -83,6 +149,7 @@ async fn handle_diff(
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
+    window: Option<&str>,
 ) -> Result<serde_json::Value, RpcError> {
     let eval_fn = eval_fn.ok_or_else(|| RpcError {
         code: -32603,
@@ -121,7 +188,7 @@ async fn handle_diff(
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
-    if let Err(e) = eval_fn(wrapped) {
+    if let Err(e) = eval_fn(window, wrapped) {
         engine.resolve(id, Err(format!("Eval failed: {e}")));
         return Err(RpcError {
             code: -32603,
@@ -180,6 +247,7 @@ async fn handle_eval_method(
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
+    window: Option<&str>,
     timeout: Duration,
 ) -> Result<serde_json::Value, RpcError> {
     let eval_fn = eval_fn.ok_or_else(|| RpcError {
@@ -196,7 +264,7 @@ async fn handle_eval_method(
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
-    if let Err(e) = eval_fn(wrapped) {
+    if let Err(e) = eval_fn(window, wrapped) {
         // Clean up pending entry on eval_fn failure
         engine.resolve(id, Err(format!("Eval failed: {e}")));
         return Err(RpcError {
@@ -281,14 +349,14 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_ping_returns_ok() {
         let engine = EvalEngine::new();
-        let result = dispatch("ping", None, &engine, None).await;
+        let result = dispatch("ping", None, &engine, None, None).await;
         assert_eq!(result.unwrap(), json!({"status": "ok"}));
     }
 
     #[tokio::test]
     async fn test_dispatch_unknown_method_returns_error() {
         let engine = EvalEngine::new();
-        let result = dispatch("nonexistent", None, &engine, None).await;
+        let result = dispatch("nonexistent", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32601);
     }
@@ -296,7 +364,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_snapshot_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("snapshot", None, &engine, None).await;
+        let result = dispatch("snapshot", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -305,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_diff_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("diff", None, &engine, None).await;
+        let result = dispatch("diff", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -323,8 +391,9 @@ mod tests {
         // Let's use a sync eval_fn and resolve manually.
         // Actually the reference check happens BEFORE the eval call, so we can check:
         // eval_fn present + no reference in params + no last_snapshot → -32602
-        let eval_fn: crate::server::EvalFn = std::sync::Arc::new(|_script| Ok(()));
-        let result = dispatch("diff", None, &engine, Some(&eval_fn)).await;
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+        let result = dispatch("diff", None, &engine, Some(&eval_fn), None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32602);
         assert!(err.message.contains("No previous snapshot"));
@@ -372,7 +441,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_console_get_logs_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("console.getLogs", None, &engine, None).await;
+        let result = dispatch("console.getLogs", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -381,7 +450,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_console_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("console.clear", None, &engine, None).await;
+        let result = dispatch("console.clear", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -404,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_network_get_requests_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("network.getRequests", None, &engine, None).await;
+        let result = dispatch("network.getRequests", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -413,7 +482,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_network_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("network.clear", None, &engine, None).await;
+        let result = dispatch("network.clear", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -460,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_watch_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("watch", None, &engine, None).await;
+        let result = dispatch("watch", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -477,7 +546,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drag_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drag", None, &engine, None).await;
+        let result = dispatch("drag", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_ne!(err.code, -32601);
     }
@@ -485,7 +554,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drop_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drop", None, &engine, None).await;
+        let result = dispatch("drop", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_ne!(err.code, -32601);
     }
@@ -507,7 +576,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_get_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.get", None, &engine, None).await;
+        let result = dispatch("storage.get", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -516,7 +585,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_set_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.set", None, &engine, None).await;
+        let result = dispatch("storage.set", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -525,7 +594,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_list_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.list", None, &engine, None).await;
+        let result = dispatch("storage.list", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -534,7 +603,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.clear", None, &engine, None).await;
+        let result = dispatch("storage.clear", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -593,9 +662,53 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_forms_dump_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("forms.dump", None, &engine, None).await;
+        let result = dispatch("forms.dump", None, &engine, None, None).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_windows_list_without_list_fn() {
+        let engine = EvalEngine::new();
+        let result = dispatch("windows.list", None, &engine, None, None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No window manager"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_windows_list_with_list_fn() {
+        let engine = EvalEngine::new();
+        let list_fn: crate::server::ListWindowsFn = std::sync::Arc::new(
+            || serde_json::json!({"windows": [{"label": "main", "url": "http://localhost", "title": "Test"}]}),
+        );
+        let result = dispatch("windows.list", None, &engine, None, Some(&list_fn)).await;
+        let val = result.unwrap();
+        let windows = val.get("windows").unwrap().as_array().unwrap();
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].get("label").unwrap(), "main");
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_window_param_extracted_from_params() {
+        let engine = EvalEngine::new();
+        // The "window" key must be stripped before being forwarded to the bridge.
+        // We verify this by inspecting the script received by eval_fn.
+        let captured: std::sync::Arc<std::sync::Mutex<String>> =
+            std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let captured_clone = captured.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, script: String| {
+                *captured_clone.lock().unwrap() = script;
+                Ok(())
+            });
+        let params = serde_json::json!({"ref": "el-1", "window": "settings"});
+        // snapshot will try to eval — it won't complete (no callback), but the script is captured.
+        let _ = dispatch("click", Some(&params), &engine, Some(&eval_fn), None).await;
+        let script = captured.lock().unwrap().clone();
+        // "window" param must not appear in the JS call args
+        assert!(!script.contains("\"window\""));
+        assert!(script.contains("\"ref\""));
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -698,13 +698,16 @@ mod tests {
         let captured: std::sync::Arc<std::sync::Mutex<String>> =
             std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let captured_clone = captured.clone();
+        let engine_clone = engine.clone();
         let eval_fn: crate::server::EvalFn =
             std::sync::Arc::new(move |_w: Option<&str>, script: String| {
                 *captured_clone.lock().unwrap() = script;
+                // Resolve the callback immediately to avoid blocking for the default 10s timeout.
+                // ID 1 is the first registered callback on a fresh EvalEngine.
+                engine_clone.resolve(1, Ok(serde_json::json!({"ok": true})));
                 Ok(())
             });
         let params = serde_json::json!({"ref": "el-1", "window": "settings"});
-        // snapshot will try to eval — it won't complete (no callback), but the script is captured.
         let _ = dispatch("click", Some(&params), &engine, Some(&eval_fn), None).await;
         let script = captured.lock().unwrap().clone();
         // "window" param must not appear in the JS call args

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -12,7 +12,7 @@ pub use error::Error;
 #[cfg(unix)]
 use eval::EvalEngine;
 #[cfg(unix)]
-use server::EvalFn;
+use server::{EvalFn, ListWindowsFn};
 #[cfg(unix)]
 use std::sync::Arc;
 #[cfg(unix)]
@@ -50,13 +50,20 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                     std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
 
                 let eval_fn = make_eval_fn(app);
+                let list_fn = make_list_fn(app);
 
                 let (listener, guard) = server::bind(&socket_path).map_err(|e| {
                     tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
                     e
                 })?;
 
-                tauri::async_runtime::spawn(server::run(listener, guard, engine, Some(eval_fn)));
+                tauri::async_runtime::spawn(server::run(
+                    listener,
+                    guard,
+                    engine,
+                    Some(eval_fn),
+                    Some(list_fn),
+                ));
 
                 Ok(())
             })
@@ -88,21 +95,49 @@ fn sanitize_identifier(raw: &str) -> String {
 
 /// Create an eval function from the app handle that evaluates JS in a webview.
 ///
-/// Tries the "main" window label first for deterministic targeting,
-/// falls back to the first available window if "main" doesn't exist.
+/// If `window` is `Some(label)`, targets that specific window (error if not found).
+/// If `window` is `None`, tries "main" first then falls back to the first available window.
 #[cfg(all(unix, debug_assertions))]
 fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
     let handle = app.clone();
-    Arc::new(move |script| {
+    Arc::new(move |window: Option<&str>, script: String| {
+        if let Some(label) = window {
+            return handle
+                .get_webview_window(label)
+                .ok_or_else(|| format!("Window '{label}' not found"))
+                .and_then(|w| w.eval(&script).map_err(|e| e.to_string()));
+        }
         if let Some(w) = handle.get_webview_window("main") {
             return w.eval(&script).map_err(|e| e.to_string());
         }
         let windows = handle.webview_windows();
-        let window = windows
+        windows
             .values()
             .next()
-            .ok_or_else(|| "No webview window available".to_owned())?;
-        window.eval(&script).map_err(|e| e.to_string())
+            .ok_or_else(|| "No webview available".to_owned())
+            .and_then(|w| w.eval(&script).map_err(|e| e.to_string()))
+    })
+}
+
+/// Create a list function that enumerates all available webview windows.
+#[cfg(all(unix, debug_assertions))]
+fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
+    let handle = app.clone();
+    Arc::new(move || {
+        let windows = handle.webview_windows();
+        let mut entries: Vec<_> = windows.iter().collect();
+        entries.sort_by_key(|(label, _)| (*label).clone());
+        let list: Vec<serde_json::Value> = entries
+            .iter()
+            .map(|(label, wv)| {
+                serde_json::json!({
+                    "label": label,
+                    "url": wv.url().map(|u| u.to_string()).unwrap_or_default(),
+                    "title": wv.title().unwrap_or_default(),
+                })
+            })
+            .collect();
+        serde_json::json!({"windows": list})
     })
 }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -125,9 +125,8 @@ fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
     let handle = app.clone();
     Arc::new(move || {
         let windows = handle.webview_windows();
-        let mut entries: Vec<_> = windows.iter().collect();
-        entries.sort_by_key(|(label, _)| (*label).clone());
-        let list: Vec<serde_json::Value> = entries
+        // BTreeMap iterates in sorted key order — no explicit sort needed
+        let list: Vec<serde_json::Value> = windows
             .iter()
             .map(|(label, wv)| {
                 serde_json::json!({

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -8,8 +8,12 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-/// A function that evaluates JS in the webview. `None` if no webview is available.
-pub(crate) type EvalFn = Arc<dyn Fn(String) -> Result<(), String> + Send + Sync>;
+/// A function that evaluates JS in the webview.
+/// The first argument is an optional window label (`None` means "use default window").
+pub(crate) type EvalFn = Arc<dyn Fn(Option<&str>, String) -> Result<(), String> + Send + Sync>;
+
+/// A function that lists all available webview windows and returns their metadata.
+pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;
 
 /// RAII guard that removes the socket file on drop (normal shutdown or panic).
 /// Stores the inode at bind time so it only unlinks its own socket, not one
@@ -103,6 +107,7 @@ pub(crate) async fn run(
     _guard: SocketGuard,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
+    list_fn: Option<ListWindowsFn>,
 ) {
     let listener = match UnixListener::from_std(std_listener) {
         Ok(l) => l,
@@ -111,7 +116,7 @@ pub(crate) async fn run(
             return;
         }
     };
-    if let Err(e) = accept_loop(listener, engine, eval_fn).await {
+    if let Err(e) = accept_loop(listener, engine, eval_fn, list_fn).await {
         tracing::error!("socket server error: {e}");
     }
 }
@@ -120,8 +125,9 @@ async fn accept_loop(
     listener: UnixListener,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
+    list_fn: Option<ListWindowsFn>,
 ) -> Result<(), Error> {
-    let ctx = Arc::new((engine, eval_fn));
+    let ctx = Arc::new((engine, eval_fn, list_fn));
 
     loop {
         let (stream, _addr) = match listener.accept().await {
@@ -133,7 +139,8 @@ async fn accept_loop(
         };
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, &ctx.0, ctx.1.as_ref()).await {
+            if let Err(e) = handle_connection(stream, &ctx.0, ctx.1.as_ref(), ctx.2.as_ref()).await
+            {
                 tracing::warn!("connection error: {e}");
             }
         });
@@ -144,6 +151,7 @@ async fn handle_connection(
     stream: UnixStream,
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
+    list_fn: Option<&ListWindowsFn>,
 ) -> Result<(), Error> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -167,7 +175,7 @@ async fn handle_connection(
                 -32600,
                 "Invalid JSON-RPC version (expected \"2.0\")",
             ),
-            Ok(req) => dispatch(&req, engine, eval_fn).await,
+            Ok(req) => dispatch(&req, engine, eval_fn, list_fn).await,
             Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
         };
 
@@ -180,8 +188,13 @@ async fn handle_connection(
     Ok(())
 }
 
-async fn dispatch(req: &Request, engine: &EvalEngine, eval_fn: Option<&EvalFn>) -> Response {
-    match handler::dispatch(&req.method, req.params.as_ref(), engine, eval_fn).await {
+async fn dispatch(
+    req: &Request,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+    list_fn: Option<&ListWindowsFn>,
+) -> Response {
+    match handler::dispatch(&req.method, req.params.as_ref(), engine, eval_fn, list_fn).await {
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {
             jsonrpc: "2.0".to_owned(),
@@ -212,7 +225,7 @@ mod tests {
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let (listener, guard) = bind(path).expect("bind test socket");
         let engine = EvalEngine::new();
-        let handle = tokio::spawn(async move { run(listener, guard, engine, None).await });
+        let handle = tokio::spawn(async move { run(listener, guard, engine, None, None).await });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
     }

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -50,9 +50,15 @@ cargo install tauri-pilot-cli
 # Check connection
 tauri-pilot ping
 
+# List open windows (multi-window apps)
+tauri-pilot windows
+
 # Inspect the UI
 tauri-pilot snapshot -i          # interactive elements only
 tauri-pilot snapshot -s "#sidebar"  # scoped to a CSS selector
+
+# Target a specific window
+tauri-pilot --window settings snapshot -i
 
 # Interact
 tauri-pilot click @e3

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -100,6 +100,27 @@ tauri-pilot assert url "/dashboard"                # URL substring
 tauri-pilot snapshot -i -s "#main-content"
 ```
 
+## Multi-window apps
+
+For Tauri apps with multiple windows, use `tauri-pilot windows` to discover available windows and `--window <label>` to target a specific one:
+
+```bash
+# List all windows
+tauri-pilot windows
+# main      http://localhost:1420/        My App
+# settings  http://localhost:1420/settings Settings
+
+# Target a specific window
+tauri-pilot --window settings snapshot -i
+tauri-pilot --window settings fill @e2 "new-value"
+
+# Or set via environment variable
+export TAURI_PILOT_WINDOW=settings
+tauri-pilot snapshot -i
+```
+
+Without `--window`, all commands target the `main` window (or the first available). The window flag works with every command including `--follow` mode and `ipc`.
+
 ## Integration with Claude Code
 
 tauri-pilot is designed to be used as a tool by Claude Code directly:

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -62,7 +62,7 @@ The protocol is implemented with three hand-rolled serde structs (~50 lines tota
 | `Response` | `jsonrpc`, `id`, `result?`, `error?` |
 | `RpcError` | `code`, `message`, `data?` |
 
-29 methods are available: `ping`, `snapshot`, `diff`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`, `eval`, `screenshot`, `text`, `html`, `value`, `attrs`, `visible`, `count`, `checked`, `wait`, `navigate`, `url`, `title`, `state`, `ipc`, `console.getLogs`, `console.clear`, `network.getRequests`, `network.clear`.
+38 methods are available: `ping`, `windows.list`, `snapshot`, `diff`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`, `drag`, `drop`, `eval`, `screenshot`, `text`, `html`, `value`, `attrs`, `visible`, `count`, `checked`, `wait`, `watch`, `navigate`, `url`, `title`, `state`, `ipc`, `console.getLogs`, `console.clear`, `network.getRequests`, `network.clear`, `storage.get`, `storage.set`, `storage.list`, `storage.clear`, `forms.dump`.
 
 ## Element Reference System
 
@@ -80,6 +80,12 @@ tauri-pilot click @e3         # clicks the element with ref e3
 tauri-pilot fill @e5 "hello"  # fills the input at e5
 ```
 
+## Multi-Window Support
+
+The plugin supports Tauri apps with multiple windows. When a JSON-RPC request includes a `"window"` parameter, the plugin resolves the target window by label via `AppHandle::get_webview_window(label)`. Without the parameter, it falls back to `"main"` then the first available window.
+
+The `windows.list` method enumerates all open windows (label, URL, title), sorted by label for deterministic output. From the CLI, use `--window <label>` to target a specific window, or `tauri-pilot windows` to list them.
+
 ## Eval + Callback Pattern (ADR-001)
 
 `webview.eval()` in Tauri v2 is **fire-and-forget** — it dispatches JS into the WebView but provides no return value. All methods that read from the page require a response, so a callback pattern is used:
@@ -92,6 +98,8 @@ tauri-pilot fill @e5 "hello"  # fills the input at e5
 The `EvalEngine` maintains:
 - A `HashMap<u64, oneshot::Sender<Result<Value, String>>>` for in-flight requests
 - An `AtomicU64` counter for request IDs
+
+The eval function dynamically resolves the target window on each call — it captures the `AppHandle` and looks up the window by label at eval time, rather than binding to a single window at startup. This allows targeting different windows across requests.
 
 This makes every eval effectively async and type-safe from the Rust side.
 

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -82,7 +82,7 @@ tauri-pilot fill @e5 "hello"  # fills the input at e5
 
 ## Multi-Window Support
 
-The plugin supports Tauri apps with multiple windows. When a JSON-RPC request includes a `"window"` parameter, the plugin resolves the target window by label via `AppHandle::get_webview_window(label)`. Without the parameter, it falls back to `"main"` then the first available window.
+The plugin supports Tauri apps with multiple windows. When a JSON-RPC request includes a `"window"` parameter, the plugin resolves the target window by label via `AppHandle::get_webview_window(label)`. If the label is present but invalid or doesn't match any open window, the request returns a "Window '{label}' not found" error — it does **not** fall back to the default. Without the parameter, it falls back to `"main"` then the first available window.
 
 The `windows.list` method enumerates all open windows (label, URL, title), sorted by label for deterministic output. From the CLI, use `--window <label>` to target a specific window, or `tauri-pilot windows` to list them.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -12,6 +12,7 @@ These options can be used with any command.
 | Option | Description |
 |--------|-------------|
 | `--socket <path>` | Explicit path to the Unix socket. Auto-detected if omitted. Env: `TAURI_PILOT_SOCKET` |
+| `--window <label>` | Target a specific window by label. Env: `TAURI_PILOT_WINDOW`. Default: `main`, falls back to first available |
 | `--json` | Output JSON instead of human-readable text |
 
 ### Socket Auto-Detection
@@ -21,6 +22,18 @@ When `--socket` is not specified, the CLI resolves the socket in this priority o
 1. `--socket <path>` — explicit flag (highest priority)
 2. `$TAURI_PILOT_SOCKET` — environment variable
 3. Glob `/tmp/tauri-pilot-*.sock` → most recently modified file (by mtime)
+
+### Window Targeting
+
+The `--window <label>` option (or `TAURI_PILOT_WINDOW` env var) selects which window all commands operate on:
+
+```bash
+tauri-pilot --window settings snapshot    # snapshot the settings window
+tauri-pilot click @e3 --window main       # click in the main window
+TAURI_PILOT_WINDOW=settings tauri-pilot snapshot
+```
+
+If `--window` is not specified, the CLI targets the `main` window and falls back to the first available window. If the specified window label does not exist, the command exits with an error.
 
 ## Target Syntax
 
@@ -51,6 +64,39 @@ tauri-pilot ping
 ```bash
 $ tauri-pilot ping
 ✓ ok
+```
+
+---
+
+### `windows`
+
+List all open windows with their label, URL, and title.
+
+```bash
+tauri-pilot windows
+```
+
+**Example:**
+
+```bash
+$ tauri-pilot windows
+main      http://localhost:1420/dashboard  PR Dashboard
+settings  http://localhost:1420/settings   Settings
+about     http://localhost:1420/about      About
+```
+
+**JSON-RPC example:**
+
+```json
+// Request
+{"jsonrpc":"2.0","id":1,"method":"windows.list","params":{}}
+
+// Response
+{"jsonrpc":"2.0","id":1,"result":{"windows":[
+  {"label":"main","url":"http://localhost:1420/dashboard","title":"PR Dashboard"},
+  {"label":"settings","url":"http://localhost:1420/settings","title":"Settings"},
+  {"label":"about","url":"http://localhost:1420/about","title":"About"}
+]}}
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #14 — Support Tauri apps with multiple windows.

- **Plugin**: `EvalFn` now accepts an optional window label, resolving dynamically via `AppHandle::get_webview_window()`. New `ListWindowsFn` type enumerates all windows sorted by label.
- **Handler**: `dispatch()` extracts and strips `"window"` param before forwarding to JS bridge. New `"windows.list"` method.
- **CLI**: `--window <label>` global flag (env: `TAURI_PILOT_WINDOW`), `tauri-pilot windows` command, `format_windows()` with ANSI-safe column alignment.
- **Backward compat**: Without `--window`, behavior unchanged (targets "main" then first available).

## Changes

| File | What |
|------|------|
| `server.rs` | `EvalFn` signature + `ListWindowsFn` type |
| `lib.rs` | Dynamic window resolution + `make_list_fn()` |
| `handler.rs` | Window extraction, `windows.list` handler |
| `cli.rs` | `--window` global option, `Windows` command |
| `main.rs` | Window injection in all RPC calls incl. follow/ipc |
| `output.rs` | `format_windows()` with column alignment |
| `cli.md` | Documentation for new command + flag |
| `CHANGELOG.md` | Entry under [Unreleased] |

## Test plan

- [x] `cargo test --workspace` — 165/165 passing
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Security review: no JS injection via window label (label never interpolated in JS)
- [x] Logic review: `--window` flows to all command paths including `--follow` and `ipc`
- [ ] Manual: test with multi-window Tauri app

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-window support so every command can target a specific window or list all open windows. Default behavior is unchanged when no window is set (try "main", then the first available).

- New Features
  - Plugin (`tauri-plugin-pilot`): `EvalFn` now accepts an optional window label and resolves via `AppHandle::get_webview_window()`. Added `windows.list` to return all windows (label, URL, title) sorted by label.
  - Handler: `dispatch()` strips `"window"` before JS evaluation and forwards the label. Added `"windows.list"` JSON-RPC method.
  - CLI (`tauri-pilot-cli`): Global `--window <label>` flag (env: `TAURI_PILOT_WINDOW`) and `tauri-pilot windows` command. The window flows through all commands, including `--follow`, `ipc`, logs, and network.
  - Output: `format_windows()` prints aligned, ANSI-safe columns and strips control characters.

- Bug Fixes
  - Forward `--window` to non-follow `logs`/`network` calls.
  - Safer formatting: compute column widths after stripping ANSI, and drop C0 control chars.
  - Docs: clarified invalid window behavior; added missing `[#14]` link; noted `--session` as a storage-level flag.

<sup>Written for commit 0fb93a7dc3ec140247b33a1b59312664a060c65d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-window support: global --window <label> (env var supported) and windows command to list open windows (label, URL, title)
  * Snapshot persistence and diffing: snapshot --save <file>, diff and diff --ref <file>
  * New interaction commands: drag, drop, watch
  * Storage and forms commands: storage get/set/list/clear, forms

* **Documentation**
  * Updated docs and guides with multi-window usage, examples, and CLI reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->