### PR TITLE
feat(eval): support reading script from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
+
 ## [0.3.0] - 2026-04-10
 
 ### Added
@@ -130,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#11]: https://github.com/mpiton/tauri-pilot/issues/11
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
+[#41]: https://github.com/mpiton/tauri-pilot/pull/41
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -98,7 +98,11 @@ pub(crate) enum Command {
     /// Get all attributes of an element.
     Attrs { target: String },
     /// Evaluate arbitrary JavaScript.
-    Eval { script: String },
+    /// Pass `-` as the script or omit it to read from stdin.
+    Eval {
+        /// JavaScript to evaluate. Use `-` or omit to read from stdin.
+        script: Option<String>,
+    },
     /// Invoke a Tauri IPC command.
     Ipc {
         command: String,
@@ -765,6 +769,51 @@ mod tests {
         assert_eq!(cli.window, Some("main".to_owned()));
         unsafe {
             std::env::remove_var("TAURI_PILOT_WINDOW");
+        }
+    }
+
+    #[test]
+    fn test_parse_eval_with_script_containing_quotes() {
+        // Scripts with double quotes are the primary motivation for stdin support —
+        // the shell would mangle them if passed as a CLI argument.
+        let script = r#"document.querySelector('[data-id="main"]').textContent"#;
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "eval",
+            script,
+        ]);
+        if let Command::Eval { script: parsed } = cli.command {
+            assert_eq!(parsed, Some(script.to_owned()));
+        } else {
+            panic!("Expected Eval command");
+        }
+    }
+
+    #[test]
+    fn test_parse_eval_dash_reads_stdin() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "eval",
+            "-",
+        ]);
+        if let Command::Eval { script } = cli.command {
+            assert_eq!(script, Some("-".to_owned()));
+        } else {
+            panic!("Expected Eval command with dash");
+        }
+    }
+
+    #[test]
+    fn test_parse_eval_no_arg_reads_stdin() {
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "eval"]);
+        if let Command::Eval { script } = cli.command {
+            assert_eq!(script, None);
+        } else {
+            panic!("Expected Eval command with no script");
         }
     }
 

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -777,13 +777,7 @@ mod tests {
         // Scripts with double quotes are the primary motivation for stdin support —
         // the shell would mangle them if passed as a CLI argument.
         let script = r#"document.querySelector('[data-id="main"]').textContent"#;
-        let cli = Cli::parse_from([
-            "tauri-pilot",
-            "--socket",
-            "/tmp/test.sock",
-            "eval",
-            script,
-        ]);
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "eval", script]);
         if let Command::Eval { script: parsed } = cli.command {
             assert_eq!(parsed, Some(script.to_owned()));
         } else {
@@ -793,13 +787,7 @@ mod tests {
 
     #[test]
     fn test_parse_eval_dash_reads_stdin() {
-        let cli = Cli::parse_from([
-            "tauri-pilot",
-            "--socket",
-            "/tmp/test.sock",
-            "eval",
-            "-",
-        ]);
+        let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "eval", "-"]);
         if let Command::Eval { script } = cli.command {
             assert_eq!(script, Some("-".to_owned()));
         } else {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -540,6 +540,15 @@ async fn run_dom_command(
                 .await
         }
         Command::Eval { script } => {
+            let script = match script.as_deref() {
+                None | Some("-") => {
+                    use std::io::Read;
+                    let mut s = String::new();
+                    std::io::stdin().read_to_string(&mut s).context("reading script from stdin")?;
+                    s
+                }
+                Some(s) => s.to_owned(),
+            };
             client
                 .call("eval", with_window(Some(json!({"script": script})), window))
                 .await

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -469,6 +469,13 @@ async fn run_diff_command(
     client.call("diff", with_window(Some(params), window)).await
 }
 
+fn read_script(reader: &mut impl std::io::Read) -> Result<String> {
+    let mut s = String::new();
+    reader.read_to_string(&mut s).context("reading script from stdin")?;
+    anyhow::ensure!(!s.trim().is_empty(), "script read from stdin is empty or blank");
+    Ok(s)
+}
+
 async fn run_dom_command(
     client: &mut Client,
     command: Command,
@@ -541,12 +548,7 @@ async fn run_dom_command(
         }
         Command::Eval { script } => {
             let script = match script.as_deref() {
-                None | Some("-") => {
-                    use std::io::Read;
-                    let mut s = String::new();
-                    std::io::stdin().read_to_string(&mut s).context("reading script from stdin")?;
-                    s
-                }
+                None | Some("-") => read_script(&mut std::io::stdin())?,
                 Some(s) => s.to_owned(),
             };
             client
@@ -1376,5 +1378,25 @@ mod tests {
         let explicit = std::path::PathBuf::from("/tmp/my-explicit.sock");
         let result = resolve_socket(Some(explicit.clone()));
         assert_eq!(result.expect("explicit path returned"), explicit);
+    }
+
+    #[test]
+    fn test_read_script_valid() {
+        let mut reader = std::io::Cursor::new(b"document.title");
+        assert_eq!(read_script(&mut reader).unwrap(), "document.title");
+    }
+
+    #[test]
+    fn test_read_script_empty_errors() {
+        let mut reader = std::io::Cursor::new(b"");
+        let err = read_script(&mut reader).unwrap_err();
+        assert!(err.to_string().contains("empty or blank"), "got: {err}");
+    }
+
+    #[test]
+    fn test_read_script_blank_errors() {
+        let mut reader = std::io::Cursor::new(b"   \n  ");
+        let err = read_script(&mut reader).unwrap_err();
+        assert!(err.to_string().contains("empty or blank"), "got: {err}");
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -481,6 +481,26 @@ fn read_script(reader: &mut impl std::io::Read) -> Result<String> {
     Ok(s)
 }
 
+async fn handle_eval(
+    client: &mut Client,
+    script: Option<String>,
+    window: Option<&str>,
+) -> Result<Value> {
+    let script = match script.as_deref() {
+        None | Some("-") => {
+            anyhow::ensure!(
+                !std::io::stdin().is_terminal(),
+                "stdin is a terminal: pass a script as argument or pipe it in"
+            );
+            read_script(&mut std::io::stdin())?
+        }
+        Some(s) => s.to_owned(),
+    };
+    client
+        .call("eval", with_window(Some(json!({"script": script})), window))
+        .await
+}
+
 async fn run_dom_command(
     client: &mut Client,
     command: Command,
@@ -551,21 +571,7 @@ async fn run_dom_command(
                 .call("attrs", with_window(Some(target_params(&target)), window))
                 .await
         }
-        Command::Eval { script } => {
-            let script = match script.as_deref() {
-                None | Some("-") => {
-                    anyhow::ensure!(
-                        !std::io::stdin().is_terminal(),
-                        "stdin is a terminal: pass a script as argument or pipe it in"
-                    );
-                    read_script(&mut std::io::stdin())?
-                }
-                Some(s) => s.to_owned(),
-            };
-            client
-                .call("eval", with_window(Some(json!({"script": script})), window))
-                .await
-        }
+        Command::Eval { script } => handle_eval(client, script, window).await,
         Command::Drag {
             source,
             target,

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -471,8 +471,13 @@ async fn run_diff_command(
 
 fn read_script(reader: &mut impl std::io::Read) -> Result<String> {
     let mut s = String::new();
-    reader.read_to_string(&mut s).context("reading script from stdin")?;
-    anyhow::ensure!(!s.trim().is_empty(), "script read from stdin is empty or blank");
+    reader
+        .read_to_string(&mut s)
+        .context("reading script from stdin")?;
+    anyhow::ensure!(
+        !s.trim().is_empty(),
+        "script read from stdin is empty or blank"
+    );
     Ok(s)
 }
 
@@ -548,7 +553,13 @@ async fn run_dom_command(
         }
         Command::Eval { script } => {
             let script = match script.as_deref() {
-                None | Some("-") => read_script(&mut std::io::stdin())?,
+                None | Some("-") => {
+                    anyhow::ensure!(
+                        !std::io::stdin().is_terminal(),
+                        "stdin is a terminal: pass a script as argument or pipe it in"
+                    );
+                    read_script(&mut std::io::stdin())?
+                }
                 Some(s) => s.to_owned(),
             };
             client


### PR DESCRIPTION
Hello,

Thanks for making and shring this tool incredibly helpful in the absence of playwright compatibility. 

One thing I noticed while trying this out is agents struggle/stumble with escaping I found that adding stdin support to the eval command (and instructing to use it in my skill) really made a difference in the success rate.

I'm new to rust so this PR may not be the best approach, but decided to share it at least for the concept.

## Summary

- `eval` now accepts `-` or no argument to read the JavaScript from stdin
- Avoids shell escaping issues for scripts containing double quotes or other special characters (e.g. `document.querySelector('[data-id="main"]').textContent`)
- Inline script argument still works as before

## Test plan

- [ ] `test_parse_eval_with_script_containing_quotes` — inline script with embedded double quotes parses correctly
- [ ] `test_parse_eval_dash_reads_stdin` — `-` sentinel is preserved through CLI parsing
- [ ] `test_parse_eval_no_arg_reads_stdin` — omitting the argument yields `None`, triggering stdin read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The eval command’s script argument is now optional: pass a script inline, use `-` to indicate stdin, or omit the argument to read from stdin.
* **Bug Fixes**
  * Reading a script from stdin now rejects empty or whitespace-only input.
* **Tests**
  * Added unit tests covering CLI parsing (including quotes and `-`) and stdin reading behavior.
* **Documentation**
  * Changelog updated to document stdin support for eval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->