### PR TITLE
fix: Dispatch pointer events for clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdin heredoc and pipe examples for `eval -` in README, SKILL.md, and CLI reference ([#50])
 - MCP server mode for exposing tauri-pilot commands as structured tools over stdio ([#51])
 
+### Fixed
+
+- `click` now dispatches pointer events before mouse events so Radix UI dropdown, select, and dialog triggers open correctly ([#52])
+
 ## [0.3.0] - 2026-04-10
 
 ### Added
@@ -139,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [#51]: https://github.com/mpiton/tauri-pilot/pull/51
+[#52]: https://github.com/mpiton/tauri-pilot/pull/52
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -12,7 +12,7 @@ use base64::Engine;
 use clap::Parser;
 use serde_json::{Value, json};
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use cli::{
@@ -1245,17 +1245,20 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    // Directories to scan: prefer XDG_RUNTIME_DIR, always include /tmp as fallback.
-    let mut dirs: Vec<PathBuf> = Vec::new();
     if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
-        dirs.push(PathBuf::from(xdg));
+        let xdg = PathBuf::from(xdg);
+        if let Some(socket) = newest_socket_in_dir(&xdg) {
+            return Ok(socket);
+        }
     }
-    dirs.push(PathBuf::from("/tmp"));
 
-    let mut candidates: Vec<PathBuf> = dirs
-        .iter()
-        .filter_map(|dir| std::fs::read_dir(dir).ok())
-        .flatten()
+    newest_socket_in_dir(Path::new("/tmp"))
+        .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
+}
+
+fn newest_socket_in_dir(dir: &Path) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| {
@@ -1282,9 +1285,7 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
     });
 
-    candidates
-        .pop()
-        .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
+    candidates.pop()
 }
 
 #[cfg(test)]
@@ -1383,6 +1384,35 @@ mod tests {
         let _ = std::fs::remove_dir(&dir);
 
         assert_eq!(result.expect("socket found"), sock);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_socket_prefers_xdg_runtime_dir_over_tmp() {
+        let dir = std::env::temp_dir().join(format!(
+            "tauri-pilot-xdg-precedence-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create xdg test dir");
+        let xdg_sock = dir.join("tauri-pilot-xdg.sock");
+        let tmp_sock = std::path::PathBuf::from(format!(
+            "/tmp/tauri-pilot-newer-tmp-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&tmp_sock);
+        std::fs::write(&xdg_sock, b"").expect("create xdg socket file");
+        std::fs::write(&tmp_sock, b"").expect("create newer tmp socket file");
+
+        // SAFETY: serial attribute serializes tests that touch XDG_RUNTIME_DIR.
+        unsafe { std::env::set_var("XDG_RUNTIME_DIR", &dir) };
+        let result = resolve_socket(None);
+        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
+
+        let _ = std::fs::remove_file(&xdg_sock);
+        let _ = std::fs::remove_file(&tmp_sock);
+        let _ = std::fs::remove_dir(&dir);
+
+        assert_eq!(result.expect("socket found"), xdg_sock);
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -428,12 +428,75 @@
     throw new Error("No ref, selector, or coordinates provided");
   }
 
+  function dispatchPointerEvent(el, type, options) {
+    const init = Object.assign({
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+      buttons: type === "pointerdown" ? 1 : 0,
+      view: window,
+      clientX: 0,
+      clientY: 0,
+    }, options || {});
+
+    if (typeof PointerEvent === "function") {
+      return el.dispatchEvent(new PointerEvent(type, init));
+    }
+
+    const event = new MouseEvent(type, init);
+    try {
+      Object.defineProperty(event, "pointerId", { value: init.pointerId });
+      Object.defineProperty(event, "pointerType", { value: init.pointerType });
+      Object.defineProperty(event, "isPrimary", { value: init.isPrimary });
+    } catch (_) {}
+    return el.dispatchEvent(event);
+  }
+
   function click(params) {
     const el = resolveTarget(params);
-    el.focus();
-    el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
-    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const rect = el.getBoundingClientRect();
+    const x = params.x != null ? params.x : rect.left + rect.width / 2;
+    const y = params.y != null ? params.y : rect.top + rect.height / 2;
+    const downInit = {
+      clientX: x,
+      clientY: y,
+      button: 0,
+      buttons: 1,
+      detail: 1,
+      view: window,
+    };
+    const upInit = {
+      clientX: x,
+      clientY: y,
+      button: 0,
+      buttons: 0,
+      detail: 1,
+      view: window,
+    };
+    const mouseInit = function(options) {
+      return Object.assign({
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }, options);
+    };
+
+    const pointerDownOk = dispatchPointerEvent(el, "pointerdown", downInit);
+    if (pointerDownOk) {
+      const mouseDownOk = el.dispatchEvent(new MouseEvent("mousedown", mouseInit(downInit)));
+      if (mouseDownOk && typeof el.focus === "function") {
+        el.focus();
+      }
+    }
+    dispatchPointerEvent(el, "pointerup", upInit);
+    if (pointerDownOk) {
+      el.dispatchEvent(new MouseEvent("mouseup", mouseInit(upInit)));
+    }
+    dispatchPointerEvent(el, "click", upInit);
     return { ok: true };
   }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -168,4 +168,47 @@ mod tests {
             "html-to-image must be injected before pilot bridge code"
         );
     }
+
+    #[cfg(all(unix, debug_assertions))]
+    #[test]
+    fn bridge_click_dispatches_pointer_sequence() {
+        let js = super::BRIDGE_JS;
+        let pointer_down_idx = js
+            .find(r#"dispatchPointerEvent(el, "pointerdown""#)
+            .expect("click must dispatch pointerdown for Radix triggers");
+        let mouse_down_idx = js
+            .find(r#"MouseEvent("mousedown""#)
+            .expect("click must keep mousedown compatibility");
+        let pointer_up_idx = js
+            .find(r#"dispatchPointerEvent(el, "pointerup""#)
+            .expect("click must dispatch pointerup for Radix triggers");
+        let mouse_up_idx = js
+            .find(r#"MouseEvent("mouseup""#)
+            .expect("click must keep mouseup compatibility");
+        let click_idx = js
+            .find(r#"dispatchPointerEvent(el, "click""#)
+            .expect("click must dispatch as a pointer event");
+
+        assert!(
+            pointer_down_idx < mouse_down_idx
+                && mouse_down_idx < pointer_up_idx
+                && pointer_up_idx < mouse_up_idx
+                && mouse_up_idx < click_idx,
+            "click must dispatch pointerdown -> mousedown -> pointerup -> mouseup -> click"
+        );
+        assert!(
+            js.contains(r#"pointerType: "mouse""#),
+            "pointer events must include mouse pointer metadata"
+        );
+        assert!(
+            js.contains(
+                "if (pointerDownOk) {\n      const mouseDownOk = el.dispatchEvent(new MouseEvent(\"mousedown\""
+            ),
+            "mousedown must only dispatch when pointerdown was not canceled"
+        );
+        assert!(
+            js.contains("if (pointerDownOk) {\n      el.dispatchEvent(new MouseEvent(\"mouseup\""),
+            "mouseup must only dispatch when pointerdown was not canceled"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #47.

The bridge click implementation now dispatches a browser-like pointer and mouse sequence for Radix UI triggers. It emits pointerdown before the compatibility mouse events, suppresses mousedown and mouseup when pointerdown is canceled, and dispatches click through the pointer event helper so listeners can observe pointer metadata.

This also keeps MCP auto-detected socket pinning stable by preferring sockets in XDG_RUNTIME_DIR before falling back to /tmp. The Ubuntu CI failure was caused by auto-detection choosing an unrelated newer /tmp socket instead of the test socket under XDG_RUNTIME_DIR.

Regression coverage now verifies the pointer event order, pointer metadata, compatibility mouse-event gating, pointer click dispatch, and XDG_RUNTIME_DIR socket precedence.

Validation run locally: cargo fmt --all --check, git diff --check, cargo test --workspace, and cargo clippy --workspace -- -D warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed click event dispatch order to emit pointer events before mouse events, resolving issues where Radix UI dropdowns, selects, and dialogs failed to open correctly.
  * Added fallback support for pointer events in less capable environments.

* **Tests**
  * Added test coverage to verify click event sequence ordering and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken clicks on Radix UI components by dispatching a browser-like pointer→mouse sequence and emitting click as a pointer event. Also stabilizes MCP socket auto-detection by preferring `XDG_RUNTIME_DIR` sockets over `/tmp`.

- **Bug Fixes**
  - Click bridge now dispatches pointerdown → (if not canceled) mousedown → pointerup → (if not canceled) mouseup → click as a pointer event with pointer metadata; uses element-center coordinates by default, focuses after mousedown if not canceled, and falls back when `PointerEvent` is unavailable.
  - CLI selects the newest socket in `XDG_RUNTIME_DIR` first, then falls back to `/tmp`, avoiding accidental pinning to unrelated newer `/tmp` sockets in CI.

<sup>Written for commit a9ce0f36f18ba5d0c2adc0da802e4d73954643f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

