### PR TITLE
chore(msrv): bump Rust 1.94.0 → 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
-      - name: Install Rust 1.94.0
+      - name: Install Rust 1.95.0
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
           components: clippy, rustfmt
 
       - name: Cache cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
-      - name: Install Rust 1.94.0
+      - name: Install Rust 1.95.0
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94.0"
+          toolchain: "1.95.0"
           components: clippy, rustfmt
 
       - name: Cache cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,9 +167,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
 [#46]: https://github.com/mpiton/tauri-pilot/issues/46
 [#48]: https://github.com/mpiton/tauri-pilot/issues/48
+[#49]: https://github.com/mpiton/tauri-pilot/issues/49
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [#51]: https://github.com/mpiton/tauri-pilot/pull/51
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52
+[#53]: https://github.com/mpiton/tauri-pilot/pull/53
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped MSRV from Rust 1.94.0 to **1.95.0** (workspace `Cargo.toml`, `ci.yml`, `release.yml`). Public docs (README, CONTRIBUTING, docs site) updated and the inaccurate "LTS" wording dropped — Rust does not yet ship an LTS channel ([#54])
+
 ### Added
 
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
@@ -166,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/mpiton/tauri-pilot/pull/50
 [#51]: https://github.com/mpiton/tauri-pilot/pull/51
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52
+[#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! This document covers the development w
 
 ## Prerequisites
 
-- Rust 1.94.1+ (LTS) with edition 2024
+- Rust 1.95.0+ with edition 2024
 - A Tauri v2 app for testing (or use the examples)
 - Linux (WebKitGTK) — macOS/Windows not yet supported
 
@@ -22,7 +22,7 @@ cargo test --workspace
 - **No `.unwrap()`** outside of tests — use `thiserror` (plugin) or `anyhow` (CLI)
 - **Clippy strict**: `cargo clippy --workspace -- -D warnings`
 - **Modules < 150 lines**, functions < 50 lines
-- **Edition 2024**, rust-version 1.94.1
+- **Edition 2024**, rust-version 1.95.0
 
 ## Workflow
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/tauri-plugin-pilot", "crates/tauri-pilot-cli"]
 [workspace.package]
 edition = "2024"
 license = "MIT"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 authors = ["Mathieu Piton <contact@mathieu-piton.com>"]
 repository = "https://github.com/mpiton/tauri-pilot"
 homepage = "https://github.com/mpiton/tauri-pilot"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/mpiton/tauri-pilot/actions/workflows/ci.yml"><img src="https://github.com/mpiton/tauri-pilot/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://crates.io/crates/tauri-plugin-pilot"><img src="https://img.shields.io/crates/v/tauri-plugin-pilot.svg" alt="crates.io"></a>
   <a href="https://github.com/mpiton/tauri-pilot/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <img src="https://img.shields.io/badge/rust-1.94.1+-orange.svg" alt="Rust 1.94.1+">
+  <img src="https://img.shields.io/badge/rust-1.95.0+-orange.svg" alt="Rust 1.95.0+">
   <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS-lightgrey.svg" alt="Platform: Linux | macOS">
   <img src="https://img.shields.io/badge/tauri-v2-24C8D8.svg" alt="Tauri v2">
 </p>
@@ -224,7 +224,7 @@ window:
 
 - **Linux** (WebKitGTK) or **macOS** (WebKit) — Windows planned
 - **Tauri v2** (v1 not supported)
-- **Rust 1.94.1+** (LTS, edition 2024)
+- **Rust 1.95.0+** (edition 2024)
 
 ## Who uses this?
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1278,9 +1278,7 @@ fn newest_socket_in_dir(dir: &Path) -> Option<PathBuf> {
             use std::os::unix::fs::MetadataExt;
             // SAFETY: getuid() has no preconditions.
             let my_uid = unsafe { libc::getuid() };
-            std::fs::metadata(p)
-                .map(|m| m.uid() == my_uid)
-                .unwrap_or(false)
+            std::fs::metadata(p).is_ok_and(|m| m.uid() == my_uid)
         })
         .collect();
 

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -570,7 +570,7 @@ pub(crate) fn format_diff(value: &serde_json::Value) {
                     );
 
                     let mut line =
-                        format!("{} {} ", crate::style::warn("~"), crate::style::info(&role),);
+                        format!("{} {} ", crate::style::warn("~"), crate::style::info(&role));
                     if let Some(ref n) = name {
                         let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
                     }
@@ -586,7 +586,7 @@ pub(crate) fn format_diff(value: &serde_json::Value) {
                 }
             } else {
                 let mut line =
-                    format!("{} {} ", crate::style::warn("~"), crate::style::info(&role),);
+                    format!("{} {} ", crate::style::warn("~"), crate::style::info(&role));
                 if let Some(ref n) = name {
                     let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
                 }
@@ -612,7 +612,7 @@ fn format_diff_entry(
         .unwrap_or("?");
     let name = el.get("name").and_then(serde_json::Value::as_str);
 
-    let mut line = format!("{} {} ", prefix_style(prefix), crate::style::info(role),);
+    let mut line = format!("{} {} ", prefix_style(prefix), crate::style::info(role));
     if let Some(n) = name {
         let _ = write!(line, "{} ", crate::style::bold(format!("\"{n}\"")));
     }

--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -7,7 +7,7 @@ Contributions are welcome. Bug reports, feature requests, and pull requests are 
 
 ## Prerequisites
 
-- Rust 1.94.0+ with edition 2024
+- Rust 1.95.0+ with edition 2024
 - A Tauri v2 app for testing (or use the examples)
 - Linux (WebKitGTK) — macOS/Windows not yet supported
 
@@ -25,7 +25,7 @@ cargo test --workspace
 - No `.unwrap()` outside of tests — use `thiserror` (plugin) or `anyhow` (CLI)
 - Clippy strict: `cargo clippy --workspace -- -D warnings`
 - Modules < 150 lines, functions < 50 lines
-- Edition 2024, rust-version 1.94.0
+- Edition 2024, rust-version 1.95.0
 
 ## Workflow
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -7,7 +7,7 @@ description: Install tauri-pilot and start testing your Tauri v2 app interactive
 
 - Linux (WebKitGTK) or macOS (WebKit) — Windows planned
 - Tauri v2 (v1 not supported)
-- Rust 1.94.0+ (edition 2024)
+- Rust 1.95.0+ (edition 2024)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

• Bump MSRV from Rust 1.94.0 to 1.95.0 across workspace and CI workflows
• Fix 4 new clippy lints: `unnecessary_trailing_comma` (3x) and `map_unwrap_or` (1x, using `is_ok_and`)
• Update public docs (README, CONTRIBUTING, docs site, ARCHI.md)—remove inaccurate "(LTS)" wording since Rust has no LTS channel yet
• Add CHANGELOG entry under [Unreleased] / Changed

## Validation

- ✅ `cargo +1.95.0 clippy --workspace -- -D warnings` (0 warnings)
- ✅ `cargo +1.95.0 test --workspace` (111 tests pass)
- ✅ `cargo +1.95.0 fmt --all -- --check` (clean)
- ✅ Smoke test on live pilot-test-app (no functional regressions)
- ✅ Adversarial code review (verdict: OK to merge)

Closes #54.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps MSRV to Rust 1.95.0 across the workspace and CI, updates docs, and fixes new clippy warnings. Also updates the CHANGELOG with missing reference links (closes #54).

- **Refactors**
  - Set `rust-version = "1.95.0"` in the workspace; pin 1.95.0 in `ci.yml` and `release.yml`.
  - Fix clippy: replace `map_unwrap_or` with `is_ok_and`; remove unnecessary trailing commas in formatting calls.
  - Update README/CONTRIBUTING/docs to 1.95.0, drop the "LTS" wording, and update the CHANGELOG (added missing [#49] and [#53] links).

<sup>Written for commit 288f096121b9e64565f3dbf3e45b12765929cafb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped minimum Rust version to 1.95.0 across CI and workspace configuration.

* **Documentation**
  * Updated README, changelog, contributing guide, and docs to reflect the new Rust requirement and adjusted badges/wording.

* **Refactor**
  * Small code cleanups and formatting simplifications to improve readability and output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->