### PR TITLE
docs(cli): add eval heredoc examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
+- Stdin heredoc and pipe examples for `eval -` in README, SKILL.md, and CLI reference ([#50])
 
 ## [0.3.0] - 2026-04-10
 
@@ -135,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
+[#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -125,7 +125,18 @@ tauri-pilot press Enter
 tauri-pilot assert text @e1 "Expected text"
 tauri-pilot assert visible @e3
 tauri-pilot wait --selector ".success-message"
+
+# Debug with JavaScript
+tauri-pilot eval "document.title"
+tauri-pilot eval - <<'EOF'
+document.querySelector('[data-id="main"]').textContent
+EOF
+echo 'window.location.pathname' | tauri-pilot eval -
 ```
+
+Use `tauri-pilot eval -` for complex or multi-line scripts. The single-quoted heredoc
+delimiter (`<<'EOF'`) disables shell expansion, so `$`, backticks, and quotes inside
+the JavaScript do not need escaping.
 
 ## Commands
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -133,6 +133,20 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 | `network -f` | Stream requests (follow) |
 | `network --clear` | Flush request buffer |
 
+Use stdin for complex or multi-line JavaScript so selectors, quotes, `$`, and
+backticks do not need shell escaping:
+
+```bash
+tauri-pilot eval - <<'EOF'
+document.querySelector('[data-id="main"]').textContent
+EOF
+
+echo 'document.title' | tauri-pilot eval -
+```
+
+Prefer the single-quoted heredoc delimiter (`<<'EOF'`) because it disables shell
+variable and command expansion inside the script.
+
 ### Record & Replay
 
 | Command | Description |

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -624,7 +624,7 @@ type      = button
 Execute arbitrary JavaScript in the WebView context and return the result.
 
 ```bash
-tauri-pilot eval <script>
+tauri-pilot eval [script|-]
 ```
 
 **Example:**
@@ -636,6 +636,23 @@ PR Dashboard
 $ tauri-pilot eval "window.location.pathname"
 /dashboard
 ```
+
+Use `-` to read JavaScript from stdin. This is useful for complex selectors,
+quotes, Panda CSS class names, or multi-line scripts:
+
+```bash
+$ tauri-pilot eval - <<'EOF'
+document.querySelector('[data-id="main"]').textContent
+EOF
+Main content
+
+$ echo 'document.title' | tauri-pilot eval -
+PR Dashboard
+```
+
+Prefer `<<'EOF'` with quotes around the heredoc delimiter. It disables shell
+variable and command expansion, so `$` and backticks inside the script do not
+need escaping.
 
 ---
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -644,9 +644,11 @@ quotes, Panda CSS class names, or multi-line scripts:
 $ tauri-pilot eval - <<'EOF'
 document.querySelector('[data-id="main"]').textContent
 EOF
+# (output depends on your app)
 Main content
 
 $ echo 'document.title' | tauri-pilot eval -
+# (output depends on your app)
 PR Dashboard
 ```
 


### PR DESCRIPTION
Adds heredoc and pipe examples for passing JavaScript to `tauri-pilot eval -` from stdin.

This fixes #43 by documenting the stdin support added in #41 in the root README, default Claude Code skill, CLI reference, and changelog. It specifically calls out the single-quoted heredoc delimiter so complex selectors, Panda CSS class names, dollar signs, backticks, and quotes can be used without shell escaping.

Fixes #43.

Validated with `git diff --check`, `npm --prefix docs run build`, and `cargo test --workspace` using Rust 1.94.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add heredoc and pipe examples for passing JavaScript to `tauri-pilot eval -` from stdin, and update the CLI usage to `tauri-pilot eval [script|-]`. Explains using a single-quoted heredoc (`<<'EOF'`) to disable shell expansion so complex selectors, Panda CSS classes, `$`, backticks, and quotes work without escaping.

Updates README, `SKILL.md`, CLI reference, and CHANGELOG.

<sup>Written for commit 4961a6944b791d2d205b7cc0d624d23c70192b19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples and guidance for executing complex JavaScript via `tauri-pilot eval` using stdin input (heredoc and piped forms).
  * Documented best practices for shell escaping, including how to use single-quoted delimiters to prevent variable expansion within scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
