### PR TITLE
feat: make skill available via skills.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ fn main() {
 cargo install tauri-pilot
 ```
 
+Optionally, make it available to your Agent:
+
+```bash
+npx skills add https://github.com/mpiton/tauri-pilot
+```
+
 ### 3. Use it
 
 ```bash


### PR DESCRIPTION
## Summary

Add a line in `README.md` to signal the project's skill is installable via skills.sh

-

## Motivation

This change will signal potential users that the tool is straightforward to integrate it into their workflow. Using the `skills` skills.sh CLI tool makes it available to any Coding Agent (CC, OpenCode, etc.)

## Changes

5 new lines in @README.md were added to note that `tauri-pilot` skill is installable via `npx skills`.

## Test Plan

Only @README.md was updated - no code changes were made.

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Tested manually with a Tauri app (if applicable)

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add README instructions to install the `tauri-pilot` skill via the `skills` CLI (`npx skills add https://github.com/mpiton/tauri-pilot`) so agents can integrate it with one command.

<sup>Written for commit 9c806ec0c1970e5dd629a156548f6fff150726b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional setup instructions for making the tool available to your Agent using `npx skills add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->