### PR TITLE
fix(security): restrict Unix socket access to current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Socket hardening** — three layers of defense against local privilege escalation ([#31])
+  - Socket permissions set to `0o600` (owner-only) immediately after bind
+  - `umask(0o177)` guard around bind to eliminate TOCTOU race window
+  - Peer credential (UID) verification rejects connections from other local users
+  - Socket placed in `$XDG_RUNTIME_DIR` (user-private `0o700` directory) with `/tmp` fallback
+  - `XDG_RUNTIME_DIR` validated for ownership and permissions before use
+  - CLI `resolve_socket()` filters candidates by UID ownership
+
 ## [0.2.0] - 2026-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#7]: https://github.com/mpiton/tauri-pilot/issues/7
 [#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
+[#31]: https://github.com/mpiton/tauri-pilot/issues/31

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22.1"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 indicatif = "0.17"
+libc = "0.2.184"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1193,9 +1193,17 @@ fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    // Auto-detect: find the most recent tauri-pilot-*.sock in /tmp
-    let mut candidates: Vec<PathBuf> = std::fs::read_dir("/tmp")
-        .map_err(|e| anyhow::anyhow!("Failed to read /tmp: {e}"))?
+    // Directories to scan: prefer XDG_RUNTIME_DIR, always include /tmp as fallback.
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
+        dirs.push(PathBuf::from(xdg));
+    }
+    dirs.push(PathBuf::from("/tmp"));
+
+    let mut candidates: Vec<PathBuf> = dirs
+        .iter()
+        .filter_map(|dir| std::fs::read_dir(dir).ok())
+        .flatten()
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| {
@@ -1205,6 +1213,14 @@ fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
                         .extension()
                         .is_some_and(|ext| ext.eq_ignore_ascii_case("sock"))
             })
+        })
+        .filter(|p| {
+            use std::os::unix::fs::MetadataExt;
+            // SAFETY: getuid() has no preconditions.
+            let my_uid = unsafe { libc::getuid() };
+            std::fs::metadata(p)
+                .map(|m| m.uid() == my_uid)
+                .unwrap_or(false)
         })
         .collect();
 
