### PR TITLE
feat(cli): add watch --require-mutation for async re-renders (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
 - Stdin heredoc and pipe examples for `eval -` in README, SKILL.md, and CLI reference ([#50])
 - MCP server mode for exposing tauri-pilot commands as structured tools over stdio ([#51])
+- `watch --require-mutation` flag defers the stability timer until at least one DOM mutation occurs, then waits for `--stable` ms of quiet. Rejects on timeout if nothing mutated. Use after IPC calls that trigger async re-renders (e.g. React state updates) where you need to block until the re-render lands ([#49])
 
 ### Changed
 
+- **Breaking:** `watch` default semantics changed — the stability timer now arms at startup instead of on the first mutation. Idle runs resolve after `--stable` ms with an empty change set (`{added:[], removed:[], modified:[]}`) instead of rejecting with a "no DOM changes" timeout error. Scripts that relied on `watch` as a "did anything change?" assertion should switch to `watch --require-mutation` to keep the old reject-on-idle behaviour ([#49])
 - `press` command now injects keyboard events at the OS level via `enigo` instead of dispatching synthetic JS `KeyboardEvent`s. Events are now `isTrusted=true` and traverse the full input pipeline, reaching DOM listeners, Tauri accelerators, and global shortcut handlers ([#45])
 - The plugin now requests window focus before injecting keys so events land on the correct webview
 - `tauri-plugin-pilot` exposes a default-on `press` feature that gates the `enigo` dependency. Build with `--no-default-features` to drop it from release builds where the whole plugin is already no-op'd ([#53])

--- a/SKILL.md
+++ b/SKILL.md
@@ -101,6 +101,7 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 | `wait --timeout 5000` | Custom timeout (default: 10000ms) |
 | `watch [--selector ".el"]` | Watch for DOM mutations (MutationObserver) |
 | `watch --timeout 3000 --stable 500` | Custom timeout and stability window |
+| `watch --require-mutation` | Wait for first mutation before stability (use after IPC triggering async re-renders) |
 
 ### Storage & Forms
 

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -144,6 +144,10 @@ pub(crate) enum Command {
         /// Wait until DOM is stable for N ms (no new mutations).
         #[arg(long, default_value = "300")]
         stable: u64,
+        /// Defer the stability timer until at least one mutation occurs.
+        /// Use after IPC calls that trigger async re-renders (e.g., React state updates).
+        #[arg(long)]
+        require_mutation: bool,
     },
     /// Display or stream captured console logs.
     Logs {
@@ -452,11 +456,13 @@ mod tests {
             selector,
             timeout,
             stable,
+            require_mutation,
         } = cli.command
         {
             assert_eq!(selector, Some(".results".to_owned()));
             assert_eq!(timeout, 5000);
             assert_eq!(stable, 500);
+            assert!(!require_mutation);
         } else {
             panic!("Expected Watch command");
         }
@@ -469,11 +475,60 @@ mod tests {
             selector,
             timeout,
             stable,
+            require_mutation,
         } = cli.command
         {
             assert_eq!(selector, None);
             assert_eq!(timeout, 10000);
             assert_eq!(stable, 300);
+            assert!(!require_mutation);
+        } else {
+            panic!("Expected Watch command");
+        }
+    }
+
+    #[test]
+    fn test_parse_watch_require_mutation() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "watch",
+            "--require-mutation",
+        ]);
+        if let Command::Watch {
+            require_mutation, ..
+        } = cli.command
+        {
+            assert!(require_mutation);
+        } else {
+            panic!("Expected Watch command");
+        }
+    }
+
+    #[test]
+    fn test_parse_watch_require_mutation_with_selector() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "watch",
+            "--selector",
+            "#root",
+            "--require-mutation",
+            "--stable",
+            "500",
+        ]);
+        if let Command::Watch {
+            selector,
+            stable,
+            require_mutation,
+            ..
+        } = cli.command
+        {
+            assert_eq!(selector, Some("#root".to_owned()));
+            assert_eq!(stable, 500);
+            assert!(require_mutation);
         } else {
             panic!("Expected Watch command");
         }

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -138,7 +138,8 @@ pub(crate) enum Command {
         /// CSS selector to scope observation to a subtree.
         #[arg(long)]
         selector: Option<String>,
-        /// Timeout in ms (reject if no changes).
+        /// Maximum wait time in ms. With `--require-mutation`, rejects on timeout
+        /// if no mutation occurred; otherwise resolves after `--stable` ms of quiet.
         #[arg(long, default_value = "10000")]
         timeout: u64,
         /// Wait until DOM is stable for N ms (no new mutations).

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -374,7 +374,8 @@ async fn run_command(
             selector,
             timeout,
             stable,
-        } => run_watch_command(client, selector, timeout, stable, window).await,
+            require_mutation,
+        } => run_watch_command(client, selector, timeout, stable, require_mutation, window).await,
         Command::Logs {
             level,
             last,
@@ -431,11 +432,15 @@ async fn run_watch_command(
     selector: Option<String>,
     timeout: u64,
     stable: u64,
+    require_mutation: bool,
     window: Option<&str>,
 ) -> Result<serde_json::Value> {
     let mut params = serde_json::Map::new();
     params.insert("timeout".into(), json!(timeout));
     params.insert("stable".into(), json!(stable));
+    if require_mutation {
+        params.insert("requireMutation".into(), json!(true));
+    }
     if let Some(sel) = selector {
         params.insert("selector".into(), json!(sel));
     }

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -271,16 +271,15 @@ impl PilotMcpServer {
                 .await
             }
             "watch" => {
-                self.call_app_tool(
-                    "watch",
-                    Some(json!({
-                        "selector": optional_string(&args, "selector")?,
-                        "timeout": optional_u64(&args, "timeout")?.unwrap_or(10_000),
-                        "stable": optional_u64(&args, "stable")?.unwrap_or(300),
-                    })),
-                    window,
-                )
-                .await
+                let mut watch_params = json!({
+                    "selector": optional_string(&args, "selector")?,
+                    "timeout": optional_u64(&args, "timeout")?.unwrap_or(10_000),
+                    "stable": optional_u64(&args, "stable")?.unwrap_or(300),
+                });
+                if optional_bool(&args, "require_mutation")?.unwrap_or(false) {
+                    watch_params["requireMutation"] = json!(true);
+                }
+                self.call_app_tool("watch", Some(watch_params), window).await
             }
             "logs" => self.call_logs_tool(&args, window).await,
             "network" => self.call_network_tool(&args, window).await,
@@ -1405,6 +1404,13 @@ fn watch_schema() -> Arc<JsonObject> {
             ),
             ("timeout", integer_prop("Timeout in milliseconds.")),
             ("stable", integer_prop("Stability window in milliseconds.")),
+            (
+                "require_mutation",
+                bool_prop(
+                    "Defer the stability timer until at least one DOM mutation occurs. \
+                     Rejects on timeout when nothing changed.",
+                ),
+            ),
         ]),
         &[],
     )

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -779,6 +779,7 @@
     var selector = options && options.selector;
     var timeout = (options && options.timeout != null) ? options.timeout : 10000;
     var stable = (options && options.stable != null) ? options.stable : 300;
+    var requireMutation = !!(options && options.requireMutation);
 
     var root;
     if (selector) {
@@ -818,6 +819,13 @@
           rej(new Error("watch timeout: no DOM changes within " + timeout + "ms"));
         }
       }, timeout);
+
+      // With requireMutation we skip starting the stable timer until the first
+      // mutation is seen; without it we start immediately so stable windows can
+      // resolve even when the DOM is idle.
+      if (!requireMutation) {
+        resetStableTimer();
+      }
 
       function pushCapped(arr, entry) {
         if (arr.length < MAX_WATCH_ENTRIES) {

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -584,6 +584,7 @@ tauri-pilot watch [OPTIONS]
 | `--selector <sel>` | Scope observation to a subtree matching this CSS selector |
 | `--timeout <ms>` | Maximum wait time in milliseconds (default: 10000) |
 | `--stable <ms>` | Wait until DOM is stable (no new mutations) for N ms (default: 300) |
+| `--require-mutation` | Defer the stability timer until at least one mutation occurs. Rejects on timeout if nothing changed. |
 
 **Examples:**
 
@@ -599,12 +600,16 @@ tauri-pilot watch --timeout 3000
 
 # Wait for DOM to settle after animations
 tauri-pilot watch --stable 500
+
+# Wait for an async re-render after an IPC call (e.g. React state update)
+tauri-pilot ipc settings_update --args '{"theme":"dark"}'
+tauri-pilot watch --require-mutation --stable 300 --timeout 2000
 ```
 
 **JSON-RPC example:**
 
 ```json
-{"jsonrpc":"2.0","id":1,"method":"watch","params":{"selector":"#results","timeout":5000,"stable":300}}
+{"jsonrpc":"2.0","id":1,"method":"watch","params":{"selector":"#results","timeout":5000,"stable":300,"requireMutation":true}}
 ```
 
 ---

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -571,7 +571,7 @@ tauri-pilot drop @e3 --file ./doc.pdf --file ./data.csv
 
 ### `watch`
 
-Watch for DOM mutations using `MutationObserver`. Blocks until changes are detected (or timeout), then returns a summary of what changed. Useful for waiting on async UI updates without polling snapshots.
+Watch for DOM mutations using `MutationObserver`. By default, it resolves once the DOM stays quiet for `--stable` ms and returns a summary of what changed — the change set can be empty on idle pages. Pass `--require-mutation` to reject on timeout when nothing mutated. Useful for waiting on async UI updates without polling snapshots.
 
 ```bash
 tauri-pilot watch [OPTIONS]


### PR DESCRIPTION
## Summary

Closes #49.

- Adds `tauri-pilot watch --require-mutation` flag. When set, the stability timer only arms after the first DOM mutation — and the call rejects on timeout if nothing mutated. Intended for use right after IPC calls that trigger async re-renders (e.g. React state updates), where the DOM hasn't started mutating yet when `watch` starts.
- **Breaking:** default `watch` semantics now arm the stability timer at startup instead of waiting for the first mutation. Idle runs resolve with an empty change set after `--stable` ms instead of rejecting with a "no DOM changes" timeout. Scripts relying on bare `watch` as a "did anything change?" assertion should switch to `watch --require-mutation`.
- Propagated through CLI (`--require-mutation`), JSON-RPC (`requireMutation`), JS bridge, and the MCP `watch` tool schema (`require_mutation`).
- Docs: updated CLI reference, SKILL.md, CHANGELOG under both `### Added` and **Breaking** `### Changed`.

## Example

```bash
tauri-pilot ipc settings_update --args '{"theme":"dark"}'
tauri-pilot watch --require-mutation --stable 300 --timeout 2000
tauri-pilot text "html"   # now guaranteed to see the applied class
```

## Test plan

- [x] `cargo test --workspace` — 232 passed (was 231, +1 new test)
- [x] `cargo fmt --all -- --check` — clean
- [x] `node` syntax check on `bridge.js`
- [x] Manual E2E against `pilot-test-app`: added a "Deferred Mutation Probe" section that schedules a DOM change 800 ms after a click (simulates async React re-render).
  - Without flag: `watch` resolves in ~308 ms before mutation lands → subsequent read returns stale state
  - With `--require-mutation`: `watch` blocks ~1100 ms (800 ms mutation + 300 ms stable) → subsequent read returns fresh state ✓
- [x] Adversarial review via `rust-reviewer` + `code-reviewer` subagents; blocking/major findings addressed (fmt fix, MCP param consistency, CHANGELOG contradiction).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tauri-pilot watch --require-mutation` to handle async re-renders by waiting for the first DOM mutation before the stability window; also changes default `watch` behavior to start the stability timer immediately and resolve idle runs. Implements #49.

- **New Features**
  - `watch --require-mutation`: defer stability until the first mutation; reject on timeout if nothing changes. Use after IPC calls or async React state updates.
  - Plumbed through JSON-RPC (`requireMutation`), MCP tool schema (`require_mutation`), and the JS bridge. CLI `--timeout` help and docs now clearly explain default idle-resolve vs `--require-mutation`; examples updated.

- **Migration**
  - Breaking: `watch` now arms the stability timer at startup and resolves with an empty change set after `--stable` ms when idle.
  - If you used `watch` as a “did anything change?” assertion, switch to `watch --require-mutation` to keep the old reject-on-idle behavior.

<sup>Written for commit 8f8d650479fb5b63098f6ac235fb9de4ab5bc010. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added watch --require-mutation to defer the stability timer until the first DOM mutation.

* **Breaking Changes**
  * watch now arms the stability timer at startup by default; idle runs resolve with an empty change set instead of rejecting. Use --require-mutation to restore previous reject-on-idle behavior.

* **Documentation**
  * CLI and JSON-RPC docs updated with the new option and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->