### PR TITLE
feat(cli): Add MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
 - Stdin heredoc and pipe examples for `eval -` in README, SKILL.md, and CLI reference ([#50])
+- MCP server mode for exposing tauri-pilot commands as structured tools over stdio ([#51])
 
 ## [0.3.0] - 2026-04-10
 
@@ -137,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
+[#51]: https://github.com/mpiton/tauri-pilot/pull/51
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ tauri-pilot wait --selector ".success-message"
 | `network` | Capture and display network requests |
 | `record` | Record interactions (`start`, `stop --output`, `status`) |
 | `replay` | Replay recorded session (`--export sh` for shell script) |
+| `mcp` | Start a Model Context Protocol server over stdio |
 
 ## For AI Agents
 
@@ -175,6 +176,38 @@ tauri-pilot is designed for AI agent consumption. The workflow is:
 The `assert` command replaces the manual `text @ref` + parse + compare pattern, reducing round-trips and token usage.
 
 Use `--json` for structured output when parsing programmatically.
+
+### MCP server
+
+For agents with native MCP support, run tauri-pilot as a stdio MCP server instead
+of shelling out for each command:
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes the same app-inspection and interaction surface as the CLI:
+`snapshot`, `click`, `fill`, `logs`, `network`, `eval`, `ipc`, `assert_*`, and the
+other testing tools. Use global flags before `mcp` to pin a specific app socket or
+window:
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["--socket", "/tmp/tauri-pilot-myapp.sock", "--window", "main", "mcp"]
+    }
+  }
+}
+```
 
 ## Requirements
 

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22.1"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 indicatif = "0.17"
 libc = "0.2.184"
+rmcp = { version = "1.4.0", default-features = false, features = ["server", "transport-io"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -22,6 +22,8 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
+    /// Start a Model Context Protocol server over stdio.
+    Mcp,
     /// List all open windows
     Windows,
     /// Check connectivity with a running Tauri app.
@@ -742,6 +744,12 @@ mod tests {
     fn test_windows_command() {
         let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "windows"]);
         assert!(matches!(cli.command, Command::Windows));
+    }
+
+    #[test]
+    fn test_mcp_command() {
+        let cli = Cli::parse_from(["tauri-pilot", "mcp"]);
+        assert!(matches!(cli.command, Command::Mcp));
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod client;
+mod mcp;
 mod output;
 mod protocol;
 mod style;
@@ -22,14 +23,24 @@ use client::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
-        .init();
-
     let args = Cli::parse();
+    let is_mcp = matches!(args.command, Command::Mcp);
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+
+    if is_mcp {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_writer(std::io::stderr)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(env_filter).init();
+    }
+
+    if is_mcp {
+        return mcp::run_mcp_server(args.socket, args.window).await;
+    }
+
     let socket = resolve_socket(args.socket)?;
     let mut client = Client::connect(&socket).await?;
 
@@ -287,7 +298,7 @@ async fn follow_network(
     }
 }
 
-fn with_window(params: Option<Value>, window: Option<&str>) -> Option<Value> {
+pub(crate) fn with_window(params: Option<Value>, window: Option<&str>) -> Option<Value> {
     match (params, window) {
         (Some(Value::Object(mut map)), Some(w)) => {
             map.insert("window".to_string(), json!(w));
@@ -304,6 +315,7 @@ async fn run_command(
     window: Option<&str>,
 ) -> Result<serde_json::Value> {
     match command {
+        Command::Mcp => anyhow::bail!("mcp must be handled before run_command"),
         Command::Windows => client.call("windows.list", None).await,
         Command::Ping => client.call("ping", with_window(None, window)).await,
         Command::State => client.call("state", with_window(None, window)).await,
@@ -851,7 +863,7 @@ async fn run_storage_command(
 const MAX_DROP_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB per file
 const MAX_TOTAL_DROP_SIZE: usize = 100 * 1024 * 1024; // 100 MB total base64 payload
 
-async fn run_drop_command(
+pub(crate) async fn run_drop_command(
     client: &mut Client,
     target: &str,
     file: Vec<std::path::PathBuf>,
@@ -888,7 +900,7 @@ async fn run_drop_command(
     client.call("drop", with_window(Some(p), window)).await
 }
 
-fn target_params(raw: &str) -> serde_json::Value {
+pub(crate) fn target_params(raw: &str) -> serde_json::Value {
     match parse_target(raw) {
         Target::Ref(r) => json!({"ref": r}),
         Target::Selector(s) => json!({"selector": s}),
@@ -970,22 +982,16 @@ async fn run_record_command(
     }
 }
 
-async fn run_replay_command(
+pub(crate) async fn run_replay_command(
     client: &mut Client,
     path: &std::path::Path,
     export: Option<&str>,
     window: Option<&str>,
 ) -> Result<Value> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read recording file: {}", path.display()))?;
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(&content).context("Invalid recording file format")?;
+    let entries = read_replay_entries(path)?;
 
     if let Some(fmt) = export {
-        if fmt == "sh" {
-            return Ok(Value::String(export_shell_script(&entries)));
-        }
-        anyhow::bail!("unsupported export format: {fmt}; supported: sh");
+        return export_replay_command(&entries, fmt);
     }
 
     let total = entries.len();
@@ -1054,6 +1060,24 @@ async fn run_replay_command(
         "skipped": skipped,
         "failed": executed - passed
     }))
+}
+
+fn read_replay_entries(path: &std::path::Path) -> Result<Vec<serde_json::Value>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read recording file: {}", path.display()))?;
+    serde_json::from_str(&content).context("Invalid recording file format")
+}
+
+pub(crate) fn export_replay_file(path: &std::path::Path, export: &str) -> Result<Value> {
+    let entries = read_replay_entries(path)?;
+    export_replay_command(&entries, export)
+}
+
+fn export_replay_command(entries: &[Value], export: &str) -> Result<Value> {
+    if export == "sh" {
+        return Ok(Value::String(export_shell_script(entries)));
+    }
+    anyhow::bail!("unsupported export format: {export}; supported: sh")
 }
 
 fn export_shell_script(entries: &[Value]) -> String {
@@ -1216,7 +1240,7 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
 }
 
 /// Resolve the socket path from explicit arg, env var, or auto-detection.
-fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
+pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
     if let Some(path) = explicit {
         return Ok(path);
     }

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1563,17 +1563,57 @@ mod tests {
     };
 
     #[test]
-    fn tool_list_contains_core_commands_sorted() {
+    fn tool_list_matches_cli_command_surface() {
         let tools = tools();
         let names: Vec<&str> = tools.iter().map(|tool| tool.name.as_ref()).collect();
-        assert!(names.contains(&"snapshot"));
-        assert!(names.contains(&"click"));
-        assert!(names.contains(&"logs"));
-        assert!(names.contains(&"record_stop"));
-        assert!(names.contains(&"replay"));
-        let mut sorted = names.clone();
-        sorted.sort_unstable();
-        assert_eq!(names, sorted);
+        let expected = vec![
+            "assert_checked",
+            "assert_contains",
+            "assert_count",
+            "assert_hidden",
+            "assert_text",
+            "assert_url",
+            "assert_value",
+            "assert_visible",
+            "attrs",
+            "check",
+            "click",
+            "diff",
+            "drag",
+            "drop",
+            "eval",
+            "fill",
+            "forms",
+            "html",
+            "ipc",
+            "logs",
+            "navigate",
+            "network",
+            "ping",
+            "press",
+            "record_start",
+            "record_status",
+            "record_stop",
+            "replay",
+            "screenshot",
+            "scroll",
+            "select",
+            "snapshot",
+            "state",
+            "storage_clear",
+            "storage_get",
+            "storage_list",
+            "storage_set",
+            "text",
+            "title",
+            "type",
+            "url",
+            "value",
+            "wait",
+            "watch",
+            "windows",
+        ];
+        assert_eq!(names, expected);
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1,0 +1,1770 @@
+use std::{
+    io::IsTerminal,
+    path::Path,
+    path::PathBuf,
+    sync::{Arc, OnceLock},
+};
+
+use anyhow::Result;
+use rmcp::{
+    ErrorData as McpError, ServerHandler, ServiceExt,
+    model::{
+        CallToolRequestParams, CallToolResult, ErrorCode, Implementation, JsonObject,
+        ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+        ToolAnnotations,
+    },
+    service::{MaybeSendFuture, RequestContext, RoleServer},
+    transport::stdio,
+};
+use serde_json::{Map, Value, json};
+
+use crate::{
+    client::Client, export_replay_file, resolve_socket, run_drop_command, run_replay_command,
+    target_params, with_window,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct PilotMcpServer {
+    socket: Option<PathBuf>,
+    window: Option<String>,
+    resolved_socket: Arc<OnceLock<PathBuf>>,
+}
+
+pub(crate) async fn run_mcp_server(socket: Option<PathBuf>, window: Option<String>) -> Result<()> {
+    print_startup_banner(socket.as_deref(), window.as_deref());
+    let service = PilotMcpServer::new(socket, window)
+        .serve(stdio())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to initialize MCP server: {e}"))?;
+    service
+        .waiting()
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP server failed: {e}"))?;
+    Ok(())
+}
+
+fn print_startup_banner(socket: Option<&Path>, window: Option<&str>) {
+    if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() {
+        eprintln!("{}", startup_banner(socket, window));
+    }
+}
+
+fn startup_banner(socket: Option<&Path>, window: Option<&str>) -> String {
+    let socket = socket.map_or_else(
+        || "auto-detect on first tool call".to_owned(),
+        |path| path.display().to_string(),
+    );
+    let window = window.unwrap_or("default app window");
+
+    format!(
+        r"
+tauri-pilot MCP server
+
+Status : listening on stdio
+Socket : {socket}
+Window : {window}
+
+stdout is reserved for MCP JSON-RPC.
+Configure your MCP client to launch this command instead of typing requests here.
+"
+    )
+}
+
+impl PilotMcpServer {
+    fn new(socket: Option<PathBuf>, window: Option<String>) -> Self {
+        Self {
+            socket,
+            window,
+            resolved_socket: Arc::new(OnceLock::new()),
+        }
+    }
+
+    async fn connect_client(&self) -> Result<Client> {
+        if let Some(socket) = &self.socket {
+            return Client::connect(socket).await;
+        }
+
+        if let Some(socket) = self.resolved_socket.get() {
+            return Client::connect(socket).await;
+        }
+
+        let socket = resolve_socket(None)?;
+        let client = Client::connect(&socket).await?;
+        let _ = self.resolved_socket.set(socket);
+        Ok(client)
+    }
+
+    async fn call_app(
+        &self,
+        method: &'static str,
+        params: Option<Value>,
+        window: Option<String>,
+    ) -> Result<Value> {
+        let mut client = self.connect_client().await?;
+        client
+            .call(method, with_window(params, window.as_deref()))
+            .await
+    }
+
+    async fn call_app_tool(
+        &self,
+        method: &'static str,
+        params: Option<Value>,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(match self.call_app(method, params, window).await {
+            Ok(result) => tool_success(result),
+            Err(err) => tool_error(err),
+        })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn call_tool_by_name(
+        &self,
+        name: &str,
+        args: JsonObject,
+    ) -> Result<CallToolResult, McpError> {
+        let window = self.window_arg(&args)?;
+        match name {
+            "ping" => self.call_app_tool("ping", None, window).await,
+            "windows" => self.call_app_tool("windows.list", None, None).await,
+            "state" => self.call_app_tool("state", None, window).await,
+            "snapshot" => self
+                .call_app_tool(
+                    "snapshot",
+                    Some(json!({
+                        "interactive": optional_bool(&args, "interactive")?.unwrap_or(false),
+                        "selector": optional_string(&args, "selector")?,
+                        "depth": optional_u8(&args, "depth")?,
+                    })),
+                    window,
+                )
+                .await,
+            "diff" => {
+                let mut params = json!({
+                    "interactive": optional_bool(&args, "interactive")?.unwrap_or(false),
+                    "selector": optional_string(&args, "selector")?,
+                    "depth": optional_u8(&args, "depth")?,
+                });
+                if let Some(reference) = args.get("reference") {
+                    params["reference"] = reference.clone();
+                }
+                self.call_app_tool("diff", Some(params), window).await
+            }
+            "click" => self.target_call("click", &args, window).await,
+            "fill" => {
+                let mut params = target_params(&required_string(&args, "target")?);
+                params["value"] = json!(required_string(&args, "value")?);
+                self.call_app_tool("fill", Some(params), window).await
+            }
+            "type" => {
+                let mut params = target_params(&required_string(&args, "target")?);
+                params["text"] = json!(required_string(&args, "text")?);
+                self.call_app_tool("type", Some(params), window).await
+            }
+            "press" => {
+                self.call_app_tool(
+                    "press",
+                    Some(json!({"key": required_string(&args, "key")?})),
+                    window,
+                )
+                .await
+            }
+            "select" => {
+                let mut params = target_params(&required_string(&args, "target")?);
+                params["value"] = json!(required_string(&args, "value")?);
+                self.call_app_tool("select", Some(params), window).await
+            }
+            "check" => self.target_call("check", &args, window).await,
+            "scroll" => {
+                self.call_app_tool(
+                    "scroll",
+                    Some(json!({
+                        "direction": optional_string(&args, "direction")?.unwrap_or_else(|| "down".to_owned()),
+                        "amount": optional_i32(&args, "amount")?,
+                        "ref": optional_ref(&args)?,
+                    })),
+                    window,
+                )
+                .await
+            }
+            "drag" => {
+                let source = required_string(&args, "source")?;
+                let mut params = json!({"source": target_params(&source)});
+                let target = optional_string(&args, "target")?;
+                let offset = args.get("offset").cloned();
+                match (target, offset) {
+                    (Some(_), Some(_)) => {
+                        return Err(invalid_params(
+                            "drag accepts either 'target' or 'offset', not both",
+                        ));
+                    }
+                    (None, None) => {
+                        return Err(invalid_params("drag requires either 'target' or 'offset'"));
+                    }
+                    (Some(target), None) => {
+                        params["target"] = target_params(&target);
+                    }
+                    (None, Some(offset)) => {
+                        params["offset"] = offset;
+                    }
+                }
+                self.call_app_tool("drag", Some(params), window).await
+            }
+            "drop" => self.call_drop_tool(args, window).await,
+            "text" => self.target_call("text", &args, window).await,
+            "html" => {
+                let params =
+                    optional_string(&args, "target")?.map(|target| target_params(&target));
+                self.call_app_tool("html", params, window).await
+            }
+            "value" => self.target_call("value", &args, window).await,
+            "attrs" => self.target_call("attrs", &args, window).await,
+            "eval" => {
+                self.call_app_tool(
+                    "eval",
+                    Some(json!({"script": required_string(&args, "script")?})),
+                    window,
+                )
+                .await
+            }
+            "ipc" => {
+                self.call_app_tool(
+                    "ipc",
+                    Some(json!({
+                        "command": required_string(&args, "command")?,
+                        "args": args.get("args").cloned(),
+                    })),
+                    window,
+                )
+                .await
+            }
+            "screenshot" => {
+                self.call_app_tool(
+                    "screenshot",
+                    Some(json!({"selector": optional_string(&args, "selector")?})),
+                    window,
+                )
+                .await
+            }
+            "navigate" => {
+                self.call_app_tool(
+                    "navigate",
+                    Some(json!({"url": required_string(&args, "url")?})),
+                    window,
+                )
+                .await
+            }
+            "url" => self.call_app_tool("url", None, window).await,
+            "title" => self.call_app_tool("title", None, window).await,
+            "wait" => {
+                self.call_app_tool(
+                    "wait",
+                    Some(json!({
+                        "target": optional_string(&args, "target")?,
+                        "selector": optional_string(&args, "selector")?,
+                        "gone": optional_bool(&args, "gone")?.unwrap_or(false),
+                        "timeout": optional_u64(&args, "timeout")?.unwrap_or(10_000),
+                    })),
+                    window,
+                )
+                .await
+            }
+            "watch" => {
+                self.call_app_tool(
+                    "watch",
+                    Some(json!({
+                        "selector": optional_string(&args, "selector")?,
+                        "timeout": optional_u64(&args, "timeout")?.unwrap_or(10_000),
+                        "stable": optional_u64(&args, "stable")?.unwrap_or(300),
+                    })),
+                    window,
+                )
+                .await
+            }
+            "logs" => self.call_logs_tool(&args, window).await,
+            "network" => self.call_network_tool(&args, window).await,
+            "storage_get" => {
+                self.call_storage_tool(
+                    "storage.get",
+                    json!({
+                        "key": required_string(&args, "key")?,
+                        "session": optional_bool(&args, "session")?.unwrap_or(false),
+                    }),
+                    window,
+                )
+                .await
+            }
+            "storage_set" => {
+                self.call_storage_tool(
+                    "storage.set",
+                    json!({
+                        "key": required_string(&args, "key")?,
+                        "value": required_string(&args, "value")?,
+                        "session": optional_bool(&args, "session")?.unwrap_or(false),
+                    }),
+                    window,
+                )
+                .await
+            }
+            "storage_list" => {
+                self.call_storage_tool(
+                    "storage.list",
+                    json!({"session": optional_bool(&args, "session")?.unwrap_or(false)}),
+                    window,
+                )
+                .await
+            }
+            "storage_clear" => {
+                self.call_storage_tool(
+                    "storage.clear",
+                    json!({"session": optional_bool(&args, "session")?.unwrap_or(false)}),
+                    window,
+                )
+                .await
+            }
+            "forms" => {
+                let params =
+                    optional_string(&args, "selector")?.map(|selector| json!({ "selector": selector }));
+                self.call_app_tool("forms.dump", params, window).await
+            }
+            "assert_text" => self.assert_text(args, window, false).await,
+            "assert_contains" => self.assert_text(args, window, true).await,
+            "assert_visible" => self.assert_bool("visible", args, window, true).await,
+            "assert_hidden" => self.assert_bool("visible", args, window, false).await,
+            "assert_value" => self.assert_value(args, window).await,
+            "assert_count" => self.assert_count(args, window).await,
+            "assert_checked" => self.assert_bool("checked", args, window, true).await,
+            "assert_url" => self.assert_url(args, window).await,
+            "record_start" => self.call_app_tool("record.start", None, window).await,
+            "record_stop" => self.call_app_tool("record.stop", None, window).await,
+            "record_status" => self.call_app_tool("record.status", None, window).await,
+            "replay" => self.call_replay_tool(args, window).await,
+            _ => Err(McpError::new(
+                ErrorCode::METHOD_NOT_FOUND,
+                format!("unknown tool: {name}"),
+                None,
+            )),
+        }
+    }
+
+    async fn target_call(
+        &self,
+        method: &'static str,
+        args: &JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let target = required_string(args, "target")?;
+        self.call_app_tool(method, Some(target_params(&target)), window)
+            .await
+    }
+
+    async fn call_logs_tool(
+        &self,
+        args: &JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        if optional_bool(args, "clear")?.unwrap_or(false) {
+            return self.call_app_tool("console.clear", None, window).await;
+        }
+        let mut params = Map::new();
+        insert_optional_string(&mut params, args, "level")?;
+        insert_optional_usize(&mut params, args, "last")?;
+        self.call_app_tool("console.getLogs", Some(Value::Object(params)), window)
+            .await
+    }
+
+    async fn call_network_tool(
+        &self,
+        args: &JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        if optional_bool(args, "clear")?.unwrap_or(false) {
+            return self.call_app_tool("network.clear", None, window).await;
+        }
+        let mut params = Map::new();
+        insert_optional_string(&mut params, args, "filter")?;
+        insert_optional_usize(&mut params, args, "last")?;
+        if optional_bool(args, "failed")?.unwrap_or(false) {
+            params.insert("failedOnly".into(), json!(true));
+        }
+        self.call_app_tool("network.getRequests", Some(Value::Object(params)), window)
+            .await
+    }
+
+    async fn call_storage_tool(
+        &self,
+        method: &'static str,
+        params: Value,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        self.call_app_tool(method, Some(params), window).await
+    }
+
+    async fn call_drop_tool(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let target = required_string(&args, "target")?;
+        let files: Vec<PathBuf> = required_string_array(&args, "files")?
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
+        if files.is_empty() {
+            return Err(invalid_params("'files' must contain at least one path"));
+        }
+        let mut client = match self.connect_client().await {
+            Ok(client) => client,
+            Err(err) => return Ok(tool_error(err)),
+        };
+        Ok(
+            match run_drop_command(&mut client, &target, files, window.as_deref()).await {
+                Ok(result) => tool_success(result),
+                Err(err) => tool_error(err),
+            },
+        )
+    }
+
+    async fn call_replay_tool(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let path = PathBuf::from(required_string(&args, "path")?);
+        let export = optional_string(&args, "export")?;
+        if let Some(export) = export.as_deref() {
+            return Ok(match export_replay_file(&path, export) {
+                Ok(result) => tool_success(result),
+                Err(err) => tool_error(err),
+            });
+        }
+        let mut client = match self.connect_client().await {
+            Ok(client) => client,
+            Err(err) => return Ok(tool_error(err)),
+        };
+        Ok(
+            match run_replay_command(&mut client, &path, export.as_deref(), window.as_deref()).await
+            {
+                Ok(result) => tool_success(result),
+                Err(err) => tool_error(err),
+            },
+        )
+    }
+
+    async fn assert_text(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+        contains: bool,
+    ) -> Result<CallToolResult, McpError> {
+        let expected = required_string(&args, "expected")?;
+        let target = required_string(&args, "target")?;
+        let actual = match self
+            .call_app("text", Some(target_params(&target)), window)
+            .await
+        {
+            Ok(Value::String(actual)) => actual,
+            Ok(other) => {
+                return Ok(tool_error_msg(format!(
+                    "expected string response, got {other}"
+                )));
+            }
+            Err(err) => return Ok(tool_error(err)),
+        };
+        let passed = if contains {
+            actual.contains(&expected)
+        } else {
+            actual == expected
+        };
+        if passed {
+            Ok(tool_success(json!({"ok": true})))
+        } else {
+            let message = if contains {
+                format!("text does not contain \"{expected}\", got \"{actual}\"")
+            } else {
+                format!("expected text \"{expected}\", got \"{actual}\"")
+            };
+            Ok(tool_error_msg(message))
+        }
+    }
+
+    async fn assert_value(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let expected = required_string(&args, "expected")?;
+        let target = required_string(&args, "target")?;
+        let actual = match self
+            .call_app("value", Some(target_params(&target)), window)
+            .await
+        {
+            Ok(Value::String(actual)) => actual,
+            Ok(other) => {
+                return Ok(tool_error_msg(format!(
+                    "expected string response, got {other}"
+                )));
+            }
+            Err(err) => return Ok(tool_error(err)),
+        };
+        if actual == expected {
+            Ok(tool_success(json!({"ok": true})))
+        } else {
+            Ok(tool_error_msg(format!(
+                "expected value \"{expected}\", got \"{actual}\""
+            )))
+        }
+    }
+
+    async fn assert_bool(
+        &self,
+        method: &'static str,
+        args: JsonObject,
+        window: Option<String>,
+        expected: bool,
+    ) -> Result<CallToolResult, McpError> {
+        let target = required_string(&args, "target")?;
+        let field = method;
+        let actual = match self
+            .call_app(method, Some(target_params(&target)), window)
+            .await
+        {
+            Ok(result) => match result.get(field).and_then(Value::as_bool) {
+                Some(value) => value,
+                None => return Ok(tool_error_msg(format!("missing boolean field '{field}'"))),
+            },
+            Err(err) => return Ok(tool_error(err)),
+        };
+        if actual == expected {
+            Ok(tool_success(json!({"ok": true})))
+        } else if method == "visible" && expected {
+            Ok(tool_error_msg("element is not visible"))
+        } else if method == "visible" {
+            Ok(tool_error_msg("element is visible"))
+        } else {
+            Ok(tool_error_msg(format!(
+                "element '{method}' state mismatch: expected {expected}"
+            )))
+        }
+    }
+
+    async fn assert_count(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let selector = required_string(&args, "selector")?;
+        let expected = required_u64(&args, "expected")?;
+        let actual = match self
+            .call_app("count", Some(json!({"selector": selector})), window)
+            .await
+        {
+            Ok(result) => match result.get("count").and_then(Value::as_u64) {
+                Some(value) => value,
+                None => return Ok(tool_error_msg("missing 'count' field")),
+            },
+            Err(err) => return Ok(tool_error(err)),
+        };
+        if actual == expected {
+            Ok(tool_success(json!({"ok": true})))
+        } else {
+            Ok(tool_error_msg(format!(
+                "expected {expected} elements, found {actual}"
+            )))
+        }
+    }
+
+    async fn assert_url(
+        &self,
+        args: JsonObject,
+        window: Option<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let expected = required_string(&args, "expected")?;
+        let actual = match self.call_app("url", None, window).await {
+            Ok(Value::String(actual)) => actual,
+            Ok(other) => {
+                return Ok(tool_error_msg(format!(
+                    "expected string response, got {other}"
+                )));
+            }
+            Err(err) => return Ok(tool_error(err)),
+        };
+        if actual.contains(&expected) {
+            Ok(tool_success(json!({"ok": true})))
+        } else {
+            Ok(tool_error_msg(format!(
+                "URL does not contain \"{expected}\", got \"{actual}\""
+            )))
+        }
+    }
+
+    fn window_arg(&self, args: &JsonObject) -> Result<Option<String>, McpError> {
+        optional_string(args, "window").map(|window| window.or_else(|| self.window.clone()))
+    }
+}
+
+impl ServerHandler for PilotMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new("tauri-pilot", env!("CARGO_PKG_VERSION"))
+                    .with_title("tauri-pilot")
+                    .with_description("MCP server for testing Tauri apps through tauri-pilot"),
+            )
+            .with_instructions(
+                "Use these tools to inspect and control a running Tauri app through tauri-pilot.",
+            )
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListToolsResult, McpError>> + MaybeSendFuture + '_ {
+        std::future::ready(Ok(ListToolsResult::with_all_items(tools())))
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<CallToolResult, McpError>> + MaybeSendFuture + '_ {
+        let name = request.name.to_string();
+        let args = request.arguments.unwrap_or_default();
+        async move { self.call_tool_by_name(&name, args).await }
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        cached_tools()
+            .iter()
+            .find(|tool| tool.name == name)
+            .cloned()
+    }
+}
+
+struct ToolSpec {
+    name: &'static str,
+    description: &'static str,
+    schema: fn() -> Arc<JsonObject>,
+    read_only: bool,
+    destructive: bool,
+    idempotent: bool,
+}
+
+#[allow(clippy::too_many_lines)]
+fn tool_specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "attrs",
+            description: "Get all HTML attributes for an element target.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "check",
+            description: "Toggle a checkbox or radio element.",
+            schema: target_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "click",
+            description: "Click an element target by ref, selector, or coordinates.",
+            schema: target_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "diff",
+            description: "Compare the current page to the previous or supplied snapshot.",
+            schema: diff_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "drag",
+            description: "Drag an element to another target or by an offset.",
+            schema: drag_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "drop",
+            description: "Drop one or more local files on an element target.",
+            schema: drop_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "eval",
+            description: "Evaluate JavaScript in the WebView context.",
+            schema: eval_schema,
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "fill",
+            description: "Clear and fill an input target with a value.",
+            schema: fill_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "forms",
+            description: "Dump all form fields on the page or inside a selector.",
+            schema: selector_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "html",
+            description: "Get inner HTML for an element target, or the full page if target is omitted.",
+            schema: optional_target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "ipc",
+            description: "Invoke a Tauri IPC command with optional JSON arguments.",
+            schema: ipc_schema,
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "logs",
+            description: "Read or clear captured console logs.",
+            schema: logs_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "navigate",
+            description: "Navigate the WebView to a URL.",
+            schema: navigate_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "network",
+            description: "Read or clear captured network requests.",
+            schema: network_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "ping",
+            description: "Check connectivity with the running Tauri app.",
+            schema: empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "press",
+            description: "Press a keyboard key.",
+            schema: press_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "record_start",
+            description: "Start recording app interactions.",
+            schema: empty_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "record_status",
+            description: "Get recorder status.",
+            schema: empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "record_stop",
+            description: "Stop recording and return recorded entries.",
+            schema: empty_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "replay",
+            description: "Replay or export a recorded tauri-pilot session file.",
+            schema: replay_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "screenshot",
+            description: "Capture the WebView or an element selector as a PNG data URL.",
+            schema: selector_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "scroll",
+            description: "Scroll the page or an element ref.",
+            schema: scroll_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "select",
+            description: "Select an option in a select element.",
+            schema: fill_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "snapshot",
+            description: "Capture an accessibility snapshot of the WebView.",
+            schema: snapshot_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "state",
+            description: "Get page URL, title, viewport, and scroll state.",
+            schema: empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "storage_clear",
+            description: "Clear localStorage or sessionStorage.",
+            schema: session_schema,
+            read_only: false,
+            destructive: true,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "storage_get",
+            description: "Read a localStorage or sessionStorage key.",
+            schema: storage_get_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "storage_list",
+            description: "List localStorage or sessionStorage entries.",
+            schema: session_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "storage_set",
+            description: "Set a localStorage or sessionStorage key.",
+            schema: storage_set_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "text",
+            description: "Get text content for an element target.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "title",
+            description: "Get the current page title.",
+            schema: empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "type",
+            description: "Type text into an element target without clearing it first.",
+            schema: type_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "url",
+            description: "Get the current page URL.",
+            schema: empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "value",
+            description: "Get an input, textarea, or select value.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "wait",
+            description: "Wait for an element or condition.",
+            schema: wait_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "watch",
+            description: "Watch for DOM mutations until the page is stable.",
+            schema: watch_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
+            name: "windows",
+            description: "List all open Tauri windows.",
+            schema: global_empty_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_checked",
+            description: "Assert that a checkbox or radio target is checked.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_contains",
+            description: "Assert that target text contains a substring.",
+            schema: expected_target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_count",
+            description: "Assert the number of elements matching a selector.",
+            schema: assert_count_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_hidden",
+            description: "Assert that an element target is hidden.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_text",
+            description: "Assert exact text content for an element target.",
+            schema: expected_target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_url",
+            description: "Assert that the current URL contains a substring.",
+            schema: expected_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_value",
+            description: "Assert an input, textarea, or select value.",
+            schema: expected_target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+        ToolSpec {
+            name: "assert_visible",
+            description: "Assert that an element target is visible.",
+            schema: target_schema,
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+        },
+    ]
+}
+
+fn tools() -> Vec<Tool> {
+    cached_tools().clone()
+}
+
+fn cached_tools() -> &'static Vec<Tool> {
+    static TOOLS: OnceLock<Vec<Tool>> = OnceLock::new();
+    TOOLS.get_or_init(build_tools)
+}
+
+fn build_tools() -> Vec<Tool> {
+    let mut specs = tool_specs();
+    specs.sort_by_key(|spec| spec.name);
+    specs
+        .into_iter()
+        .map(|spec| {
+            Tool::new(spec.name, spec.description, (spec.schema)()).with_annotations(
+                ToolAnnotations::new()
+                    .read_only(spec.read_only)
+                    .destructive(spec.destructive)
+                    .idempotent(spec.idempotent)
+                    .open_world(false),
+            )
+        })
+        .collect()
+}
+
+fn tool_success(result: Value) -> CallToolResult {
+    let mut payload = Map::new();
+    payload.insert("result".to_owned(), result);
+    CallToolResult::structured(Value::Object(payload))
+}
+
+fn tool_error(err: impl std::fmt::Display) -> CallToolResult {
+    tool_error_msg(err.to_string())
+}
+
+fn tool_error_msg(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::structured_error(json!({ "error": message.into() }))
+}
+
+fn invalid_params(message: impl Into<String>) -> McpError {
+    McpError::invalid_params(message.into(), None)
+}
+
+fn required_string(args: &JsonObject, name: &str) -> Result<String, McpError> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| invalid_params(format!("'{name}' is required and must be a string")))
+}
+
+fn optional_string(args: &JsonObject, name: &str) -> Result<Option<String>, McpError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        _ => Err(invalid_params(format!("'{name}' must be a string"))),
+    }
+}
+
+fn required_u64(args: &JsonObject, name: &str) -> Result<u64, McpError> {
+    args.get(name)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_params(format!("'{name}' is required and must be an integer")))
+}
+
+fn optional_u64(args: &JsonObject, name: &str) -> Result<Option<u64>, McpError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| invalid_params(format!("'{name}' must be an integer"))),
+    }
+}
+
+fn optional_usize(args: &JsonObject, name: &str) -> Result<Option<usize>, McpError> {
+    optional_u64(args, name)?
+        .map(|value| {
+            usize::try_from(value)
+                .map_err(|_| invalid_params(format!("'{name}' is out of range for usize")))
+        })
+        .transpose()
+}
+
+fn optional_i32(args: &JsonObject, name: &str) -> Result<Option<i32>, McpError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let parsed = value
+                .as_i64()
+                .ok_or_else(|| invalid_params(format!("'{name}' must be an integer")))?;
+            i32::try_from(parsed)
+                .map(Some)
+                .map_err(|_| invalid_params(format!("'{name}' is out of range for i32")))
+        }
+    }
+}
+
+fn optional_u8(args: &JsonObject, name: &str) -> Result<Option<u8>, McpError> {
+    match optional_u64(args, name)? {
+        Some(value) => u8::try_from(value)
+            .map(Some)
+            .map_err(|_| invalid_params(format!("'{name}' is out of range for u8"))),
+        None => Ok(None),
+    }
+}
+
+fn optional_bool(args: &JsonObject, name: &str) -> Result<Option<bool>, McpError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| invalid_params(format!("'{name}' must be a boolean"))),
+    }
+}
+
+fn optional_ref(args: &JsonObject) -> Result<Option<String>, McpError> {
+    match optional_string(args, "ref")? {
+        Some(value) => Ok(Some(value.trim_start_matches('@').to_owned())),
+        None => Ok(None),
+    }
+}
+
+fn required_string_array(args: &JsonObject, name: &str) -> Result<Vec<String>, McpError> {
+    let values = args
+        .get(name)
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid_params(format!("'{name}' is required and must be an array")))?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| invalid_params(format!("'{name}' must contain only strings")))
+        })
+        .collect()
+}
+
+fn insert_optional_string(
+    params: &mut Map<String, Value>,
+    args: &JsonObject,
+    name: &str,
+) -> Result<(), McpError> {
+    if let Some(value) = optional_string(args, name)? {
+        params.insert(name.to_owned(), json!(value));
+    }
+    Ok(())
+}
+
+fn insert_optional_usize(
+    params: &mut Map<String, Value>,
+    args: &JsonObject,
+    name: &str,
+) -> Result<(), McpError> {
+    if let Some(value) = optional_usize(args, name)? {
+        params.insert(name.to_owned(), json!(value));
+    }
+    Ok(())
+}
+
+fn empty_schema() -> Arc<JsonObject> {
+    object_schema(Map::new(), &[])
+}
+
+fn global_empty_schema() -> Arc<JsonObject> {
+    let mut schema = Map::new();
+    schema.insert("type".to_owned(), json!("object"));
+    schema.insert("properties".to_owned(), Value::Object(Map::new()));
+    schema.insert("additionalProperties".to_owned(), json!(false));
+    Arc::new(schema)
+}
+
+fn target_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([(
+            "target",
+            string_prop("Element ref, CSS selector, or x,y coordinates."),
+        )]),
+        &["target"],
+    )
+}
+
+fn optional_target_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([(
+            "target",
+            string_prop("Optional element ref, CSS selector, or x,y coordinates."),
+        )]),
+        &[],
+    )
+}
+
+fn expected_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([("expected", string_prop("Expected value or substring."))]),
+        &["expected"],
+    )
+}
+
+fn expected_target_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "target",
+                string_prop("Element ref, CSS selector, or x,y coordinates."),
+            ),
+            ("expected", string_prop("Expected value or substring.")),
+        ]),
+        &["target", "expected"],
+    )
+}
+
+fn snapshot_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "interactive",
+                bool_prop("Only include interactive elements."),
+            ),
+            (
+                "selector",
+                string_prop("CSS selector to scope the snapshot."),
+            ),
+            ("depth", integer_prop("Maximum traversal depth.")),
+        ]),
+        &[],
+    )
+}
+
+fn diff_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "interactive",
+                bool_prop("Only include interactive elements."),
+            ),
+            (
+                "selector",
+                string_prop("CSS selector to scope the new snapshot."),
+            ),
+            ("depth", integer_prop("Maximum traversal depth.")),
+            (
+                "reference",
+                any_prop("Optional prior snapshot object to compare against."),
+            ),
+        ]),
+        &[],
+    )
+}
+
+fn fill_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "target",
+                string_prop("Element ref, CSS selector, or x,y coordinates."),
+            ),
+            ("value", string_prop("Value to set.")),
+        ]),
+        &["target", "value"],
+    )
+}
+
+fn type_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "target",
+                string_prop("Element ref, CSS selector, or x,y coordinates."),
+            ),
+            ("text", string_prop("Text to type.")),
+        ]),
+        &["target", "text"],
+    )
+}
+
+fn press_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([("key", string_prop("Keyboard key to press."))]),
+        &["key"],
+    )
+}
+
+fn scroll_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "direction",
+                enum_prop("Direction to scroll.", &["up", "down", "left", "right"]),
+            ),
+            ("amount", integer_prop("Pixel amount to scroll.")),
+            (
+                "ref",
+                string_prop("Optional element ref, with or without @."),
+            ),
+        ]),
+        &[],
+    )
+}
+
+fn drag_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "source",
+                string_prop("Source element ref, selector, or coordinates."),
+            ),
+            (
+                "target",
+                string_prop("Destination element ref, selector, or coordinates."),
+            ),
+            (
+                "offset",
+                any_prop("Optional offset object such as {\"x\": 0, \"y\": 100}."),
+            ),
+        ]),
+        &["source"],
+    )
+}
+
+fn drop_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "target",
+                string_prop("Drop target ref, selector, or coordinates."),
+            ),
+            ("files", array_string_prop("Local file paths to drop.")),
+        ]),
+        &["target", "files"],
+    )
+}
+
+fn eval_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([("script", string_prop("JavaScript to evaluate."))]),
+        &["script"],
+    )
+}
+
+fn ipc_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("command", string_prop("Tauri IPC command name.")),
+            (
+                "args",
+                any_prop("Optional JSON object of command arguments."),
+            ),
+        ]),
+        &["command"],
+    )
+}
+
+fn selector_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([("selector", string_prop("Optional CSS selector."))]),
+        &[],
+    )
+}
+
+fn navigate_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([("url", string_prop("URL to navigate to."))]),
+        &["url"],
+    )
+}
+
+fn wait_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "target",
+                string_prop("Element ref, CSS selector, or x,y coordinates."),
+            ),
+            ("selector", string_prop("CSS selector to wait for.")),
+            ("gone", bool_prop("Wait for the element to disappear.")),
+            ("timeout", integer_prop("Timeout in milliseconds.")),
+        ]),
+        &[],
+    )
+}
+
+fn watch_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "selector",
+                string_prop("CSS selector to scope observation."),
+            ),
+            ("timeout", integer_prop("Timeout in milliseconds.")),
+            ("stable", integer_prop("Stability window in milliseconds.")),
+        ]),
+        &[],
+    )
+}
+
+fn logs_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "level",
+                enum_prop(
+                    "Optional log level filter.",
+                    &["log", "info", "warn", "error"],
+                ),
+            ),
+            ("last", integer_prop("Return only the last N log entries.")),
+            (
+                "clear",
+                bool_prop("Clear the log buffer instead of reading it."),
+            ),
+        ]),
+        &[],
+    )
+}
+
+fn network_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("filter", string_prop("Optional URL substring filter.")),
+            ("failed", bool_prop("Only return failed requests.")),
+            ("last", integer_prop("Return only the last N requests.")),
+            (
+                "clear",
+                bool_prop("Clear the request buffer instead of reading it."),
+            ),
+        ]),
+        &[],
+    )
+}
+
+fn session_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([(
+            "session",
+            bool_prop("Use sessionStorage instead of localStorage."),
+        )]),
+        &[],
+    )
+}
+
+fn storage_get_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("key", string_prop("Storage key.")),
+            (
+                "session",
+                bool_prop("Use sessionStorage instead of localStorage."),
+            ),
+        ]),
+        &["key"],
+    )
+}
+
+fn storage_set_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("key", string_prop("Storage key.")),
+            ("value", string_prop("Storage value.")),
+            (
+                "session",
+                bool_prop("Use sessionStorage instead of localStorage."),
+            ),
+        ]),
+        &["key", "value"],
+    )
+}
+
+fn assert_count_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("selector", string_prop("CSS selector to count.")),
+            ("expected", integer_prop("Expected element count.")),
+        ]),
+        &["selector", "expected"],
+    )
+}
+
+fn replay_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            ("path", string_prop("Path to a recording JSON file.")),
+            (
+                "export",
+                enum_prop("Export format instead of replaying.", &["sh"]),
+            ),
+        ]),
+        &["path"],
+    )
+}
+
+fn object_schema(mut properties: Map<String, Value>, required: &[&str]) -> Arc<JsonObject> {
+    properties.insert(
+        "window".to_owned(),
+        string_prop("Optional Tauri window label overriding the MCP server default."),
+    );
+    let mut schema = Map::new();
+    schema.insert("type".to_owned(), json!("object"));
+    schema.insert("properties".to_owned(), Value::Object(properties));
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), json!(required));
+    }
+    schema.insert("additionalProperties".to_owned(), json!(false));
+    Arc::new(schema)
+}
+
+fn props<const N: usize>(properties: [(&str, Value); N]) -> Map<String, Value> {
+    properties
+        .into_iter()
+        .map(|(name, schema)| (name.to_owned(), schema))
+        .collect()
+}
+
+fn string_prop(description: &str) -> Value {
+    json!({"type": "string", "description": description})
+}
+
+fn bool_prop(description: &str) -> Value {
+    json!({"type": "boolean", "description": description})
+}
+
+fn integer_prop(description: &str) -> Value {
+    json!({"type": "integer", "description": description})
+}
+
+fn array_string_prop(description: &str) -> Value {
+    json!({"type": "array", "items": {"type": "string"}, "description": description})
+}
+
+fn any_prop(description: &str) -> Value {
+    json!({"description": description})
+}
+
+fn enum_prop(description: &str, values: &[&str]) -> Value {
+    json!({"type": "string", "enum": values, "description": description})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{Request, Response};
+    use serial_test::serial;
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        net::UnixListener,
+        task::JoinHandle,
+    };
+
+    #[test]
+    fn tool_list_contains_core_commands_sorted() {
+        let tools = tools();
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name.as_ref()).collect();
+        assert!(names.contains(&"snapshot"));
+        assert!(names.contains(&"click"));
+        assert!(names.contains(&"logs"));
+        assert!(names.contains(&"record_stop"));
+        assert!(names.contains(&"replay"));
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn schemas_include_window_override() {
+        let schema = target_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema has properties");
+        assert!(properties.contains_key("target"));
+        assert!(properties.contains_key("window"));
+    }
+
+    #[test]
+    fn windows_schema_omits_window_override() {
+        let schema = global_empty_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema has properties");
+        assert!(!properties.contains_key("window"));
+    }
+
+    #[test]
+    fn startup_banner_explains_stdio_server() {
+        let banner = startup_banner(None, Some("main"));
+
+        assert!(banner.contains("tauri-pilot MCP server"));
+        assert!(banner.contains("listening on stdio"));
+        assert!(banner.contains("auto-detect on first tool call"));
+        assert!(banner.contains("main"));
+        assert!(banner.contains("stdout is reserved for MCP JSON-RPC"));
+    }
+
+    #[tokio::test]
+    async fn replay_export_does_not_connect_to_socket() {
+        let recording = std::env::temp_dir().join(format!(
+            "tauri-pilot-mcp-replay-test-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &recording,
+            r#"[{"action":"click","timestamp":0,"ref":"e1"}]"#,
+        )
+        .expect("write recording");
+
+        let missing_socket = std::env::temp_dir().join(format!(
+            "tauri-pilot-mcp-missing-{}.sock",
+            std::process::id()
+        ));
+        let pilot = PilotMcpServer::new(Some(missing_socket), None);
+        let mut args = Map::new();
+        args.insert("path".to_owned(), json!(recording.display().to_string()));
+        args.insert("export".to_owned(), json!("sh"));
+
+        let result = pilot
+            .call_tool_by_name("replay", args)
+            .await
+            .expect("tool call succeeds");
+
+        assert_eq!(result.is_error, Some(false));
+        let script = result
+            .structured_content
+            .as_ref()
+            .and_then(|content| content.get("result"))
+            .and_then(Value::as_str)
+            .expect("script result");
+        assert!(script.starts_with("#!/bin/bash"));
+        assert!(script.contains("tauri-pilot click @e1"));
+
+        let _ = std::fs::remove_file(&recording);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn auto_detected_socket_is_pinned_after_first_connection() {
+        let dir =
+            std::env::temp_dir().join(format!("tauri-pilot-mcp-pin-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create socket dir");
+        let old_socket = dir.join("tauri-pilot-old.sock");
+        let new_socket = dir.join("tauri-pilot-new.sock");
+        let _ = std::fs::remove_file(&old_socket);
+        let _ = std::fs::remove_file(&new_socket);
+
+        let old_server = spawn_click_server(old_socket.clone(), "old", 2);
+
+        // SAFETY: serial attribute serializes tests that touch XDG_RUNTIME_DIR.
+        unsafe { std::env::set_var("XDG_RUNTIME_DIR", &dir) };
+
+        let pilot = PilotMcpServer::new(None, None);
+        let first = call_click(&pilot).await;
+        assert_eq!(tool_result_source(&first), Some("old"));
+
+        let new_server = spawn_click_server(new_socket.clone(), "new", 1);
+        let second = call_click(&pilot).await;
+        assert_eq!(tool_result_source(&second), Some("old"));
+
+        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
+        old_server.await.expect("old mock server task");
+        new_server.abort();
+        let _ = std::fs::remove_file(&old_socket);
+        let _ = std::fs::remove_file(&new_socket);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[tokio::test]
+    async fn click_tool_sends_json_rpc_request() {
+        let socket = std::env::temp_dir().join(format!(
+            "tauri-pilot-mcp-click-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read request");
+            let request: Request = serde_json::from_str(line.trim()).expect("parse request");
+            assert_eq!(request.method, "click");
+            assert_eq!(request.params, Some(json!({"ref": "e3"})));
+            let mut response =
+                serde_json::to_vec(&Response::success(request.id, json!({"ok": true})))
+                    .expect("serialize response");
+            response.push(b'\n');
+            writer.write_all(&response).await.expect("write response");
+        });
+
+        let pilot = PilotMcpServer::new(Some(socket.clone()), None);
+        let mut args = Map::new();
+        args.insert("target".to_owned(), json!("@e3"));
+        let result = pilot
+            .call_tool_by_name("click", args)
+            .await
+            .expect("tool call succeeds");
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(
+            result.structured_content,
+            Some(json!({"result": {"ok": true}}))
+        );
+
+        server.await.expect("mock server task");
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    async fn call_click(pilot: &PilotMcpServer) -> CallToolResult {
+        let mut args = Map::new();
+        args.insert("target".to_owned(), json!("@e3"));
+        pilot
+            .call_tool_by_name("click", args)
+            .await
+            .expect("tool call succeeds")
+    }
+
+    fn tool_result_source(result: &CallToolResult) -> Option<&str> {
+        result
+            .structured_content
+            .as_ref()
+            .and_then(|content| content.get("result"))
+            .and_then(|result| result.get("source"))
+            .and_then(Value::as_str)
+    }
+
+    fn spawn_click_server(
+        socket: PathBuf,
+        source: &'static str,
+        requests: usize,
+    ) -> JoinHandle<()> {
+        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+        tokio::spawn(async move {
+            for _ in 0..requests {
+                let (stream, _) = listener.accept().await.expect("accept");
+                let (reader, mut writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut line = String::new();
+                reader.read_line(&mut line).await.expect("read request");
+                let request: Request = serde_json::from_str(line.trim()).expect("parse request");
+                assert_eq!(request.method, "click");
+                let mut response =
+                    serde_json::to_vec(&Response::success(request.id, json!({"source": source})))
+                        .expect("serialize response");
+                response.push(b'\n');
+                writer.write_all(&response).await.expect("write response");
+            }
+        })
+    }
+}

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -285,40 +285,40 @@ impl PilotMcpServer {
             "logs" => self.call_logs_tool(&args, window).await,
             "network" => self.call_network_tool(&args, window).await,
             "storage_get" => {
-                self.call_storage_tool(
+                self.call_app_tool(
                     "storage.get",
-                    json!({
+                    Some(json!({
                         "key": required_string(&args, "key")?,
                         "session": optional_bool(&args, "session")?.unwrap_or(false),
-                    }),
+                    })),
                     window,
                 )
                 .await
             }
             "storage_set" => {
-                self.call_storage_tool(
+                self.call_app_tool(
                     "storage.set",
-                    json!({
+                    Some(json!({
                         "key": required_string(&args, "key")?,
                         "value": required_string(&args, "value")?,
                         "session": optional_bool(&args, "session")?.unwrap_or(false),
-                    }),
+                    })),
                     window,
                 )
                 .await
             }
             "storage_list" => {
-                self.call_storage_tool(
+                self.call_app_tool(
                     "storage.list",
-                    json!({"session": optional_bool(&args, "session")?.unwrap_or(false)}),
+                    Some(json!({"session": optional_bool(&args, "session")?.unwrap_or(false)})),
                     window,
                 )
                 .await
             }
             "storage_clear" => {
-                self.call_storage_tool(
+                self.call_app_tool(
                     "storage.clear",
-                    json!({"session": optional_bool(&args, "session")?.unwrap_or(false)}),
+                    Some(json!({"session": optional_bool(&args, "session")?.unwrap_or(false)})),
                     window,
                 )
                 .await
@@ -392,15 +392,6 @@ impl PilotMcpServer {
             .await
     }
 
-    async fn call_storage_tool(
-        &self,
-        method: &'static str,
-        params: Value,
-        window: Option<String>,
-    ) -> Result<CallToolResult, McpError> {
-        self.call_app_tool(method, Some(params), window).await
-    }
-
     async fn call_drop_tool(
         &self,
         args: JsonObject,
@@ -444,8 +435,7 @@ impl PilotMcpServer {
             Err(err) => return Ok(tool_error(err)),
         };
         Ok(
-            match run_replay_command(&mut client, &path, export.as_deref(), window.as_deref()).await
-            {
+            match run_replay_command(&mut client, &path, None, window.as_deref()).await {
                 Ok(result) => tool_success(result),
                 Err(err) => tool_error(err),
             },
@@ -542,6 +532,10 @@ impl PilotMcpServer {
             Ok(tool_error_msg("element is not visible"))
         } else if method == "visible" {
             Ok(tool_error_msg("element is visible"))
+        } else if method == "checked" && expected {
+            Ok(tool_error_msg("element is not checked"))
+        } else if method == "checked" {
+            Ok(tool_error_msg("element is checked"))
         } else {
             Ok(tool_error_msg(format!(
                 "element '{method}' state mismatch: expected {expected}"

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -145,3 +145,38 @@ tauri-pilot assert text @e1 "Results"     # verify in one step
 ```
 
 No custom integration code is needed — tauri-pilot is a CLI that Claude Code can invoke directly.
+
+## MCP Server
+
+Agents with native Model Context Protocol support can use tauri-pilot as a stdio
+MCP server:
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes the same app-facing commands as structured tools:
+`snapshot`, `click`, `fill`, `logs`, `network`, `eval`, `ipc`, `assert_*`, and
+more. Tool calls return structured JSON content, so agents do not need to parse
+terminal output.
+
+Use global flags before `mcp` when an agent should target a specific app socket or
+window:
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["--socket", "/tmp/tauri-pilot-myapp.sock", "--window", "main", "mcp"]
+    }
+  }
+}
+```

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -68,6 +68,54 @@ $ tauri-pilot ping
 
 ---
 
+### `mcp`
+
+Start a Model Context Protocol server over stdio. MCP-compatible agents can use
+this server to call tauri-pilot tools natively instead of spawning a CLI process
+for each interaction.
+
+```bash
+tauri-pilot mcp
+```
+
+**Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Use global flags before `mcp` to pin the server to a socket or default window:
+
+```json
+{
+  "mcpServers": {
+    "tauri-pilot": {
+      "command": "tauri-pilot",
+      "args": ["--socket", "/tmp/tauri-pilot-myapp.sock", "--window", "main", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes tools for the CLI's app-facing commands, including
+`snapshot`, `diff`, `click`, `fill`, `type`, `press`, `select`, `check`, `scroll`,
+`drag`, `drop`, `text`, `html`, `value`, `attrs`, `eval`, `ipc`, `screenshot`,
+`navigate`, `url`, `title`, `wait`, `watch`, `logs`, `network`, `storage_*`,
+`forms`, `assert_*`, `record_*`, and `replay`.
+
+The server starts even if no Tauri app is currently running. Each tool call
+resolves and connects to the tauri-pilot Unix socket lazily, using `--socket`,
+`TAURI_PILOT_SOCKET`, or the normal socket auto-detection rules.
+
+---
+
 ### `windows`
 
 List all open windows with their label, URL, and title.


### PR DESCRIPTION
Add a stdio Model Context Protocol server exposed as `tauri-pilot mcp`, so MCP-native agents can drive Tauri Pilot through structured tools instead of spawning one CLI command per interaction.

This addresses #16 by mapping the existing app-facing CLI surface into MCP tools, including inspection, interaction, assertions, logs, network, storage, recording, replay, and window commands. The server keeps stdout reserved for MCP JSON-RPC, resolves the Tauri Pilot socket lazily for each tool call, supports the existing global `--socket` and `--window` flags, and allows individual tools to override the default window.

The documentation now includes MCP configuration examples for the README, CLI reference, and AI-agent guide. Reviewers may want to focus on the tool schemas and dispatch table in `crates/tauri-pilot-cli/src/mcp.rs`, since that is where most of the new command surface is exposed.

Closes #16.

Validated with `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `npm --prefix docs run build`, and a stdio MCP smoke test that initializes the server and lists the advertised tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stdio Model Context Protocol server exposed as `tauri-pilot mcp`, so MCP clients can call Pilot tools directly instead of spawning a CLI process per step. The server auto-detects the app socket on first use and pins it for the session; stdout is JSON-RPC only and a TTY-only startup banner/logs go to stderr.

- **New Features**
  - New `mcp` command starts a stdio MCP server.
  - Exposes tools for existing app commands (inspection, interaction, assertions, logs, network, storage, recording, replay, windows) with JSON schemas and read-only/idempotent/destructive annotations.
  - Stdout reserved for MCP JSON-RPC; logs and the startup banner go to stderr (banner only when TTY).
  - Starts without a running app; lazily connects and pins the resolved socket. Honors global `--socket` and `--window`; tools can override `window`.
  - `replay` supports `export: "sh"` without connecting to the app.

- **Dependencies**
  - Added `rmcp` (server + stdio transport) to implement the MCP server.

<sup>Written for commit 24bd1819dba118124019fb234255ebaa8ac5efb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP (Model Context Protocol) server support, enabling `tauri-pilot mcp` to run as a stdio MCP server for integration with AI agents and MCP-compatible clients.
  * MCP server exposes all existing commands (snapshot, click, fill, logs, network, eval, ipc, assertions) with structured JSON responses.

* **Documentation**
  * Added MCP server configuration and usage examples in CLI and AI agent guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->