@@ -1222,6 +1238,7 @@ fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_mime_from_ext_png() {
@@ -1293,5 +1310,62 @@ mod tests {
     fn test_with_window_none_params_creates_object() {
         let result = with_window(None, Some("main"));
         assert_eq!(result, Some(json!({"window": "main"})));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_socket_finds_socket_in_xdg_runtime_dir() {
+        let dir =
+            std::env::temp_dir().join(format!("tauri-pilot-xdg-cli-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create xdg test dir");
+        let sock = dir.join("tauri-pilot-myapp.sock");
+        // Create a dummy file that looks like a socket name.
+        std::fs::write(&sock, b"").expect("create dummy socket file");
+
+        // SAFETY: serial attribute serializes tests that touch XDG_RUNTIME_DIR.
+        unsafe { std::env::set_var("XDG_RUNTIME_DIR", &dir) };
+        let result = resolve_socket(None);
+        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
+
+        let _ = std::fs::remove_file(&sock);
+        let _ = std::fs::remove_dir(&dir);
+
+        assert_eq!(result.expect("socket found"), sock);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_socket_falls_back_to_tmp_when_xdg_unset() {
+        let tmp_sock = std::path::PathBuf::from(format!(
+            "/tmp/tauri-pilot-fallback-test-{}.sock",
+            std::process::id()
+        ));
+        // Remove then recreate to ensure this file has the newest mtime.
+        let _ = std::fs::remove_file(&tmp_sock);
+        std::fs::write(&tmp_sock, b"").expect("create dummy socket in /tmp");
+
+        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
+        let result = resolve_socket(None);
+
+        let _ = std::fs::remove_file(&tmp_sock);
+
+        // Assert the result is a valid tauri-pilot socket path, not an exact path,
+        // to avoid flakiness if other sockets exist in /tmp with newer mtime.
+        let found = result.expect("socket found in /tmp");
+        let name = found
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("socket has a filename");
+        assert!(
+            name.starts_with("tauri-pilot-") && name.ends_with(".sock"),
+            "expected a tauri-pilot-*.sock path, got: {found:?}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_socket_returns_explicit_path() {
+        let explicit = std::path::PathBuf::from("/tmp/my-explicit.sock");
+        let result = resolve_socket(Some(explicit.clone()));
+        assert_eq!(result.expect("explicit path returned"), explicit);
     }
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -32,7 +32,7 @@ const BRIDGE_JS: &str = concat!(
 ///
 /// On non-Unix platforms or in release builds, returns a no-op plugin.
 /// In debug builds on Unix, injects the JS bridge, stores an `EvalEngine`,
-/// and starts a Unix socket server at `/tmp/tauri-pilot-{identifier}.sock`.
+/// and starts a Unix socket server at `$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock` (falls back to `/tmp` if unavailable).
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     #[cfg(not(all(unix, debug_assertions)))]
@@ -49,8 +49,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 app.manage(engine.clone());
 
                 let identifier = sanitize_identifier(&app.config().identifier);
-                let socket_path =
-                    std::path::PathBuf::from(format!("/tmp/tauri-pilot-{identifier}.sock"));
+                let socket_path = server::socket_path(&identifier);
 
                 let eval_fn = make_eval_fn(app);
                 let list_fn = make_list_fn(app);

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -4,6 +4,7 @@ use crate::handler;
 use crate::protocol::{Request, Response};
 use crate::recorder::Recorder;
 
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -51,6 +52,47 @@ fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
     }
 }
 
+/// Returns true if `path` is a directory owned by the current user with no group/world permissions.
+fn is_private_dir(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match std::fs::metadata(path) {
+        Ok(m) => {
+            // SAFETY: getuid() has no preconditions.
+            let my_uid = unsafe { libc::getuid() };
+            m.uid() == my_uid && m.mode().trailing_zeros() >= 6
+        }
+        Err(_) => false,
+    }
+}
+
+/// Core implementation — accepts the XDG value directly so tests can call it without mutating
+/// the process environment.
+fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
+    if let Some(val) = xdg.filter(|v| !v.is_empty()) {
+        let path = std::path::PathBuf::from(&val);
+        if is_private_dir(&path) {
+            return path;
+        }
+        tracing::warn!(
+            path = %path.display(),
+            "XDG_RUNTIME_DIR is not a private directory, falling back to /tmp"
+        );
+    }
+    std::path::PathBuf::from("/tmp")
+}
+
+/// Returns the directory for the socket file.
+/// Prefers `$XDG_RUNTIME_DIR` when it is a private directory (owned by current user, no
+/// group/world access). Falls back to `/tmp` with a warning if the directory is not private.
+fn socket_dir() -> std::path::PathBuf {
+    socket_dir_from(std::env::var_os("XDG_RUNTIME_DIR"))
+}
+
+/// Build the full socket path for the given app identifier.
+pub(crate) fn socket_path(identifier: &str) -> std::path::PathBuf {
+    socket_dir().join(format!("tauri-pilot-{identifier}.sock"))
+}
+
 /// Bind the socket using the **std** (sync) listener so this can be called
 /// outside a tokio runtime (e.g. from Tauri plugin `setup`).
 ///
@@ -60,7 +102,13 @@ fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
 pub(crate) fn bind(
     socket_path: &std::path::Path,
 ) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
-    let listener = match std::os::unix::net::UnixListener::bind(socket_path) {
+    // SAFETY: umask is always safe to call; we restore the old mask immediately.
+    let old_mask = unsafe { libc::umask(0o177) };
+    let first_bind = std::os::unix::net::UnixListener::bind(socket_path);
+    // SAFETY: restoring the umask we just saved.
+    unsafe { libc::umask(old_mask) };
+
+    let listener = match first_bind {
         Ok(l) => l,
         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
             // Probe: if a live server answers, the socket is truly in use.
@@ -76,7 +124,12 @@ pub(crate) fn bind(
                 Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
                     // Stale socket from a crashed process — safe to remove and retry.
                     let _ = std::fs::remove_file(socket_path);
-                    std::os::unix::net::UnixListener::bind(socket_path)?
+                    // SAFETY: umask is always safe to call; we restore the old mask immediately.
+                    let old_mask = unsafe { libc::umask(0o177) };
+                    let retry_bind = std::os::unix::net::UnixListener::bind(socket_path);
+                    // SAFETY: restoring the umask we just saved.
+                    unsafe { libc::umask(old_mask) };
+                    retry_bind?
                 }
                 Err(e) => {
                     return Err(Error::Io(e));
@@ -85,6 +138,9 @@ pub(crate) fn bind(
         }
         Err(e) => return Err(Error::Io(e)),
     };
+
+    // Restrict socket to owner-only access (defense-in-depth alongside XDG_RUNTIME_DIR).
+    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))?;
 
     // Must be non-blocking for tokio conversion
     listener.set_nonblocking(true)?;
@@ -140,6 +196,25 @@ async fn accept_loop(
                 continue;
             }
         };
+        // Verify the connecting process belongs to the same user.
+        match stream.peer_cred() {
+            Ok(cred) => {
+                // SAFETY: getuid() is always safe to call; it has no preconditions.
+                let my_uid = unsafe { libc::getuid() };
+                if cred.uid() != my_uid {
+                    tracing::warn!(
+                        peer_uid = cred.uid(),
+                        expected_uid = my_uid,
+                        "rejected connection from different user"
+                    );
+                    continue;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("failed to get peer credentials: {e}");
+                continue;
+            }
+        }
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
             if let Err(e) =
@@ -321,5 +396,44 @@ mod tests {
 
         handle.abort();
         let _ = std::fs::remove_file(&socket);
+    }
+
+    #[test]
+    fn test_socket_dir_from_returns_xdg_runtime_dir_when_set_and_private() {
+        use std::os::unix::fs::PermissionsExt;
+        // Create a private temp dir (0o700) to simulate a valid XDG_RUNTIME_DIR.
+        let dir = std::env::temp_dir().join(format!("tauri-pilot-xdg-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let result = socket_dir_from(Some(dir.as_os_str().to_owned()));
+        let _ = std::fs::remove_dir(&dir);
+        assert_eq!(result, dir);
+    }
+
+    #[test]
+    fn test_socket_dir_from_falls_back_to_tmp_when_none() {
+        let result = socket_dir_from(None);
+        assert_eq!(result, std::path::PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn test_socket_dir_from_falls_back_to_tmp_when_empty() {
+        let result = socket_dir_from(Some(std::ffi::OsString::new()));
+        assert_eq!(result, std::path::PathBuf::from("/tmp"));
+    }
+
+    #[tokio::test]
+    async fn test_bind_socket_has_mode_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let socket = unique_socket_path();
+        let (listener, guard) = bind(&socket).expect("bind test socket");
+        let meta = std::fs::metadata(&socket).expect("socket metadata");
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "socket must be owner-only (0o600), got {mode:#o}"
+        );
+        drop(listener);
+        drop(guard);
     }
 }

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -59,7 +59,7 @@ fn is_private_dir(path: &std::path::Path) -> bool {
         Ok(m) => {
             // SAFETY: getuid() has no preconditions.
             let my_uid = unsafe { libc::getuid() };
-            m.uid() == my_uid && m.mode().trailing_zeros() >= 6
+            m.is_dir() && m.uid() == my_uid && m.mode().trailing_zeros() >= 6
         }
         Err(_) => false,
     }


### PR DESCRIPTION
## Summary

Fixes #31 — Unix socket in `/tmp` with no permission restriction allowing any local user to execute arbitrary JS in the webview.

Implements three layers of defense:
- **umask guard**: `umask(0o177)` around `bind()` calls eliminates the TOCTOU race window between socket creation and permission setting
- **Socket permissions**: `chmod 0o600` (owner-only) applied immediately after bind as defense-in-depth
- **Peer credential check**: `stream.peer_cred()` verifies connecting process UID matches server UID; rejects other users silently
- **XDG_RUNTIME_DIR**: socket placed in user-private `$XDG_RUNTIME_DIR` (validated for ownership + mode `0o700`) with `/tmp` fallback
- **CLI hardening**: `resolve_socket()` filters socket candidates by UID ownership to prevent rogue socket injection

### Files changed

| File | Change |
|------|--------|
| `crates/tauri-plugin-pilot/src/server.rs` | `socket_dir_from()`, `is_private_dir()`, umask guard, peer_cred check, 4 new tests |
| `crates/tauri-plugin-pilot/src/lib.rs` | Uses `server::socket_path()` instead of hardcoded `/tmp` |
| `crates/tauri-pilot-cli/src/main.rs` | `resolve_socket()` scans XDG + /tmp, filters by UID |
| `crates/tauri-pilot-cli/Cargo.toml` | Added `libc` dependency for `getuid()` |
| `CHANGELOG.md` | Security section under [Unreleased] |

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — 190 tests pass (102 CLI + 88 plugin)
- [x] New tests: `socket_dir_from` with/without XDG, `bind` permissions `0o600`, CLI XDG resolution
- [ ] Manual: run Tauri app, verify socket appears in `$XDG_RUNTIME_DIR` with `0o600` permissions
- [ ] Manual: attempt connection from different user — should be rejected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the debug Unix socket to the current user to prevent cross-user access and code execution. Fixes #31 by moving the socket to a private runtime dir, enforcing owner-only perms, and verifying client UID.

- **Security**
  - Create sockets with `umask(0o177)` and set mode to `0o600` after bind.
  - Prefer `$XDG_RUNTIME_DIR` (owned by user, mode `0o700`, and a directory); fall back to `/tmp`.
  - Check `peer_cred()` on every connection; reject non-matching UIDs.
  - CLI `resolve_socket()` scans XDG + `/tmp` and only picks sockets owned by the current UID.

- **Dependencies**
  - Add `libc` to `@tauri-pilot-cli` for `getuid()`.

<sup>Written for commit c8d374b56065007fedcbaea010f6c06743b533f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Socket access hardened to owner-only permissions.
  * Incoming connections are validated to reject other local users.
  * Socket files are placed in the user runtime directory (with a secure private-directory check) and fall back to /tmp when needed.

* **Improvements**
  * CLI socket discovery now only considers sockets owned by the current user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->