### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-05
+
 ### Security
 
 - **Socket hardening** — three layers of defense against local privilege escalation ([#31])
@@ -121,7 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#12]: https://github.com/mpiton/tauri-pilot/issues/12
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.2.0
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
 [#9]: https://github.com/mpiton/tauri-pilot/issues/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.2.0
+[0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
 [#9]: https://github.com/mpiton/tauri-pilot/issues/9
 [#1]: https://github.com/mpiton/tauri-pilot/pull/1

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Bump version from 0.2.0 to 0.2.1 in both crate Cargo.toml files
- Move `[Unreleased]` changelog entries into `[0.2.1] - 2026-04-05` section
- Update comparison links

## What's in this release

### Security

- **Socket hardening** — three layers of defense against local privilege escalation (#31)
  - Socket permissions `0o600` (owner-only) immediately after bind
  - `umask(0o177)` guard around bind to eliminate TOCTOU race window
  - Peer credential (UID) verification rejects connections from other local users
  - Socket placed in `$XDG_RUNTIME_DIR` (user-private `0o700` directory) with `/tmp` fallback
  - CLI `resolve_socket()` filters candidates by UID ownership

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] 88 tests pass
- [x] `cargo fmt` no changes

## Post-merge

After merging, tag the release:
```bash
git checkout main && git pull
git tag -a v0.2.1 -m "Release v0.2.1"
git push --tags
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.2.1: bump `tauri-pilot-cli` and `tauri-plugin-pilot` to 0.2.1 and finalize the changelog with correct compare links. This release hardens the local socket to prevent privilege escalation.

- **New Features**
  - Set socket permissions to 0600 and wrap bind with `umask(0o177)` to close the race window.
  - Verify peer UID; reject non-owner connections.
  - Use $XDG_RUNTIME_DIR (0o700) with /tmp fallback; CLI resolve_socket() only accepts sockets owned by the current UID.

<sup>Written for commit be6af0afd8b98e167fdafac73f9d018aaaaf38cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Socket hardening improvements implemented to strengthen connection handling.

* **Chores**
  * Release prepared and version bumped to 0.2.1, with changelog updated to include the new release entry and compare references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->