### PR TITLE
fix(plugin): accept statements in eval command (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `eval` now accepts `const`, `let`, `var`, function declarations and other statements — the previous `new Function("return (…)")` wrapper forced an expression context and rejected top-level declarations. Scripts now run through indirect `eval`, which returns the completion value of the last expression ([#46])
 - `click` now dispatches pointer events before mouse events so Radix UI dropdown, select, and dialog triggers open correctly ([#52])
 - `press "Control+1"` and similar combos now trigger Tauri global shortcuts and any handler that requires trusted keyboard events ([#45])
 - `press` with an explicit `--window <label>` now returns an error when the target window cannot be focused, instead of silently delivering the key to whatever window currently holds focus ([#53])
@@ -157,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
+[#46]: https://github.com/mpiton/tauri-pilot/issues/46
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [#51]: https://github.com/mpiton/tauri-pilot/pull/51
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -696,11 +696,17 @@
   function evalScript(options) {
     var script = options && options.script;
     if (!script) throw new Error("No script provided");
-    // Indirect eval runs in global scope and returns the completion value of
-    // the last expression — so both `document.title` (bare expression) and
-    // `const x = 1; x` (statements + trailing expression) work. A
-    // `new Function("return (" + script + ")")` wrapper would force the input
-    // into an expression context and reject `const`/`let`/`var` (#46).
+    // Try expression context first: `{a:1}` stays an object literal (not a
+    // labeled block), `class C {}` evaluates to the constructor, and bare
+    // expressions like `document.title` keep their prior semantics.
+    try {
+      return new Function("return (" + script + ")")();
+    } catch (e) {
+      if (!(e instanceof SyntaxError)) throw e;
+    }
+    // Fallback for statements (`const x = 1; x`, function declarations, etc.)
+    // that the expression wrapper rejects. Indirect eval runs in global scope
+    // and returns the completion value of the last expression (#46).
     var indirectEval = eval;
     return indirectEval(script);
   }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -696,19 +696,24 @@
   function evalScript(options) {
     var script = options && options.script;
     if (!script) throw new Error("No script provided");
-    // Try expression context first: `{a:1}` stays an object literal (not a
-    // labeled block), `class C {}` evaluates to the constructor, and bare
-    // expressions like `document.title` keep their prior semantics.
+    // Compile as an expression first so `{a:1}` keeps its object-literal
+    // semantics (not a labeled block) and `class C {}` evaluates to the
+    // constructor. Keep compilation separate from execution: a runtime
+    // SyntaxError from e.g. `JSON.parse('x')` must propagate, not trigger
+    // the statement fallback — otherwise the script would run twice.
+    var expr;
     try {
-      return new Function("return (" + script + ")")();
+      expr = new Function("return (" + script + ")");
     } catch (e) {
       if (!(e instanceof SyntaxError)) throw e;
+      // Fallback for statements (`const x = 1; x`, function declarations,
+      // etc.) that the expression wrapper can't parse. Indirect eval runs
+      // in global scope and returns the completion value of the last
+      // expression (#46).
+      var indirectEval = eval;
+      return indirectEval(script);
     }
-    // Fallback for statements (`const x = 1; x`, function declarations, etc.)
-    // that the expression wrapper rejects. Indirect eval runs in global scope
-    // and returns the completion value of the last expression (#46).
-    var indirectEval = eval;
-    return indirectEval(script);
+    return expr();
   }
 
   function waitFor(options) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -696,7 +696,13 @@
   function evalScript(options) {
     var script = options && options.script;
     if (!script) throw new Error("No script provided");
-    return new Function("return (" + script + ")")();
+    // Indirect eval runs in global scope and returns the completion value of
+    // the last expression — so both `document.title` (bare expression) and
+    // `const x = 1; x` (statements + trailing expression) work. A
+    // `new Function("return (" + script + ")")` wrapper would force the input
+    // into an expression context and reject `const`/`let`/`var` (#46).
+    var indirectEval = eval;
+    return indirectEval(script);
   }
 
   function waitFor(options) {

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -731,9 +731,9 @@ $ tauri-pilot eval "function pick(n){return n*2;} pick(21)"
 ```
 
 If the final statement is a `Promise`, it is awaited before the value is
-serialized. If the script ends on a declaration (`const x = 1;`) instead of an
-expression, the returned value is `null` — append the bare identifier (`; x`)
-to read the value back.
+serialized. Scripts that end on a declaration (`const x = 1;`) instead of an
+expression return `null` — append the bare identifier (`; x`) to read the value
+back.
 
 Top-level `await` is not supported; wrap async work in an IIFE:
 `(async () => await fetch('/api').then(r => r.json()))()`.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -718,6 +718,26 @@ Prefer `<<'EOF'` with quotes around the heredoc delimiter. It disables shell
 variable and command expansion, so `$` and backticks inside the script do not
 need escaping.
 
+Statements are supported alongside bare expressions — `const`, `let`, `var`,
+function declarations and blocks all work, and the completion value of the last
+expression is returned:
+
+```bash
+$ tauri-pilot eval "const els = document.querySelectorAll('button'); els.length"
+7
+
+$ tauri-pilot eval "function pick(n){return n*2;} pick(21)"
+42
+```
+
+If the final statement is a `Promise`, it is awaited before the value is
+serialized. If the script ends on a declaration (`const x = 1;`) instead of an
+expression, the returned value is `null` — append the bare identifier (`; x`)
+to read the value back.
+
+Top-level `await` is not supported; wrap async work in an IIFE:
+`(async () => await fetch('/api').then(r => r.json()))()`.
+
 ---
 
 ### `ipc`


### PR DESCRIPTION
## Summary

- Indirect `eval` replaces `new Function("return (…)")` in the bridge's `evalScript`, so `tauri-pilot eval "const x = 1; x"` now returns `1` instead of `SyntaxError: Unexpected keyword 'const'`.
- Bare expressions, returned `Promise`s (awaited by the outer wrapper), and error propagation (`SyntaxError`/`ReferenceError`) are unchanged.
- CHANGELOG entry under `[Unreleased] → Fixed` and CLI docs gain an example plus caveats on declaration-only scripts (return `null`) and top-level `await` (still not supported — wrap in an IIFE).

Closes #46.

## Test plan

- [x] `cargo test --workspace` — 226 tests pass.
- [x] Live validation against `pilot-test-app` (debug build, CLI release build):
  - [x] `eval "document.title"` → title returned
  - [x] `eval "const x = 1; x"` → `1`
  - [x] `eval "var y = 42; y"` → `42`
  - [x] `eval "let z = 'hi'; z"` → `hi`
  - [x] `eval "function sum(a,b){return a+b;} sum(2,3)"` → `5`
  - [x] `eval "Promise.resolve(99)"` → `99`
  - [x] `eval "if(true){'yes'}else{'no'}"` → `yes`
  - [x] Regressions check: `title`, `url`, `snapshot`, invalid JS (`SyntaxError`), undefined variable (`ReferenceError`) all behave as before.
- [x] Adversarial review (code + security agents): no new injection surface, CSP requirements unchanged (both `new Function` and `eval` need `'unsafe-eval'`), scope/`this`/strict-mode semantics equivalent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow statements in `tauri-pilot eval` (e.g., const/let/var and function declarations) so scripts like `const x = 1; x` work, while preserving prior expression semantics. Keeps object literals and class constructors behaving as before.

- **Bug Fixes**
  - Try `new Function("return (...)")` first; if it fails with a parse-time `SyntaxError`, fall back to indirect `eval` and return the last expression’s value. Legacy shapes like `{a:1}` and `class C {}` keep prior behavior; expressions and Promise awaiting are unchanged.
  - Split compilation from execution so runtime errors (including `SyntaxError`) propagate without re-running the script.
  - Docs updated with examples and caveats: declaration-only scripts return null; top‑level `await` is still unsupported (use an async IIFE). CSP and scope/strict‑mode semantics are unchanged.

<sup>Written for commit 8c25d4980411097744233cb9ca8593cd233d9267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `eval` now accepts JavaScript statement forms (declarations, function defs, blocks) in addition to expressions and returns the completion value of the last statement.

* **Bug Fixes**
  * Fixed execution behavior so runtime errors propagate correctly and statement-form scripts produce expected completion values.

* **Documentation**
  * Expanded `tauri-pilot eval` docs with examples, notes on promise awaiting, top-level await limitations, and how to return declared identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->