### PR TITLE
fix(plugin): inject press at OS level so events are trusted (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `press` command now injects keyboard events at the OS level via `enigo` instead of dispatching synthetic JS `KeyboardEvent`s. Events are now `isTrusted=true` and traverse the full input pipeline, reaching DOM listeners, Tauri accelerators, and global shortcut handlers ([#45])
 - The plugin now requests window focus before injecting keys so events land on the correct webview
+- `tauri-plugin-pilot` exposes a default-on `press` feature that gates the `enigo` dependency. Build with `--no-default-features` to drop it from release builds where the whole plugin is already no-op'd ([#53])
 
 ### Fixed
 
 - `click` now dispatches pointer events before mouse events so Radix UI dropdown, select, and dialog triggers open correctly ([#52])
 - `press "Control+1"` and similar combos now trigger Tauri global shortcuts and any handler that requires trusted keyboard events ([#45])
+- `press` with an explicit `--window <label>` now returns an error when the target window cannot be focused, instead of silently delivering the key to whatever window currently holds focus ([#53])
+- `press` serializes the full `focus → settle → inject` sequence, so two concurrent calls targeting different windows can no longer race on the focus step and cross their keys ([#53])
+- `press` combo parser now rejects empty segments between `+` (e.g. `Control++P`, `+A`) instead of silently normalizing them into different shortcuts ([#53])
+- `press` now explicitly enables enigo's `wayland` backend so OS-level key injection works on Wayland sessions, not just X11 ([#53])
 
 ## [0.3.0] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdin heredoc and pipe examples for `eval -` in README, SKILL.md, and CLI reference ([#50])
 - MCP server mode for exposing tauri-pilot commands as structured tools over stdio ([#51])
 
+### Changed
+
+- `press` command now injects keyboard events at the OS level via `enigo` instead of dispatching synthetic JS `KeyboardEvent`s. Events are now `isTrusted=true` and traverse the full input pipeline, reaching DOM listeners, Tauri accelerators, and global shortcut handlers ([#45])
+- The plugin now requests window focus before injecting keys so events land on the correct webview
+
 ### Fixed
 
 - `click` now dispatches pointer events before mouse events so Radix UI dropdown, select, and dialog triggers open correctly ([#52])
+- `press "Control+1"` and similar combos now trigger Tauri global shortcuts and any handler that requires trusted keyboard events ([#45])
 
 ## [0.3.0] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `press` serializes the full `focus → settle → inject` sequence, so two concurrent calls targeting different windows can no longer race on the focus step and cross their keys ([#53])
 - `press` combo parser now rejects empty segments between `+` (e.g. `Control++P`, `+A`) instead of silently normalizing them into different shortcuts ([#53])
 - `press` now explicitly enables enigo's `wayland` backend so OS-level key injection works on Wayland sessions, not just X11 ([#53])
+- `press` validates the combo string before taking the focus lock or stealing focus, so malformed input returns `-32602` (invalid params) immediately instead of `-32603` after an 80ms focus settle ([#53])
+- `simulate_press` now propagates modifier-release failures instead of dropping them, so a combo can no longer return `Ok(())` while leaving a modifier stuck down ([#53])
 
 ## [0.3.0] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `press` now explicitly enables enigo's `wayland` backend so OS-level key injection works on Wayland sessions, not just X11 ([#53])
 - `press` validates the combo string before taking the focus lock or stealing focus, so malformed input returns `-32602` (invalid params) immediately instead of `-32603` after an 80ms focus settle ([#53])
 - `simulate_press` now propagates modifier-release failures instead of dropping them, so a combo can no longer return `Ok(())` while leaving a modifier stuck down ([#53])
+- `press` with `--window <label>` but no focus hook installed now errors instead of silently injecting into whatever window has focus ([#53])
+- `Enigo::new` failure hint about macOS Accessibility permission is now gated to macOS builds — Linux and Windows errors no longer point users at the wrong remediation ([#53])
 
 ## [0.3.0] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `simulate_press` now propagates modifier-release failures instead of dropping them, so a combo can no longer return `Ok(())` while leaving a modifier stuck down ([#53])
 - `press` with `--window <label>` but no focus hook installed now errors instead of silently injecting into whatever window has focus ([#53])
 - `Enigo::new` failure hint about macOS Accessibility permission is now gated to macOS builds — Linux and Windows errors no longer point users at the wrong remediation ([#53])
+- `press` JoinError handling distinguishes panics from cancellation and runtime-shutdown cases instead of reporting every failure as "panicked" ([#53])
 
 ## [0.3.0] - 2026-04-10
 

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -16,6 +16,14 @@ links = "tauri-plugin-pilot"
 [lints]
 workspace = true
 
+[features]
+default = ["press"]
+# Enables the OS-level `press` command. Pulls in `enigo` and its platform
+# backends. Opt out with `--no-default-features` to drop the dependency from
+# release builds where the whole plugin is already no-op'd by
+# `cfg(debug_assertions)`.
+press = ["dep:enigo"]
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
@@ -24,7 +32,9 @@ tracing.workspace = true
 thiserror = "2"
 tauri = { version = "2", features = ["unstable"] }
 libc = "0.2.184"
-enigo = "0.6.1"
+# `wayland` enables the libei-based Wayland backend so `press` works on
+# modern Linux sessions, not just X11.
+enigo = { version = "0.6.1", features = ["wayland"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -24,6 +24,7 @@ tracing.workspace = true
 thiserror = "2"
 tauri = { version = "2", features = ["unstable"] }
 libc = "0.2.184"
+enigo = "0.6.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -535,14 +535,6 @@
     return { ok: true };
   }
 
-  function press(params) {
-    var key = params.key || params;
-    const target = document.activeElement || document.body;
-    target.dispatchEvent(new KeyboardEvent("keydown", { key: key, bubbles: true }));
-    target.dispatchEvent(new KeyboardEvent("keyup", { key: key, bubbles: true }));
-    return { ok: true };
-  }
-
   function select(params) {
     const el = resolveTarget(params);
     const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
@@ -1005,7 +997,6 @@
     click: click,
     fill: fill,
     type: typeText,
-    press: press,
     select: select,
     check: check,
     scroll: scroll,

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -307,10 +307,17 @@ async fn handle_press(
         })?;
 
     if let Some(focus) = focus_fn {
-        if let Err(e) = focus(window) {
-            tracing::warn!(window = ?window, error = %e, "focus before press failed (continuing)");
+        match focus(window) {
+            Ok(()) => {
+                // Only wait if the WM actually accepted the focus request —
+                // a failed focus call won't transfer focus, so sleeping
+                // would just delay the press for nothing.
+                tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
+            }
+            Err(e) => {
+                tracing::warn!(window = ?window, error = %e, "focus before press failed (continuing)");
+            }
         }
-        tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
     }
 
     let combo = key_str.to_owned();

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,17 +1,29 @@
 use crate::diff;
 use crate::eval::EvalEngine;
+#[cfg(feature = "press")]
 use crate::key;
 use crate::protocol::RpcError;
 use crate::recorder::{RecordEntry, Recorder};
 use crate::server::{EvalFn, FocusFn, ListWindowsFn};
 
 use std::time::Duration;
+#[cfg(feature = "press")]
+use tokio::sync::Mutex as AsyncMutex;
 
 /// Delay after requesting window focus before injecting OS-level keyboard
 /// events, so the window manager has time to actually transfer focus. Tuned
 /// empirically — too short and the first key on Wayland drops; too long and
 /// press feels sluggish.
+#[cfg(feature = "press")]
 const FOCUS_SETTLE_MS: u64 = 80;
+
+/// Serializes the full `focus → settle → inject` sequence across concurrent
+/// `press` calls. The inner `key::PRESS_LOCK` only covers the OS injection,
+/// so without this outer lock two calls targeting different windows could
+/// race on the focus step and deliver both keys to whichever window won the
+/// focus race.
+#[cfg(feature = "press")]
+static PRESS_ORDER_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -52,7 +64,7 @@ pub(crate) async fn dispatch(
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
     list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
+    #[cfg_attr(not(feature = "press"), allow(unused_variables))] focus_fn: Option<&FocusFn>,
     recorder: &Recorder,
 ) -> Result<serde_json::Value, RpcError> {
     // Save original params before window extraction so the recorder can strip
@@ -84,7 +96,15 @@ pub(crate) async fn dispatch(
             Ok(result)
         }
         "diff" => handle_diff(params, engine, eval_fn, win).await,
+        #[cfg(feature = "press")]
         "press" => handle_press(params, focus_fn, win).await,
+        #[cfg(not(feature = "press"))]
+        "press" => Err(RpcError {
+            code: -32601,
+            message: "press disabled (compile `tauri-plugin-pilot` with the `press` feature)"
+                .to_owned(),
+            data: None,
+        }),
         "click" | "fill" | "type" | "select" | "check" | "scroll" | "drag" | "drop" | "text"
         | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state"
         | "wait" | "visible" | "count" | "checked" => {
@@ -291,6 +311,7 @@ async fn handle_diff(
 /// reach Tauri accelerators or window-manager-level shortcut handlers (#45).
 /// Native injection via `enigo` produces real keyboard events that traverse
 /// the full pipeline.
+#[cfg(feature = "press")]
 async fn handle_press(
     params: Option<&serde_json::Value>,
     focus_fn: Option<&FocusFn>,
@@ -306,6 +327,11 @@ async fn handle_press(
             data: None,
         })?;
 
+    // Hold this lock across the whole focus → settle → inject sequence so
+    // two concurrent `press` calls cannot interleave their focus steps (call
+    // A focuses window X, call B focuses window Y, then both keys land on Y).
+    let _order_guard = PRESS_ORDER_LOCK.lock().await;
+
     if let Some(focus) = focus_fn {
         match focus(window) {
             Ok(()) => {
@@ -315,7 +341,17 @@ async fn handle_press(
                 tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
             }
             Err(e) => {
-                tracing::warn!(window = ?window, error = %e, "focus before press failed (continuing)");
+                if let Some(label) = window {
+                    // The caller explicitly targeted a window; silently
+                    // falling through would deliver the key to whatever
+                    // window currently has focus and still return ok.
+                    return Err(RpcError {
+                        code: -32603,
+                        message: format!("failed to focus window '{label}': {e}"),
+                        data: None,
+                    });
+                }
+                tracing::warn!(error = %e, "focus before press failed (continuing)");
             }
         }
     }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -337,6 +337,17 @@ async fn handle_press(
         data: None,
     })?;
 
+    // An explicit `--window <label>` with no focus hook installed would
+    // otherwise silently drop the focus step and inject into whatever window
+    // currently has focus. Reject before taking any lock.
+    if window.is_some() && focus_fn.is_none() {
+        return Err(RpcError {
+            code: -32603,
+            message: "cannot focus target window: no focus hook installed".to_owned(),
+            data: None,
+        });
+    }
+
     // Hold this lock across the whole focus → settle → inject sequence so
     // two concurrent `press` calls cannot interleave their focus steps (call
     // A focuses window X, call B focuses window Y, then both keys land on Y).
@@ -514,6 +525,28 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, -32602);
         assert!(err.message.contains("invalid press combo"));
+    }
+
+    #[cfg(feature = "press")]
+    #[tokio::test]
+    async fn test_dispatch_press_with_explicit_window_and_no_focus_fn_errors() {
+        // --window <label> with no focus hook must not silently inject into
+        // the currently focused window. We can pass `window` through params
+        // (handler extracts it before dispatch).
+        let engine = EvalEngine::new();
+        let result = dispatch(
+            "press",
+            Some(&json!({"key": "Enter", "window": "settings"})),
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("focus"));
     }
 
     #[cfg(feature = "press")]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -380,10 +380,22 @@ async fn handle_press(
     let combo = key_str.to_owned();
     tokio::task::spawn_blocking(move || key::simulate_press(&combo))
         .await
-        .map_err(|e| RpcError {
-            code: -32603,
-            message: format!("press task panicked: {e}"),
-            data: None,
+        .map_err(|e| {
+            // A JoinError can be a panic, a cancellation, or a runtime
+            // shutdown — reporting every one as "panicked" misleads during
+            // teardown.
+            let message = if e.is_panic() {
+                format!("press task panicked: {e}")
+            } else if e.is_cancelled() {
+                "press task was cancelled".to_owned()
+            } else {
+                format!("press task failed: {e}")
+            };
+            RpcError {
+                code: -32603,
+                message,
+                data: None,
+            }
         })?
         .map_err(|e| RpcError {
             code: -32603,

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -327,6 +327,16 @@ async fn handle_press(
             data: None,
         })?;
 
+    // Parse the combo up front: a bad combo is a client input error, so we
+    // shouldn't take the serialization lock, steal focus, or sleep for it —
+    // and we report it as -32602 (invalid params) instead of letting the
+    // later spawn_blocking path surface it as -32603 (internal error).
+    key::parse_combo(key_str).map_err(|e| RpcError {
+        code: -32602,
+        message: format!("invalid press combo: {e}"),
+        data: None,
+    })?;
+
     // Hold this lock across the whole focus → settle → inject sequence so
     // two concurrent `press` calls cannot interleave their focus steps (call
     // A focuses window X, call B focuses window Y, then both keys land on Y).
@@ -483,6 +493,37 @@ mod tests {
         let engine = EvalEngine::new();
         let result = dispatch("ping", None, &engine, None, None, None, &Recorder::new()).await;
         assert_eq!(result.unwrap(), json!({"status": "ok"}));
+    }
+
+    #[cfg(feature = "press")]
+    #[tokio::test]
+    async fn test_dispatch_press_with_invalid_combo_returns_invalid_params() {
+        // A malformed combo must not steal focus or acquire the serialization
+        // lock — it should short-circuit with -32602 (invalid params).
+        let engine = EvalEngine::new();
+        let result = dispatch(
+            "press",
+            Some(&json!({"key": "Control++P"})),
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert!(err.message.contains("invalid press combo"));
+    }
+
+    #[cfg(feature = "press")]
+    #[tokio::test]
+    async fn test_dispatch_press_with_missing_key_returns_invalid_params() {
+        let engine = EvalEngine::new();
+        let result =
+            dispatch("press", None, &engine, None, None, None, &Recorder::new()).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code, -32602);
     }
 
     #[tokio::test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -565,8 +565,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_press_with_missing_key_returns_invalid_params() {
         let engine = EvalEngine::new();
-        let result =
-            dispatch("press", None, &engine, None, None, None, &Recorder::new()).await;
+        let result = dispatch("press", None, &engine, None, None, None, &Recorder::new()).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32602);
     }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,10 +1,17 @@
 use crate::diff;
 use crate::eval::EvalEngine;
+use crate::key;
 use crate::protocol::RpcError;
 use crate::recorder::{RecordEntry, Recorder};
-use crate::server::{EvalFn, ListWindowsFn};
+use crate::server::{EvalFn, FocusFn, ListWindowsFn};
 
 use std::time::Duration;
+
+/// Delay after requesting window focus before injecting OS-level keyboard
+/// events, so the window manager has time to actually transfer focus. Tuned
+/// empirically — too short and the first key on Wayland drops; too long and
+/// press feels sluggish.
+const FOCUS_SETTLE_MS: u64 = 80;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -38,13 +45,14 @@ fn extract_window(
 }
 
 /// Dispatch a JSON-RPC method call to the appropriate handler.
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub(crate) async fn dispatch(
     method: &str,
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
     list_fn: Option<&ListWindowsFn>,
+    focus_fn: Option<&FocusFn>,
     recorder: &Recorder,
 ) -> Result<serde_json::Value, RpcError> {
     // Save original params before window extraction so the recorder can strip
@@ -76,9 +84,10 @@ pub(crate) async fn dispatch(
             Ok(result)
         }
         "diff" => handle_diff(params, engine, eval_fn, win).await,
-        "click" | "fill" | "type" | "press" | "select" | "check" | "scroll" | "drag" | "drop"
-        | "text" | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
-        | "state" | "wait" | "visible" | "count" | "checked" => {
+        "press" => handle_press(params, focus_fn, win).await,
+        "click" | "fill" | "type" | "select" | "check" | "scroll" | "drag" | "drop" | "text"
+        | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state"
+        | "wait" | "visible" | "count" | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
         "watch" => {
@@ -276,6 +285,51 @@ async fn handle_diff(
     })
 }
 
+/// Handle the "press" method by injecting an OS-level keyboard event.
+///
+/// JS-dispatched `KeyboardEvent`s are flagged `isTrusted: false` and never
+/// reach Tauri accelerators or window-manager-level shortcut handlers (#45).
+/// Native injection via `enigo` produces real keyboard events that traverse
+/// the full pipeline.
+async fn handle_press(
+    params: Option<&serde_json::Value>,
+    focus_fn: Option<&FocusFn>,
+    window: Option<&str>,
+) -> Result<serde_json::Value, RpcError> {
+    let key_str = params
+        .and_then(|p| p.get("key"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| RpcError {
+            code: -32602,
+            message: "press requires a non-empty \"key\" string param".to_owned(),
+            data: None,
+        })?;
+
+    if let Some(focus) = focus_fn {
+        if let Err(e) = focus(window) {
+            tracing::warn!(window = ?window, error = %e, "focus before press failed (continuing)");
+        }
+        tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
+    }
+
+    let combo = key_str.to_owned();
+    tokio::task::spawn_blocking(move || key::simulate_press(&combo))
+        .await
+        .map_err(|e| RpcError {
+            code: -32603,
+            message: format!("press task panicked: {e}"),
+            data: None,
+        })?
+        .map_err(|e| RpcError {
+            code: -32603,
+            message: format!("press failed: {e}"),
+            data: None,
+        })?;
+
+    Ok(serde_json::json!({"ok": true}))
+}
+
 /// Handle a method that requires JS evaluation via the bridge.
 async fn handle_eval_method(
     method: &str,
@@ -384,14 +438,23 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_ping_returns_ok() {
         let engine = EvalEngine::new();
-        let result = dispatch("ping", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch("ping", None, &engine, None, None, None, &Recorder::new()).await;
         assert_eq!(result.unwrap(), json!({"status": "ok"}));
     }
 
     #[tokio::test]
     async fn test_dispatch_unknown_method_returns_error() {
         let engine = EvalEngine::new();
-        let result = dispatch("nonexistent", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "nonexistent",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32601);
     }
@@ -399,7 +462,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_snapshot_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("snapshot", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "snapshot",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -408,7 +480,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_diff_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("diff", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch("diff", None, &engine, None, None, None, &Recorder::new()).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -433,6 +505,7 @@ mod tests {
             None,
             &engine,
             Some(&eval_fn),
+            None,
             None,
             &Recorder::new(),
         )
@@ -490,6 +563,7 @@ mod tests {
             &engine,
             None,
             None,
+            None,
             &Recorder::new(),
         )
         .await;
@@ -501,7 +575,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_console_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("console.clear", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "console.clear",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -530,6 +613,7 @@ mod tests {
             &engine,
             None,
             None,
+            None,
             &Recorder::new(),
         )
         .await;
@@ -541,7 +625,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_network_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("network.clear", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "network.clear",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -588,7 +681,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_watch_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("watch", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch("watch", None, &engine, None, None, None, &Recorder::new()).await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -605,7 +698,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drag_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drag", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch("drag", None, &engine, None, None, None, &Recorder::new()).await;
         let err = result.unwrap_err();
         assert_ne!(err.code, -32601);
     }
@@ -613,7 +706,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drop_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drop", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch("drop", None, &engine, None, None, None, &Recorder::new()).await;
         let err = result.unwrap_err();
         assert_ne!(err.code, -32601);
     }
@@ -635,7 +728,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_get_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.get", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "storage.get",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -644,7 +746,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_set_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.set", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "storage.set",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -653,7 +764,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_list_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.list", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "storage.list",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -662,7 +782,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_storage_clear_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("storage.clear", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "storage.clear",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -721,7 +850,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_forms_dump_without_eval_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("forms.dump", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "forms.dump",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -730,7 +868,16 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_windows_list_without_list_fn() {
         let engine = EvalEngine::new();
-        let result = dispatch("windows.list", None, &engine, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "windows.list",
+            None,
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
         let err = result.unwrap_err();
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No window manager"));
@@ -748,6 +895,7 @@ mod tests {
             &engine,
             None,
             Some(&list_fn),
+            None,
             &Recorder::new(),
         )
         .await;
@@ -781,6 +929,7 @@ mod tests {
             &engine,
             Some(&eval_fn),
             None,
+            None,
             &Recorder::new(),
         )
         .await;
@@ -794,7 +943,7 @@ mod tests {
     async fn test_dispatch_record_start_returns_recording() {
         let engine = EvalEngine::new();
         let recorder = Recorder::new();
-        let result = dispatch("record.start", None, &engine, None, None, &recorder)
+        let result = dispatch("record.start", None, &engine, None, None, None, &recorder)
             .await
             .unwrap();
         assert_eq!(result["status"], "recording");
@@ -807,7 +956,7 @@ mod tests {
         let recorder = Recorder::new();
         recorder.start();
         recorder.record("click", Some(&json!({"ref": "e1"})));
-        let result = dispatch("record.stop", None, &engine, None, None, &recorder)
+        let result = dispatch("record.stop", None, &engine, None, None, None, &recorder)
             .await
             .unwrap();
         assert_eq!(result["count"], 1);
@@ -820,7 +969,7 @@ mod tests {
         let engine = EvalEngine::new();
         let recorder = Recorder::new();
         recorder.start();
-        let result = dispatch("record.status", None, &engine, None, None, &recorder)
+        let result = dispatch("record.status", None, &engine, None, None, None, &recorder)
             .await
             .unwrap();
         assert_eq!(result["active"], true);
@@ -833,9 +982,17 @@ mod tests {
         let recorder = Recorder::new();
         recorder.start();
         let params = json!({"action": "navigate", "timestamp": 100, "url": "/home"});
-        let result = dispatch("record.add", Some(&params), &engine, None, None, &recorder)
-            .await
-            .unwrap();
+        let result = dispatch(
+            "record.add",
+            Some(&params),
+            &engine,
+            None,
+            None,
+            None,
+            &recorder,
+        )
+        .await
+        .unwrap();
         assert_eq!(result["status"], "ok");
         let entries = recorder.stop();
         assert_eq!(entries.len(), 1);

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -200,9 +200,8 @@ pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
         // (libei/X11) and Windows the remediation is different, so don't
         // point users at the wrong fix.
         #[cfg(target_os = "macos")]
-        let msg = format!(
-            "{e} (on macOS, grant Accessibility permission to the launching terminal)"
-        );
+        let msg =
+            format!("{e} (on macOS, grant Accessibility permission to the launching terminal)");
         #[cfg(not(target_os = "macos"))]
         let msg = e.to_string();
         KeyError::EnigoInit(msg)

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -1,0 +1,246 @@
+//! Native OS-level keyboard event injection.
+//!
+//! Synthetic `KeyboardEvent`s dispatched from JS are flagged `isTrusted: false`
+//! and never reach the OS / window-manager layer where Tauri global shortcuts
+//! and accelerators are registered. Injecting at the OS layer (via [`enigo`])
+//! produces "real" key events that traverse the full pipeline:
+//!
+//! ```text
+//! enigo → OS input subsystem → window manager → toolkit (GTK/AppKit/Win32)
+//!       → webview → DOM listeners
+//!       → Tauri accelerator/global-shortcut handlers
+//! ```
+//!
+//! See issue #45.
+use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KeyError {
+    #[error("empty key combo")]
+    Empty,
+    #[error("unknown key: {0}")]
+    UnknownKey(String),
+    #[error("enigo init failed: {0}")]
+    EnigoInit(String),
+    #[error("enigo input failed: {0}")]
+    EnigoInput(String),
+}
+
+/// Parsed combo: zero or more modifiers and exactly one main key.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Combo {
+    pub modifiers: Vec<Key>,
+    pub key: Key,
+}
+
+/// Parse a combo string like `"Control+Shift+P"` into modifiers + main key.
+///
+/// Accepts `+` or `-` as separators. Tokens are matched case-insensitively
+/// against a small alias table; single characters become `Key::Unicode`.
+pub fn parse_combo(combo: &str) -> Result<Combo, KeyError> {
+    let trimmed = combo.trim();
+    if trimmed.is_empty() {
+        return Err(KeyError::Empty);
+    }
+
+    let tokens: Vec<&str> = trimmed
+        .split(['+', '-'])
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        return Err(KeyError::Empty);
+    }
+
+    let (last, rest) = tokens.split_last().expect("non-empty");
+    let mut modifiers = Vec::with_capacity(rest.len());
+    for tok in rest {
+        modifiers.push(parse_modifier(tok)?);
+    }
+    let key = parse_key(last)?;
+    Ok(Combo { modifiers, key })
+}
+
+fn parse_modifier(token: &str) -> Result<Key, KeyError> {
+    match token.to_ascii_lowercase().as_str() {
+        "ctrl" | "control" => Ok(Key::Control),
+        "shift" => Ok(Key::Shift),
+        "alt" | "option" => Ok(Key::Alt),
+        "meta" | "super" | "cmd" | "command" | "win" => Ok(Key::Meta),
+        other => Err(KeyError::UnknownKey(other.to_owned())),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn parse_key(token: &str) -> Result<Key, KeyError> {
+    if let Some(ch) = single_char(token) {
+        return Ok(Key::Unicode(ch));
+    }
+    let lower = token.to_ascii_lowercase();
+    let key = match lower.as_str() {
+        "enter" | "return" => Key::Return,
+        "tab" => Key::Tab,
+        "space" | "spacebar" => Key::Space,
+        "escape" | "esc" => Key::Escape,
+        "backspace" => Key::Backspace,
+        "delete" | "del" => Key::Delete,
+        "home" => Key::Home,
+        "end" => Key::End,
+        "pageup" | "page_up" => Key::PageUp,
+        "pagedown" | "page_down" => Key::PageDown,
+        "up" | "uparrow" | "arrowup" => Key::UpArrow,
+        "down" | "downarrow" | "arrowdown" => Key::DownArrow,
+        "left" | "leftarrow" | "arrowleft" => Key::LeftArrow,
+        "right" | "rightarrow" | "arrowright" => Key::RightArrow,
+        "ctrl" | "control" => Key::Control,
+        "shift" => Key::Shift,
+        "alt" | "option" => Key::Alt,
+        "meta" | "super" | "cmd" | "command" | "win" => Key::Meta,
+        "f1" => Key::F1,
+        "f2" => Key::F2,
+        "f3" => Key::F3,
+        "f4" => Key::F4,
+        "f5" => Key::F5,
+        "f6" => Key::F6,
+        "f7" => Key::F7,
+        "f8" => Key::F8,
+        "f9" => Key::F9,
+        "f10" => Key::F10,
+        "f11" => Key::F11,
+        "f12" => Key::F12,
+        _ => return Err(KeyError::UnknownKey(token.to_owned())),
+    };
+    Ok(key)
+}
+
+fn single_char(token: &str) -> Option<char> {
+    let mut chars = token.chars();
+    let first = chars.next()?;
+    if chars.next().is_none() {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+/// Press `combo` at the OS level. Modifiers are pressed in order, then the
+/// main key is tapped (press+release), then modifiers are released in reverse
+/// order — the same pattern a human or Playwright would produce.
+///
+/// This is a blocking OS call; callers in async contexts should wrap with
+/// `tokio::task::spawn_blocking` to avoid stalling the runtime.
+pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
+    let parsed = parse_combo(combo)?;
+    let mut enigo =
+        Enigo::new(&Settings::default()).map_err(|e| KeyError::EnigoInit(e.to_string()))?;
+
+    for m in &parsed.modifiers {
+        enigo
+            .key(*m, Direction::Press)
+            .map_err(|e| KeyError::EnigoInput(e.to_string()))?;
+    }
+    let tap_result = enigo.key(parsed.key, Direction::Click);
+    // Always release modifiers, even on tap failure, to avoid leaving the OS
+    // in a stuck-modifier state.
+    for m in parsed.modifiers.iter().rev() {
+        let _ = enigo.key(*m, Direction::Release);
+    }
+    tap_result.map_err(|e| KeyError::EnigoInput(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_eq(a: &Key, b: &Key) -> bool {
+        // Key doesn't impl PartialEq for all variants in older versions; format!-compare.
+        format!("{a:?}") == format!("{b:?}")
+    }
+
+    #[test]
+    fn test_parse_single_char_returns_unicode() {
+        let combo = parse_combo("a").unwrap();
+        assert!(combo.modifiers.is_empty());
+        assert!(key_eq(&combo.key, &Key::Unicode('a')));
+    }
+
+    #[test]
+    fn test_parse_ctrl_plus_one() {
+        let combo = parse_combo("Control+1").unwrap();
+        assert_eq!(combo.modifiers.len(), 1);
+        assert!(key_eq(&combo.modifiers[0], &Key::Control));
+        assert!(key_eq(&combo.key, &Key::Unicode('1')));
+    }
+
+    #[test]
+    fn test_parse_ctrl_shift_p() {
+        let combo = parse_combo("Ctrl+Shift+P").unwrap();
+        assert_eq!(combo.modifiers.len(), 2);
+        assert!(key_eq(&combo.modifiers[0], &Key::Control));
+        assert!(key_eq(&combo.modifiers[1], &Key::Shift));
+        assert!(key_eq(&combo.key, &Key::Unicode('P')));
+    }
+
+    #[test]
+    fn test_parse_named_key_enter() {
+        let combo = parse_combo("Enter").unwrap();
+        assert!(key_eq(&combo.key, &Key::Return));
+    }
+
+    #[test]
+    fn test_parse_function_key_f5() {
+        let combo = parse_combo("F5").unwrap();
+        assert!(key_eq(&combo.key, &Key::F5));
+    }
+
+    #[test]
+    fn test_parse_arrow_key() {
+        let combo = parse_combo("ArrowUp").unwrap();
+        assert!(key_eq(&combo.key, &Key::UpArrow));
+    }
+
+    #[test]
+    fn test_parse_meta_aliases_resolve_to_meta() {
+        for alias in ["Meta+a", "Cmd+a", "Super+a", "Win+a", "Command+a"] {
+            let combo = parse_combo(alias).unwrap();
+            assert!(key_eq(&combo.modifiers[0], &Key::Meta), "alias: {alias}");
+        }
+    }
+
+    #[test]
+    fn test_parse_dash_separator_accepted() {
+        let combo = parse_combo("Ctrl-Shift-P").unwrap();
+        assert_eq!(combo.modifiers.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_case_insensitive_modifiers() {
+        let combo = parse_combo("CONTROL+a").unwrap();
+        assert!(key_eq(&combo.modifiers[0], &Key::Control));
+    }
+
+    #[test]
+    fn test_parse_empty_returns_error() {
+        assert!(matches!(parse_combo(""), Err(KeyError::Empty)));
+        assert!(matches!(parse_combo("   "), Err(KeyError::Empty)));
+        assert!(matches!(parse_combo("+++"), Err(KeyError::Empty)));
+    }
+
+    #[test]
+    fn test_parse_unknown_modifier_returns_error() {
+        assert!(matches!(
+            parse_combo("Hyper+a"),
+            Err(KeyError::UnknownKey(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_unknown_key_returns_error() {
+        assert!(matches!(
+            parse_combo("Ctrl+NotAKey"),
+            Err(KeyError::UnknownKey(_))
+        ));
+    }
+}

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -13,7 +13,14 @@
 //!
 //! See issue #45.
 use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+use std::sync::Mutex;
 use thiserror::Error;
+
+/// Serializes all OS-level key injections from this process. Concurrent calls
+/// to `simulate_press` from multiple tokio tasks would otherwise interleave
+/// modifier-down/up events on the libei/uinput backends, producing scrambled
+/// shortcuts. The lock is held only for the duration of one combo (a few ms).
+static PRESS_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Error)]
 pub enum KeyError {
@@ -36,29 +43,42 @@ pub struct Combo {
 
 /// Parse a combo string like `"Control+Shift+P"` into modifiers + main key.
 ///
-/// Accepts `+` or `-` as separators. Tokens are matched case-insensitively
-/// against a small alias table; single characters become `Key::Unicode`.
+/// `+` is the only separator. Trailing `+` is interpreted as the literal `+`
+/// key (e.g. `"Control++"` == Control plus the `+` key), and `"+"` alone is
+/// just the `+` key. This keeps combos like `"Shift+-"` (Shift + minus)
+/// unambiguous.
 pub fn parse_combo(combo: &str) -> Result<Combo, KeyError> {
     let trimmed = combo.trim();
     if trimmed.is_empty() {
         return Err(KeyError::Empty);
     }
+    if trimmed == "+" {
+        return Ok(Combo {
+            modifiers: Vec::new(),
+            key: Key::Unicode('+'),
+        });
+    }
 
-    let tokens: Vec<&str> = trimmed
-        .split(['+', '-'])
-        .map(str::trim)
-        .filter(|t| !t.is_empty())
-        .collect();
-    if tokens.is_empty() {
+    // If the combo ends with `+`, the last "key" is the `+` character itself.
+    let (body, main) = if let Some(prefix) = trimmed.strip_suffix('+') {
+        (prefix.trim_end_matches('+').trim(), "+")
+    } else {
+        match trimmed.rsplit_once('+') {
+            Some((mods, k)) => (mods.trim(), k.trim()),
+            None => ("", trimmed),
+        }
+    };
+
+    let mut modifiers = Vec::new();
+    if !body.is_empty() {
+        for tok in body.split('+').map(str::trim).filter(|t| !t.is_empty()) {
+            modifiers.push(parse_modifier(tok)?);
+        }
+    }
+    if main.is_empty() {
         return Err(KeyError::Empty);
     }
-
-    let (last, rest) = tokens.split_last().expect("non-empty");
-    let mut modifiers = Vec::with_capacity(rest.len());
-    for tok in rest {
-        modifiers.push(parse_modifier(tok)?);
-    }
-    let key = parse_key(last)?;
+    let key = parse_key(main)?;
     Ok(Combo { modifiers, key })
 }
 
@@ -128,26 +148,49 @@ fn single_char(token: &str) -> Option<char> {
 /// main key is tapped (press+release), then modifiers are released in reverse
 /// order — the same pattern a human or Playwright would produce.
 ///
-/// This is a blocking OS call; callers in async contexts should wrap with
+/// If a modifier press or the key tap fails, every modifier successfully
+/// pressed so far is released before returning, so the OS is never left with
+/// a stuck modifier (e.g. permanent Shift). On macOS, when Enigo silently
+/// no-ops because Accessibility permission is missing, the first failing call
+/// returns an error; the `EnigoInput` message includes a hint pointing at the
+/// permission.
+///
+/// All callers serialize through a process-global lock so two concurrent
+/// `press` RPC calls never interleave their modifier-down/key/modifier-up
+/// sequences. This is a blocking OS call; async callers should wrap with
 /// `tokio::task::spawn_blocking` to avoid stalling the runtime.
 pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
     let parsed = parse_combo(combo)?;
-    let mut enigo =
-        Enigo::new(&Settings::default()).map_err(|e| KeyError::EnigoInit(e.to_string()))?;
+    let _guard = PRESS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-    for m in &parsed.modifiers {
+    let mut enigo = Enigo::new(&Settings::default()).map_err(|e| {
+        KeyError::EnigoInit(format!(
+            "{e} (on macOS, grant Accessibility permission to the launching terminal)"
+        ))
+    })?;
+
+    // Track how many modifiers were pressed so we can release exactly those
+    // on any failure path — including failures during the modifier press loop.
+    let mut pressed: Vec<Key> = Vec::with_capacity(parsed.modifiers.len());
+    let press_outcome = (|| -> Result<(), KeyError> {
+        for m in &parsed.modifiers {
+            enigo
+                .key(*m, Direction::Press)
+                .map_err(|e| KeyError::EnigoInput(e.to_string()))?;
+            pressed.push(*m);
+        }
         enigo
-            .key(*m, Direction::Press)
-            .map_err(|e| KeyError::EnigoInput(e.to_string()))?;
-    }
-    let tap_result = enigo.key(parsed.key, Direction::Click);
-    // Always release modifiers, even on tap failure, to avoid leaving the OS
-    // in a stuck-modifier state.
-    for m in parsed.modifiers.iter().rev() {
+            .key(parsed.key, Direction::Click)
+            .map_err(|e| KeyError::EnigoInput(e.to_string()))
+    })();
+
+    // Always release the modifiers we actually pressed, in reverse order.
+    for m in pressed.iter().rev() {
         let _ = enigo.key(*m, Direction::Release);
     }
-    tap_result.map_err(|e| KeyError::EnigoInput(e.to_string()))?;
-    Ok(())
+    press_outcome
 }
 
 #[cfg(test)]
@@ -210,9 +253,28 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_dash_separator_accepted() {
-        let combo = parse_combo("Ctrl-Shift-P").unwrap();
-        assert_eq!(combo.modifiers.len(), 2);
+    fn test_parse_dash_is_treated_as_minus_key() {
+        // `-` is no longer a separator (review #45 finding 3): "Shift+-" must
+        // parse as Shift + the literal `-` key, not as nonsense.
+        let combo = parse_combo("Shift+-").unwrap();
+        assert_eq!(combo.modifiers.len(), 1);
+        assert!(key_eq(&combo.modifiers[0], &Key::Shift));
+        assert!(key_eq(&combo.key, &Key::Unicode('-')));
+    }
+
+    #[test]
+    fn test_parse_plus_alone_is_plus_key() {
+        let combo = parse_combo("+").unwrap();
+        assert!(combo.modifiers.is_empty());
+        assert!(key_eq(&combo.key, &Key::Unicode('+')));
+    }
+
+    #[test]
+    fn test_parse_trailing_plus_is_plus_key_with_modifiers() {
+        let combo = parse_combo("Control++").unwrap();
+        assert_eq!(combo.modifiers.len(), 1);
+        assert!(key_eq(&combo.modifiers[0], &Key::Control));
+        assert!(key_eq(&combo.key, &Key::Unicode('+')));
     }
 
     #[test]
@@ -225,7 +287,15 @@ mod tests {
     fn test_parse_empty_returns_error() {
         assert!(matches!(parse_combo(""), Err(KeyError::Empty)));
         assert!(matches!(parse_combo("   "), Err(KeyError::Empty)));
-        assert!(matches!(parse_combo("+++"), Err(KeyError::Empty)));
+    }
+
+    #[test]
+    fn test_parse_repeated_plus_collapses_to_plus_key() {
+        // "+++" has nothing meaningful between modifiers — the trailing-`+`
+        // rule takes the last `+` as the key, modifiers list ends up empty.
+        let combo = parse_combo("+++").unwrap();
+        assert!(combo.modifiers.is_empty());
+        assert!(key_eq(&combo.key, &Key::Unicode('+')));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -217,10 +217,28 @@ pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
     })();
 
     // Always release the modifiers we actually pressed, in reverse order.
+    // We keep going after a release failure so subsequent modifiers still
+    // get a chance to come back up — but we remember the first error so we
+    // don't return Ok with a modifier potentially stuck down.
+    let mut release_error: Option<KeyError> = None;
     for m in pressed.iter().rev() {
-        let _ = enigo.key(*m, Direction::Release);
+        if let Err(e) = enigo.key(*m, Direction::Release)
+            && release_error.is_none()
+        {
+            release_error = Some(KeyError::EnigoInput(format!(
+                "modifier release failed (possible stuck key): {e}"
+            )));
+        }
     }
-    press_outcome
+
+    // If the press itself failed, report that (more actionable than a
+    // downstream release error). Otherwise surface any release failure so
+    // callers learn about a stuck modifier instead of seeing Ok(()).
+    press_outcome?;
+    match release_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -47,6 +47,9 @@ pub struct Combo {
 /// key (e.g. `"Control++"` == Control plus the `+` key), and `"+"` alone is
 /// just the `+` key. This keeps combos like `"Shift+-"` (Shift + minus)
 /// unambiguous.
+///
+/// Empty segments between `+` separators are rejected — `"Control++P"` and
+/// `"+A"` are errors, not silently normalized into `"Control+P"` / `"A"`.
 pub fn parse_combo(combo: &str) -> Result<Combo, KeyError> {
     let trimmed = combo.trim();
     if trimmed.is_empty() {
@@ -59,22 +62,49 @@ pub fn parse_combo(combo: &str) -> Result<Combo, KeyError> {
         });
     }
 
-    // If the combo ends with `+`, the last "key" is the `+` character itself.
-    let (body, main) = if let Some(prefix) = trimmed.strip_suffix('+') {
-        (prefix.trim_end_matches('+').trim(), "+")
+    // Determine the modifier section and the main key token. A trailing `+`
+    // means "the main key is `+`"; the `+` immediately before it is the
+    // separator between the last modifier (if any) and that key.
+    let (modifier_section, main) = if let Some(prefix) = trimmed.strip_suffix('+') {
+        match prefix.strip_suffix('+') {
+            Some(body) => (body, "+"),
+            // `"abc+"` with no separator `+` before — malformed.
+            None if !prefix.is_empty() => {
+                return Err(KeyError::UnknownKey(combo.trim().to_owned()));
+            }
+            None => (prefix, "+"),
+        }
     } else {
         match trimmed.rsplit_once('+') {
-            Some((mods, k)) => (mods.trim(), k.trim()),
+            // A leading `+` (e.g. `"+A"`) produces `mods = ""` while a `+`
+            // actually exists in the input — reject instead of silently
+            // treating it as "no modifiers".
+            Some(("", _)) => {
+                return Err(KeyError::UnknownKey(combo.trim().to_owned()));
+            }
+            Some((mods, k)) => (mods, k.trim()),
             None => ("", trimmed),
         }
     };
 
-    let mut modifiers = Vec::new();
-    if !body.is_empty() {
-        for tok in body.split('+').map(str::trim).filter(|t| !t.is_empty()) {
-            modifiers.push(parse_modifier(tok)?);
-        }
-    }
+    let modifiers = if modifier_section.is_empty() {
+        Vec::new()
+    } else {
+        modifier_section
+            .split('+')
+            .map(|tok| {
+                let trimmed_tok = tok.trim();
+                if trimmed_tok.is_empty() {
+                    // An empty segment between separators is a typo, not a
+                    // modifier — reject rather than silently collapsing.
+                    Err(KeyError::UnknownKey(combo.trim().to_owned()))
+                } else {
+                    parse_modifier(trimmed_tok)
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
     if main.is_empty() {
         return Err(KeyError::Empty);
     }
@@ -290,12 +320,29 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_repeated_plus_collapses_to_plus_key() {
-        // "+++" has nothing meaningful between modifiers — the trailing-`+`
-        // rule takes the last `+` as the key, modifiers list ends up empty.
-        let combo = parse_combo("+++").unwrap();
-        assert!(combo.modifiers.is_empty());
-        assert!(key_eq(&combo.key, &Key::Unicode('+')));
+    fn test_parse_triple_plus_returns_error() {
+        // `"+++"` has an empty modifier segment once the trailing `+` is
+        // stripped off as the main key. Rejecting is safer than silently
+        // collapsing: if a user typed three `+`, something is wrong.
+        assert!(matches!(parse_combo("+++"), Err(KeyError::UnknownKey(_))));
+    }
+
+    #[test]
+    fn test_parse_empty_modifier_segment_returns_error() {
+        // `"Control++P"` previously parsed as `"Control+P"` because the empty
+        // segment between the two `+` was silently dropped. That turns typos
+        // into different shortcuts — reject instead.
+        assert!(matches!(
+            parse_combo("Control++P"),
+            Err(KeyError::UnknownKey(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_leading_plus_returns_error() {
+        // `"+A"` previously parsed as just `"A"` — the leading `+` was
+        // discarded. Same reasoning: silent normalization hides typos.
+        assert!(matches!(parse_combo("+A"), Err(KeyError::UnknownKey(_))));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -196,9 +196,16 @@ pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let mut enigo = Enigo::new(&Settings::default()).map_err(|e| {
-        KeyError::EnigoInit(format!(
+        // The Accessibility permission hint only applies to macOS — on Linux
+        // (libei/X11) and Windows the remediation is different, so don't
+        // point users at the wrong fix.
+        #[cfg(target_os = "macos")]
+        let msg = format!(
             "{e} (on macOS, grant Accessibility permission to the launching terminal)"
-        ))
+        );
+        #[cfg(not(target_os = "macos"))]
+        let msg = e.to_string();
+        KeyError::EnigoInit(msg)
     })?;
 
     // Track how many modifiers were pressed so we can release exactly those

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 #[allow(dead_code)]
 pub(crate) mod eval;
 mod handler;
+#[cfg(feature = "press")]
 pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 #[allow(dead_code)]
 pub(crate) mod eval;
 mod handler;
+pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;
 #[cfg(unix)]
@@ -15,7 +16,7 @@ use eval::EvalEngine;
 #[cfg(unix)]
 use recorder::Recorder;
 #[cfg(unix)]
-use server::{EvalFn, ListWindowsFn};
+use server::{EvalFn, FocusFn, ListWindowsFn};
 #[cfg(unix)]
 use std::sync::Arc;
 #[cfg(unix)]
@@ -53,6 +54,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
                 let eval_fn = make_eval_fn(app);
                 let list_fn = make_list_fn(app);
+                let focus_fn = make_focus_fn(app);
 
                 let (listener, guard) = server::bind(&socket_path).map_err(|e| {
                     tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
@@ -67,6 +69,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                     engine,
                     Some(eval_fn),
                     Some(list_fn),
+                    Some(focus_fn),
                     recorder,
                 ));
 
@@ -121,6 +124,34 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
             .next()
             .ok_or_else(|| "No webview available".to_owned())
             .and_then(|w| w.eval(&script).map_err(|e| e.to_string()))
+    })
+}
+
+/// Create a focus function that requests OS focus for a webview window.
+///
+/// Resolution mirrors `make_eval_fn`: explicit label first, then `"main"`, then
+/// the first window. The call is best-effort — failures are returned to the
+/// caller (which logs and continues), since the press still has a chance of
+/// landing on whatever window currently holds focus.
+#[cfg(all(unix, debug_assertions))]
+fn make_focus_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> FocusFn {
+    let handle = app.clone();
+    Arc::new(move |window: Option<&str>| {
+        let target = if let Some(label) = window {
+            handle
+                .get_webview_window(label)
+                .ok_or_else(|| format!("Window '{label}' not found"))?
+        } else if let Some(w) = handle.get_webview_window("main") {
+            w
+        } else {
+            handle
+                .webview_windows()
+                .values()
+                .next()
+                .cloned()
+                .ok_or_else(|| "No webview available".to_owned())?
+        };
+        target.set_focus().map_err(|e| e.to_string())
     })
 }
 

--- a/crates/tauri-plugin-pilot/src/server.rs
+++ b/crates/tauri-plugin-pilot/src/server.rs
@@ -17,6 +17,11 @@ pub(crate) type EvalFn = Arc<dyn Fn(Option<&str>, String) -> Result<(), String> 
 /// A function that lists all available webview windows and returns their metadata.
 pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;
 
+/// A function that requests focus for a webview window.
+/// `None` means "default window" (same resolution as `EvalFn`).
+/// Used before native key injection so synthesised OS events reach the right window.
+pub(crate) type FocusFn = Arc<dyn Fn(Option<&str>) -> Result<(), String> + Send + Sync>;
+
 /// RAII guard that removes the socket file on drop (normal shutdown or panic).
 /// Stores the inode at bind time so it only unlinks its own socket, not one
 /// created by an overlapping instance.
@@ -165,6 +170,7 @@ pub(crate) async fn run(
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
     list_fn: Option<ListWindowsFn>,
+    focus_fn: Option<FocusFn>,
     recorder: Recorder,
 ) {
     let listener = match UnixListener::from_std(std_listener) {
@@ -174,7 +180,7 @@ pub(crate) async fn run(
             return;
         }
     };
-    if let Err(e) = accept_loop(listener, engine, eval_fn, list_fn, recorder).await {
+    if let Err(e) = accept_loop(listener, engine, eval_fn, list_fn, focus_fn, recorder).await {
         tracing::error!("socket server error: {e}");
     }
 }
@@ -184,9 +190,10 @@ async fn accept_loop(
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
     list_fn: Option<ListWindowsFn>,
+    focus_fn: Option<FocusFn>,
     recorder: Recorder,
 ) -> Result<(), Error> {
-    let ctx = Arc::new((engine, eval_fn, list_fn, recorder));
+    let ctx = Arc::new((engine, eval_fn, list_fn, focus_fn, recorder));
 
     loop {
         let (stream, _addr) = match listener.accept().await {
@@ -217,8 +224,15 @@ async fn accept_loop(
         }
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
-            if let Err(e) =
-                handle_connection(stream, &ctx.0, ctx.1.as_ref(), ctx.2.as_ref(), &ctx.3).await
+            if let Err(e) = handle_connection(
+                stream,
+                &ctx.0,
+                ctx.1.as_ref(),
+                ctx.2.as_ref(),
+                ctx.3.as_ref(),
+                &ctx.4,
+            )
+            .await
             {
                 tracing::warn!("connection error: {e}");
             }
@@ -231,6 +245,7 @@ async fn handle_connection(
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
     list_fn: Option<&ListWindowsFn>,
+    focus_fn: Option<&FocusFn>,
     recorder: &Recorder,
 ) -> Result<(), Error> {
     let (reader, mut writer) = stream.into_split();
@@ -255,7 +270,7 @@ async fn handle_connection(
                 -32600,
                 "Invalid JSON-RPC version (expected \"2.0\")",
             ),
-            Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, recorder).await,
+            Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, focus_fn, recorder).await,
             Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
         };
 
@@ -273,6 +288,7 @@ async fn dispatch_request(
     engine: &EvalEngine,
     eval_fn: Option<&EvalFn>,
     list_fn: Option<&ListWindowsFn>,
+    focus_fn: Option<&FocusFn>,
     recorder: &Recorder,
 ) -> Response {
     match handler::dispatch(
@@ -281,6 +297,7 @@ async fn dispatch_request(
         engine,
         eval_fn,
         list_fn,
+        focus_fn,
         recorder,
     )
     .await
@@ -315,10 +332,9 @@ mod tests {
     async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let (listener, guard) = bind(path).expect("bind test socket");
         let engine = EvalEngine::new();
-        let handle =
-            tokio::spawn(
-                async move { run(listener, guard, engine, None, None, Recorder::new()).await },
-            );
+        let handle = tokio::spawn(async move {
+            run(listener, guard, engine, None, None, None, Recorder::new()).await
+        });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
     }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -381,21 +381,33 @@ tauri-pilot type @e2 " additional text"
 
 ### `press`
 
-Send a keyboard event to the focused element.
+Inject a keyboard event at the OS level. Events are `isTrusted=true`, so they
+reach DOM listeners, Tauri accelerators, and `tauri-plugin-global-shortcut`
+handlers — exactly like a physical key press.
 
 ```bash
 tauri-pilot press <key>
 ```
 
-Common keys: `Enter`, `Tab`, `Escape`, `ArrowDown`, `ArrowUp`, `Backspace`, `Space`.
+`<key>` accepts modifier-prefixed combos: `Modifier+...+Key`, with `+` or `-`
+as the separator.
+
+- **Modifiers** (case-insensitive): `Control`/`Ctrl`, `Shift`, `Alt`/`Option`, `Meta`/`Cmd`/`Super`/`Win`
+- **Common keys**: `Enter`, `Tab`, `Escape`, `ArrowUp`/`ArrowDown`/`ArrowLeft`/`ArrowRight`, `Backspace`, `Delete`, `Home`, `End`, `PageUp`, `PageDown`, `Space`, `F1`–`F12`, or any single character
 
 **Example:**
 
 ```bash
 tauri-pilot press Enter
 tauri-pilot press Tab
-tauri-pilot press Escape
+tauri-pilot press Control+1
+tauri-pilot press Ctrl+Shift+P
 ```
+
+Before pressing, the plugin requests focus on the target window so the event
+lands on the right webview. The press takes effect on whatever element holds
+focus inside that window — call `click` first if you need to focus a specific
+input.
 
 ---
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -389,8 +389,10 @@ handlers — exactly like a physical key press.
 tauri-pilot press <key>
 ```
 
-`<key>` accepts modifier-prefixed combos: `Modifier+...+Key`, with `+` or `-`
-as the separator.
+`<key>` accepts modifier-prefixed combos in the form `Modifier+...+Key`. Only
+`+` is a separator — `-` is treated as the literal minus key, so `Shift+-`
+means Shift + minus. A trailing `+` is the `+` key itself (e.g. `Control++`
+is Control + plus).
 
 - **Modifiers** (case-insensitive): `Control`/`Ctrl`, `Shift`, `Alt`/`Option`, `Meta`/`Cmd`/`Super`/`Win`
 - **Common keys**: `Enter`, `Tab`, `Escape`, `ArrowUp`/`ArrowDown`/`ArrowLeft`/`ArrowRight`, `Backspace`, `Delete`, `Home`, `End`, `PageUp`, `PageDown`, `Space`, `F1`–`F12`, or any single character


### PR DESCRIPTION
## Summary

- Replaces JS-synthetic `KeyboardEvent` dispatch with OS-level keyboard injection via [`enigo`](https://crates.io/crates/enigo). Events are now `isTrusted=true` and traverse the full pipeline — DOM listeners, Tauri accelerators, and global-shortcut handlers all see them.
- Adds a `FocusFn` callback so the plugin requests focus on the target window before injection.
- Tightens the combo parser (only `+` separator, supports `"+"`, `"Control++"`, `"Shift+-"`).
- Removes the obsolete JS `press` from `bridge.js`.

Closes #45.

## Why

`tauri-pilot press "Control+1"` was producing false negatives in QA suites — every keyboard-driven flow appeared broken even when it worked manually. Synthetic `KeyboardEvent`s are flagged `isTrusted: false` and never reach Tauri/GTK accelerator handlers. Native injection produces real OS events that traverse the full input pipeline.

## Implementation notes

- **Stuck-key protection**: `simulate_press` tracks every successfully-pressed modifier in a `Vec` and releases exactly those on any failure path. Earlier modifiers are never left held down if a later press fails.
- **Concurrent serialization**: a process-global `std::sync::Mutex` (`PRESS_LOCK`) ensures two parallel `press` RPC calls can't interleave their modifier-down/up events on libei/uinput backends.
- **Focus before injection**: `FocusFn` mirrors the resolution chain of `EvalFn` (explicit label → `"main"` → first window). 80ms settle delay only when the focus call succeeds.
- **macOS hint**: `EnigoInit` errors include guidance about the Accessibility permission.
- **Test app**: `pilot-test-app` now registers `Ctrl+1` and `Ctrl+Shift+P` as Tauri global shortcuts and exposes `#last-keydown` (with `data-trusted` attribute) so the fix is verifiable end-to-end.

## Test plan

- [x] `cargo test --workspace` (221 passed)
- [x] `cargo clippy -p tauri-plugin-pilot -- -D warnings` (clean, toolchain 1.94)
- [x] `cargo fmt --all -- --check`
- [x] E2E on `pilot-test-app`: `tauri-pilot press "Control+1"` → `#last-keydown` shows `data-trusted="true"` (was `false` before fix)
- [x] Edge cases verified E2E: `+`, `Control++`, `Shift+-`, `Control+Shift+P`
- [x] Adversarial review (rust-reviewer + security-reviewer) — 1 BLOCKER + 3 MAJOR + 2 MINOR all addressed in commit 2

## Notes for reviewers

- The branch has two commits: the initial implementation, then the review-fix commit. Squash-merge is fine.
- Adds `enigo 0.6.1` to plugin dependencies. On Linux it pulls `x11rb` (pure Rust) and `xkbcommon` (already required by webkit2gtk-4.1). No new system packages needed on the supported CI matrix (Ubuntu + macOS).
- The plugin is debug-only (`#[cfg(debug_assertions)]`) — release builds are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `press` command to OS-level keyboard injection via `enigo` so key events are trusted and reach DOM listeners, Tauri accelerators, and global shortcuts (fixes #45). Adds focus-before-press and serializes focus → settle → inject for reliable delivery.

- **Bug Fixes**
  - Focuses the target window before pressing; waits briefly only on success; returns an error if `--window <label>` cannot be focused or when no focus hook is installed.
  - Serializes the full focus → settle → inject sequence across calls; adds stuck-key protection and propagates modifier-release failures.
  - Tightens and validates the combo parser: only “+” as a separator; rejects empty segments (e.g. `Control++P`, `+A`); supports “+”, “Control++”, and “Shift+-”; malformed combos return `-32602` early.
  - Removes JS `press` from `bridge.js`; enables Wayland backend; macOS Accessibility hint is now shown only on macOS.
  - Distinguishes panic, cancellation, and runtime-shutdown cases when the press worker fails, instead of reporting all as “panicked”.

- **Dependencies**
  - Adds `enigo` 0.6.1 behind a default-on `press` feature in `tauri-plugin-pilot` (with `wayland`). Build with `--no-default-features` to drop it.

<sup>Written for commit 3f223fdb3a5f44e5e9434df3378e9e37043dab59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `press` now injects OS-level, trusted keyboard events, requests window focus before sending keys, and is enabled by default (opt‑out available).

* **Bug Fixes**
  * Serialized focus→settle→inject to avoid cross-window races.
  * Global shortcuts now trigger for trusted combos.
  * Specified-window targets emit clear errors when focus cannot be acquired.
  * Rejects malformed combo strings and enables Wayland backend.

* **Documentation**
  * Expanded `press` docs with combo syntax, modifier aliases, examples, and focus guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->