### PR TITLE
fix(cli): treat undefined eval results as success (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `press` with `--window <label>` but no focus hook installed now errors instead of silently injecting into whatever window has focus ([#53])
 - `Enigo::new` failure hint about macOS Accessibility permission is now gated to macOS builds — Linux and Windows errors no longer point users at the wrong remediation ([#53])
 - `press` JoinError handling distinguishes panics from cancellation and runtime-shutdown cases instead of reporting every failure as "panicked" ([#53])
+- `eval` now exits with code 0 when the JS expression returns `undefined` (e.g. `element.click()`, void functions). Previously the CLI bailed with `Error: Server returned empty result without error`, breaking bash `&&` chains and `set -e` scripts even though the eval had succeeded ([#48])
 
 ## [0.3.0] - 2026-04-10
 
@@ -159,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
 [#46]: https://github.com/mpiton/tauri-pilot/issues/46
+[#48]: https://github.com/mpiton/tauri-pilot/issues/48
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [#51]: https://github.com/mpiton/tauri-pilot/pull/51
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52

--- a/crates/tauri-pilot-cli/src/client.rs
+++ b/crates/tauri-pilot-cli/src/client.rs
@@ -65,9 +65,12 @@ impl Client {
             bail!("RPC error ({}): {}", err.code, err.message);
         }
 
-        response
-            .result
-            .context("Server returned empty result without error")
+        // A missing `result` field (or explicit `"result": null`) means the
+        // server-side script completed successfully but produced no value —
+        // e.g., `element.click()` or any void expression. Treat this as
+        // success with Value::Null rather than an error so bash `&&` chains
+        // and `set -e` keep working. See #48.
+        Ok(response.result.unwrap_or(serde_json::Value::Null))
     }
 }
 
@@ -124,6 +127,70 @@ mod tests {
         let mut client = connect_with_retry(&socket).await;
         let result = client.call("ping", None).await.unwrap();
         assert_eq!(result, serde_json::json!({"status": "ok"}));
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_client_null_result_is_success() {
+        // A JSON-RPC response with explicit `"result": null` must be treated as
+        // success with Value::Null — not a protocol error. This happens when an
+        // eval'd JS expression legitimately returns `undefined` (e.g.,
+        // `element.click()`, void functions). Regression test for #48.
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05c.sock");
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).unwrap();
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let req: Request = serde_json::from_str(line.trim()).unwrap();
+            // Write `{"result": null}` explicitly to simulate a void JS expr.
+            let raw = format!(r#"{{"jsonrpc":"2.0","id":{},"result":null}}"#, req.id);
+            writer.write_all(raw.as_bytes()).await.unwrap();
+            writer.write_all(b"\n").await.unwrap();
+            writer.flush().await.unwrap();
+        });
+
+        let mut client = connect_with_retry(&socket).await;
+        let result = client.call("eval", None).await.unwrap();
+        assert_eq!(result, serde_json::Value::Null);
+
+        handle.abort();
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    async fn test_client_missing_result_is_success() {
+        // Defensive coverage: a response with neither `result` nor `error` is
+        // technically a JSON-RPC protocol edge case. The #48 path is actually
+        // covered by `test_client_null_result_is_success` above — the plugin
+        // emits `"result": null` (explicit), which serde then conflates with
+        // absent for `Option<Value>`. This test locks in that both shapes
+        // deserialize to the same successful `Value::Null` outcome.
+        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05d.sock");
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).unwrap();
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let req: Request = serde_json::from_str(line.trim()).unwrap();
+            // Neither `result` nor `error` present
+            let raw = format!(r#"{{"jsonrpc":"2.0","id":{}}}"#, req.id);
+            writer.write_all(raw.as_bytes()).await.unwrap();
+            writer.write_all(b"\n").await.unwrap();
+            writer.flush().await.unwrap();
+        });
+
+        let mut client = connect_with_retry(&socket).await;
+        let result = client.call("eval", None).await.unwrap();
+        assert_eq!(result, serde_json::Value::Null);
 
         handle.abort();
         let _ = std::fs::remove_file(&socket);

--- a/crates/tauri-pilot-cli/src/client.rs
+++ b/crates/tauri-pilot-cli/src/client.rs
@@ -166,11 +166,11 @@ mod tests {
     #[tokio::test]
     async fn test_client_missing_result_is_success() {
         // Defensive coverage: a response with neither `result` nor `error` is
-        // technically a JSON-RPC protocol edge case. The #48 path is actually
-        // covered by `test_client_null_result_is_success` above — the plugin
-        // emits `"result": null` (explicit), which serde then conflates with
-        // absent for `Option<Value>`. This test locks in that both shapes
-        // deserialize to the same successful `Value::Null` outcome.
+        // technically a JSON-RPC protocol edge case. The #48 path proper is
+        // covered by `test_client_null_result_is_success` above (explicit
+        // `"result": null`); this test pins down the companion shape where
+        // the field is omitted entirely. Both end up as `Value::Null` via
+        // `unwrap_or`.
         let socket = PathBuf::from("/tmp/tauri-pilot-test-t05d.sock");
         let _ = std::fs::remove_file(&socket);
         let listener = UnixListener::bind(&socket).unwrap();

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -91,12 +91,17 @@ impl EvalEngine {
     /// Uses `__TAURI_INTERNALS__.invoke` which is always available (even without
     /// `withGlobalTauri`). The expression is `await`-ed so async results resolve
     /// before serialization.
+    ///
+    /// Normalizes `undefined` results to `null` (string `"null"`) so Tauri does
+    /// not drop the `result` field — otherwise a void expression (e.g.,
+    /// `element.click()`) would cause the handler to log a bogus "neither
+    /// result nor error" warning (#48).
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
             "(async()=>{{try{{let __r=await({script});\
              await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
-             {{id:{id},result:JSON.stringify(__r)}});\
+             {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}});\
              }}catch(__e){{await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
              {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
         )
@@ -215,6 +220,19 @@ mod tests {
         assert!(script.contains("__callback"));
         assert!(script.contains("try"));
         assert!(script.contains("catch"));
+    }
+
+    #[test]
+    fn test_wrap_script_normalizes_undefined_to_null() {
+        // #48: A JS expression returning undefined must not cause the handler
+        // to log "callback received with neither result nor error". The wrapper
+        // converts undefined → the string "null" so Tauri keeps the `result`
+        // field populated.
+        let script = EvalEngine::wrap_script(1, "element.click()");
+        assert!(
+            script.contains("__r===undefined?'null':JSON.stringify(__r)"),
+            "wrapped script must normalize undefined to the string 'null'; got: {script}"
+        );
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -674,6 +674,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_callback_with_null_string_resolves_to_value_null() {
+        // #48 round-trip: wrap_script sends `result: 'null'` (string) when the
+        // JS expr returns undefined. The callback must parse it back to
+        // Value::Null so the client sees a clean success, not a warn fallback.
+        let engine = EvalEngine::new();
+        let (id, rx) = engine.register();
+        handle_callback(&engine, id, Some("null".to_owned()), None);
+        let val = rx.await.unwrap().unwrap();
+        assert_eq!(val, serde_json::Value::Null);
+    }
+
+    #[tokio::test]
     async fn test_callback_with_error() {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -735,6 +735,15 @@ serialized. Scripts that end on a declaration (`const x = 1;`) instead of an
 expression return `null` — append the bare identifier (`; x`) to read the value
 back.
 
+Expressions that return `undefined` (e.g. `element.click()`, `console.log(...)`,
+any void function) print nothing and exit with status `0`, so they compose
+cleanly with `&&` and `set -e`:
+
+```bash
+$ tauri-pilot eval "document.querySelector('a')?.click()" && tauri-pilot state
+# click fires, then state prints — exit 0
+```
+
 Top-level `await` is not supported; wrap async work in an IIFE:
 `(async () => await fetch('/api').then(r => r.json()))()`.
 


### PR DESCRIPTION
## Summary

Fixes #48. `tauri-pilot eval "document.querySelector('a')?.click()"` no longer exits with code 1 and `Error: Server returned empty result without error` when the JS expression returns `undefined`. Void expressions now exit 0 with empty output, so they compose cleanly with bash `&&` chains and `set -e`.

## Root cause

Six-layer chain: JS `undefined` → `JSON.stringify(undefined) === undefined` → Tauri omits the `result` field → handler resolves with `Value::Null` → plugin serializes `{"result": null}` → serde on the client side conflates `"result": null` with an absent field for `Option<Value>` → client bails with "empty result without error".

## Changes

- **`crates/tauri-pilot-cli/src/client.rs`**: A missing or null `result` is now treated as success with `Value::Null` (the CLI's existing `format_text` already handles `Value::Null` as empty output). Two regression tests cover `"result": null` and the absent-field shape.
- **`crates/tauri-plugin-pilot/src/eval.rs`**: `wrap_script` now normalizes `undefined` to the string `'null'` before stringifying, so Tauri keeps the `result` field populated and the handler no longer logs `callback received with neither result nor error` on every void eval.
- **`crates/tauri-plugin-pilot/src/handler.rs`**: Adds an integration-level test that exercises the full `handle_callback(Some("null"), None)` → `Value::Null` round-trip.
- **`CHANGELOG.md`**: `[Unreleased] > Fixed` entry with `[#48]` reference.
- **`docs/src/content/docs/reference/cli.md`**: Short note that void expressions print nothing and exit 0, with a `&&` example.

## Test plan

- [x] `cargo test --workspace` → 230 pass (1 new)
- [x] RED test confirmed failing before the fix, GREEN after
- [x] `cargo clippy --workspace -- -D warnings` → no new warnings (4 pre-existing warnings on main)
- [x] Verified end-to-end in `pilot-test-app`:
  - `eval "document.querySelector('#login-form button')?.click()"` → exit 0
  - `eval "void 0"` → exit 0
  - `eval "1+1"` → prints `2`, exit 0
  - `eval "undefined"` → exit 0
  - `eval "<void expr>" && tauri-pilot title` → chain succeeds
- [x] Adversarial code + rust reviews — verdict APPROVE, medium/low findings addressed

Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `tauri-pilot eval` exiting with code 1 when a JS expression returns `undefined`. Void expressions now print nothing and exit 0, so bash `&&` and `set -e` work as expected (fixes #48).

- **Bug Fixes**
  - `crates/tauri-pilot-cli`: Treat missing or `null` `result` as success (`Value::Null`). Adds tests for both response shapes.
  - `crates/tauri-plugin-pilot` (`eval`): Normalize `undefined` to the string `'null'` before stringifying to keep the `result` field. Adds a wrapper test and a handler round-trip test.
  - Docs/Changelog: Note the new behavior with a `&&` example and add the changelog entry.

<sup>Written for commit 1596bd97af58798377782b840aad1ab1bdcf278c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `eval` now treats JavaScript expressions that yield `undefined`/void as success (exit code 0) instead of an error, preserving shell `&&`/`set -e` behavior.

* **Documentation**
  * Updated CLI docs with guidance and examples for undefined-returning expressions.

* **Tests**
  * Added tests verifying null/missing results are handled as successful responses.

* **Chores**
  * Added an unreleased changelog entry documenting this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->