### PR TITLE
feat: macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     name: Check & Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,15 @@ env:
 jobs:
   check:
     name: Check & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **macOS support** — CI verification on macOS, updated documentation and platform requirements ([#37])
+
 ## [0.2.1] - 2026-04-05
 
 ### Security
@@ -123,6 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#12]: https://github.com/mpiton/tauri-pilot/issues/12
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
+[#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ fn main() {
 >   "permissions": ["core:default", "pilot:default"]
 > }
 > ```
+>
+> Without `pilot:default`, eval commands fail with: `eval timed out after 10s`.
 
 ### 2. Install the CLI
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://crates.io/crates/tauri-plugin-pilot"><img src="https://img.shields.io/crates/v/tauri-plugin-pilot.svg" alt="crates.io"></a>
   <a href="https://github.com/mpiton/tauri-pilot/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/rust-1.94.1+-orange.svg" alt="Rust 1.94.1+">
-  <img src="https://img.shields.io/badge/platform-linux-lightgrey.svg" alt="Platform: Linux">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS-lightgrey.svg" alt="Platform: Linux | macOS">
   <img src="https://img.shields.io/badge/tauri-v2-24C8D8.svg" alt="Tauri v2">
 </p>
 
@@ -38,7 +38,7 @@ ok
 
 ## Why?
 
-There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't work (Tauri uses WebKitGTK, not Chromium). tauri-pilot bridges this gap with a lightweight plugin + CLI that speaks a protocol optimized for LLM consumption.
+There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't work (Tauri uses system WebViews — WebKitGTK on Linux, WebKit on macOS — not Chromium). tauri-pilot bridges this gap with a lightweight plugin + CLI that speaks a protocol optimized for LLM consumption.
 
 ## How it works
 
@@ -51,7 +51,7 @@ There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't
                                    │  │  JS Bridge (injected)│   │
                                    │  │  window.__PILOT__    │   │
                                    │  └─────────────────────┘   │
-                                   │  WebView (WebKitGTK)        │
+                                   │  WebView                    │
                                    └─────────────────────────────┘
 ```
 
@@ -82,6 +82,15 @@ fn main() {
     builder.run(tauri::generate_context!()).expect("error running app");
 }
 ```
+
+> **Required capability** — add `pilot:default` to your app's capability file
+> (e.g. `src-tauri/capabilities/default.json`):
+>
+> ```json
+> {
+>   "permissions": ["core:default", "pilot:default"]
+> }
+> ```
 
 ### 2. Install the CLI
 
@@ -167,7 +176,7 @@ Use `--json` for structured output when parsing programmatically.
 
 ## Requirements
 
-- **Linux** (WebKitGTK) — macOS/Windows planned
+- **Linux** (WebKitGTK) or **macOS** (WebKit) — Windows planned
 - **Tauri v2** (v1 not supported)
 - **Rust 1.94.1+** (LTS, edition 2024)
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -38,7 +38,19 @@ fn main() {
 }
 ```
 
-### 3. Install the CLI
+### 3. Add the required capability
+
+Add `pilot:default` to your app's capability file (e.g. `src-tauri/capabilities/default.json`):
+
+```json
+{
+  "permissions": ["core:default", "pilot:default"]
+}
+```
+
+Without this permission, eval commands fail with: `eval timed out after 10s`.
+
+### 4. Install the CLI
 
 ```bash
 cargo install tauri-pilot-cli

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -5,7 +5,7 @@ description: Install tauri-pilot and start testing your Tauri v2 app interactive
 
 ## Requirements
 
-- Linux (WebKitGTK) — macOS/Windows planned
+- Linux (WebKitGTK) or macOS (WebKit) — Windows planned
 - Tauri v2 (v1 not supported)
 - Rust 1.94.0+ (edition 2024)
 

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -16,7 +16,7 @@ This page explains how the different components of tauri-pilot fit together and 
                                    │  │  JS Bridge (injected)│   │
                                    │  │  window.__PILOT__    │   │
                                    │  └─────────────────────┘   │
-                                   │  WebView (WebKitGTK)        │
+                                   │  WebView                    │
                                    └─────────────────────────────┘
 ```
 

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -62,15 +62,15 @@ The CLI auto-discovers this socket when you run commands.
 
 ## 5. Permissions
 
-The plugin operates through the standard Plugin API and WebView eval. It ships a default permission (`allow-callback`) for its internal `__callback` IPC command. If your app enforces Tauri capabilities, add the plugin's permission set to your `tauri.conf.json`:
+The plugin requires the `pilot:default` permission for its internal `__callback` IPC command. Add it to your capability file (e.g. `src-tauri/capabilities/default.json`):
 
 ```json
 {
-  "permissions": ["pilot:default"]
+  "permissions": ["core:default", "pilot:default"]
 }
 ```
 
-Most apps using the default Tauri capability configuration will not need any manual permission entries.
+Without this permission, eval commands will time out with "eval timed out after 10s".
 
 ## 6. Verify the setup
 


### PR DESCRIPTION
## Summary

- Add macOS to CI test matrix (`ubuntu-latest` + `macos-latest`)
- Update platform badge, README requirements, and "Why?" section for macOS
- Document `pilot:default` capability as **required** (not optional) with timeout error message
- Update documentation site (getting-started, architecture, plugin-setup)
- Add CHANGELOG entry under [Unreleased]

No Rust code changes — `#[cfg(unix)]` already covers macOS. This is purely CI + docs.

Closes #37

## Test plan

- [ ] CI passes on both `ubuntu-latest` and `macos-latest`
- [ ] `cargo test --workspace` passes locally
- [ ] `cargo clippy --workspace` passes locally
- [ ] Documentation renders correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add macOS support across CI and docs. We now test on `macos-latest` (matrix with `fail-fast: false`) and document macOS as supported; closes #37.

- **New Features**
  - CI matrix runs on `ubuntu-latest` and `macos-latest` with `fail-fast: false`; Linux-only packages install only on Linux.
  - Docs updated for macOS (badge, requirements, architecture wording) and guides include the required capability step and timeout message; CHANGELOG updated. No Rust changes (`#[cfg(unix)]` already covers macOS).

- **Migration**
  - Add `pilot:default` alongside `core:default` to your app’s capability file to avoid eval timeouts ("eval timed out after 10s").

<sup>Written for commit d2b3563421ace539512cb8042e2ad9d41974b39f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS support with WebKit-based WebView.

* **Documentation**
  * Updated platform support and architecture wording to include macOS.
  * Clarified permission requirements, specifying the pilot:default capability and noting eval timeout without it.
  * Updated changelog and guides to document macOS support.

* **CI/CD**
  * CI expanded to run verification on both Linux and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->