### PR TITLE
fix: wrong cli crate name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ fn main() {
 ### 2. Install the CLI
 
 ```bash
-cargo install tauri-pilot
+cargo install tauri-pilot-cli
 ```
 
 Optionally, make it available to your Agent:


### PR DESCRIPTION
## Summary
- Fix incorrect `cargo install` crate name in README (`tauri-pilot` -> `tauri-pilot-cli`)

## Motivation
The README listed `cargo install tauri-pilot` but the CLI crate is published as `tauri-pilot-cli`, so the install instructions don't work.

## Changes
Updated the install command in `README.md` from `cargo install tauri-pilot` to `cargo install tauri-pilot-cli`.

## Test Plan
- docs change only

## Checklist
- docs change only 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README install command to use the published crate `tauri-pilot-cli` instead of `tauri-pilot`, so `cargo install` works as documented.

<sup>Written for commit f21cd5c34b5c6b579d6707528119f68eb1c8428b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI installation instructions to reflect the correct package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->