### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-17
+
 ### Added
 
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
@@ -170,7 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52
 [#53]: https://github.com/mpiton/tauri-pilot/pull/53
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...HEAD
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
@@ -185,3 +187,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
 [0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0
+[0.4.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/mpiton/tauri-pilot/issues/10
 [#37]: https://github.com/mpiton/tauri-pilot/issues/37
 [#41]: https://github.com/mpiton/tauri-pilot/pull/41
+[#45]: https://github.com/mpiton/tauri-pilot/issues/45
 [#46]: https://github.com/mpiton/tauri-pilot/issues/46
 [#48]: https://github.com/mpiton/tauri-pilot/issues/48
 [#49]: https://github.com/mpiton/tauri-pilot/issues/49
@@ -173,6 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#53]: https://github.com/mpiton/tauri-pilot/pull/53
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mpiton/tauri-pilot/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.1.0
@@ -186,5 +189,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
-[0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0
-[0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,4 +187,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
 [0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0
-[0.4.0]: https://github.com/mpiton/tauri-pilot/releases/tag/v0.4.0
+[0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bumped MSRV from Rust 1.94.0 to **1.95.0** (workspace `Cargo.toml`, `ci.yml`, `release.yml`). Public docs (README, CONTRIBUTING, docs site) updated and the inaccurate "LTS" wording dropped — Rust does not yet ship an LTS channel ([#54])
-
 ### Added
 
 - `eval` command now reads the script from stdin when the argument is `-` or omitted ([#41])
@@ -24,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `press` command now injects keyboard events at the OS level via `enigo` instead of dispatching synthetic JS `KeyboardEvent`s. Events are now `isTrusted=true` and traverse the full input pipeline, reaching DOM listeners, Tauri accelerators, and global shortcut handlers ([#45])
 - The plugin now requests window focus before injecting keys so events land on the correct webview
 - `tauri-plugin-pilot` exposes a default-on `press` feature that gates the `enigo` dependency. Build with `--no-default-features` to drop it from release builds where the whole plugin is already no-op'd ([#53])
+- Bumped MSRV from Rust 1.94.0 to **1.95.0** (workspace `Cargo.toml`, `ci.yml`, `release.yml`). Public docs (README, CONTRIBUTING, docs site) updated and the inaccurate "LTS" wording dropped — Rust does not yet ship an LTS channel ([#54])
 
 ### Fixed
 

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -68,8 +68,15 @@ else
 fi
 
 # Add version link if not present
+# Prefer compare/vPREV...vNEW format for consistency with prior entries; fall back
+# to releases/tag/ only for the first-ever release (no previous tag exists yet).
 if ! grep -q "\[$VERSION\]:" CHANGELOG.md; then
-  echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/releases/tag/v$VERSION" >> CHANGELOG.md
+  PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -vx "v$VERSION" | head -n1 || true)
+  if [ -n "$PREVIOUS_TAG" ]; then
+    echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/compare/$PREVIOUS_TAG...v$VERSION" >> CHANGELOG.md
+  else
+    echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/releases/tag/v$VERSION" >> CHANGELOG.md
+  fi
 fi
 
 echo "  Updated CHANGELOG.md"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,7 +52,7 @@ if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
   echo "Error: CHANGELOG.md is missing '## [Unreleased]' header"
   exit 1
 fi
-if grep -q "## \[$VERSION\]" CHANGELOG.md; then
+if grep -Fq "## [$VERSION]" CHANGELOG.md; then
   echo "Error: CHANGELOG.md already has an entry for $VERSION"
   exit 1
 fi
@@ -72,8 +72,8 @@ fi
 # appended to the end of the file on each release.
 # Prefer compare/vPREV...vNEW format for consistency with prior entries; fall back
 # to releases/tag/ only for the first-ever release (no previous tag exists yet).
-if ! grep -q "\[$VERSION\]:" CHANGELOG.md; then
-  PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -vx "v$VERSION" | head -n1 || true)
+if ! grep -Fq "[$VERSION]:" CHANGELOG.md; then
+  PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -Fvx "v$VERSION" | head -n1 || true)
   if [ -n "$PREVIOUS_TAG" ]; then
     NEW_LINK="[$VERSION]: https://github.com/mpiton/tauri-pilot/compare/$PREVIOUS_TAG...v$VERSION"
   else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,16 +67,19 @@ else
   echo "[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v$VERSION...HEAD" >> CHANGELOG.md
 fi
 
-# Add version link if not present
+# Add version link if not present — insert immediately after the [Unreleased]
+# definition so every version link stays grouped together instead of being
+# appended to the end of the file on each release.
 # Prefer compare/vPREV...vNEW format for consistency with prior entries; fall back
 # to releases/tag/ only for the first-ever release (no previous tag exists yet).
 if ! grep -q "\[$VERSION\]:" CHANGELOG.md; then
   PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -vx "v$VERSION" | head -n1 || true)
   if [ -n "$PREVIOUS_TAG" ]; then
-    echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/compare/$PREVIOUS_TAG...v$VERSION" >> CHANGELOG.md
+    NEW_LINK="[$VERSION]: https://github.com/mpiton/tauri-pilot/compare/$PREVIOUS_TAG...v$VERSION"
   else
-    echo "[$VERSION]: https://github.com/mpiton/tauri-pilot/releases/tag/v$VERSION" >> CHANGELOG.md
+    NEW_LINK="[$VERSION]: https://github.com/mpiton/tauri-pilot/releases/tag/v$VERSION"
   fi
+  perl -i -pe "s|(\[Unreleased\]:.*)|\$1\n$NEW_LINK|" CHANGELOG.md
 fi
 
 echo "  Updated CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Bumps `tauri-plugin-pilot` and `tauri-pilot-cli` from `0.3.0` to `0.4.0`
- Finalises `CHANGELOG.md` with the dated `[0.4.0]` section (see file for the full list of Added / Changed / Fixed)
- Fixes `scripts/release.sh` so that future releases auto-generate `compare/vPREV...vNEW` footer links instead of the `releases/tag/` form, matching every prior entry

## Highlights of 0.4.0

### Added
- `eval` reads the script from stdin when the argument is `-` or omitted (#41, #50)
- MCP server mode exposes tauri-pilot commands as structured tools over stdio (#51)
- `watch --require-mutation` defers the stability timer until the first DOM mutation (#49)

### Changed (breaking)
- `watch` default semantics: stability timer arms at startup; idle runs resolve with empty change sets instead of rejecting (#49)
- `press` injects at OS level via `enigo` so events are `isTrusted=true` and reach Tauri accelerators / global shortcuts (#45, #53)

### Fixed
- `eval` accepts `const`/`let`/`var`/function declarations via indirect eval (#46)
- `click` dispatches pointer events before mouse events for Radix UI triggers (#52)
- `eval` exits 0 when JS returns `undefined` so `&&` chains and `set -e` scripts no longer break (#48)
- Plus 10+ `press` reliability fixes (focus lock, Wayland, combo validation, error propagation) (#53)

### Internal
- MSRV bumped to Rust 1.95.0 (#54)

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (111 tests passing)
- [x] `cargo fmt --all` (clean)
- [ ] After merge: push `v0.4.0` tag (kept local for now) to trigger the Release workflow and publish both crates to crates.io

## Release steps (after merge)

```bash
git checkout main && git pull
git push origin v0.4.0  # tag was created locally by scripts/release.sh
```

The Release workflow verifies the tag matches `Cargo.toml` versions, runs tests + clippy, publishes `tauri-plugin-pilot` then `tauri-pilot-cli` to crates.io, and creates the GitHub Release with the changelog body.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v0.4.0 for `tauri-plugin-pilot` and `tauri-pilot-cli`. Finalizes the changelog (groups version links, adds the missing #45 reference) and updates `scripts/release.sh` to emit compare links, insert the new version link after [Unreleased], and use fixed‑string grep to avoid semver regex issues.

- **New Features**
  - `eval` reads scripts from stdin when `-` or omitted.
  - MCP server mode exposes commands as structured tools over stdio.
  - `watch --require-mutation` defers the stability timer until the first DOM mutation.

- **Migration**
  - `watch` defaults: the stability timer arms at startup; idle runs now resolve with empty change sets.
  - `press` injects keys at the OS level via `enigo`, so events are trusted and reach accelerators/global shortcuts.

<sup>Written for commit 07a20ab4c37b28907c29187fced1154ed803faab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.4.0 released (2026-04-17)

* **Chores**
  * Updated version information across project packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->