### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-10
+
 ### Added
 
 - **macOS support** — CI verification on macOS, updated documentation and platform requirements ([#37])
@@ -128,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
@@ -142,3 +144,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
+[0.3.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,4 +144,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
-[0.3.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.3.0
+[0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Bump all crate versions from 0.2.1 to 0.3.0
- Finalize CHANGELOG.md with release date

## Changes since v0.2.1

- **macOS support** — CI verification on macOS, updated documentation and platform requirements (#37, #38)

## Test plan

- [x] `cargo test --workspace` — 190 tests passing
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --all` — clean
- [ ] After merge: `git tag -a v0.3.0 -m "Release v0.3.0" && git push --tags`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v0.3.0 release by bumping `tauri-pilot-cli` and `tauri-plugin-pilot` to 0.3.0, finalizing the changelog with the release date, and fixing the 0.3.0 compare link. v0.3.0 highlights macOS support verified in CI and updated platform requirements.

<sup>Written for commit c07355966be3fd00659dd3e0687a8fb19dc73b92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.0.
  * Updated changelog to add a 0.3.0 release section and adjusted the compare link to reference v0.3.0.
  * Bumped package versions across CLI and plugin components to 0.3.0 to align with the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->