### PR TITLE
feat(cli): batch scenario runner — tauri-pilot run <scenario.toml>

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,23 @@ cargo test --workspace
 
 See [ARCHI.md](ARCHI.md) for architecture decisions and module structure.
 
+## `run` vs `record`/`replay`
+
+tauri-pilot offers two complementary automation modes:
+
+| Mode | Command | Format | Use case |
+|------|---------|--------|----------|
+| **Declarative** | `tauri-pilot run <file.toml>` | TOML scenario | Structured tests with assertions and assertions (CI-friendly) |
+| **Capture-replay** | `tauri-pilot record start` / `replay` | JSON session | Quick capture of manual interactions for later replay |
+
+**`run` (TOML scenario)** — define steps declaratively with action types, assertions, and
+timeouts. Exits 0 on success, 1 on any failure. Supports JUnit XML output (`--junit`).
+Automatically captures failure screenshots to `./tauri-pilot-failures/`.
+
+**`record` / `replay` (JSON session)** — record interactions as they happen, then replay
+the timing-accurate sequence. Useful for smoke tests derived from manual exploration.
+Export to shell script with `replay --export sh`.
+
 ## Reporting Issues
 
 Use the issue templates — bug reports and feature requests are welcome.

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -32,8 +32,11 @@ owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 indicatif = "0.17"
 libc = "0.2.184"
 rmcp = { version = "1.4.0", default-features = false, features = ["server", "transport-io"] }
+toml = "0.8"
+quick-xml = "0.36"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 assert_cmd = "2"
 serial_test = "3.4.0"
+tempfile = "3"

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -210,6 +210,17 @@ pub(crate) enum Command {
         #[arg(long)]
         export: Option<String>,
     },
+    /// Execute a declarative scenario from a TOML file.
+    Run {
+        /// Path to scenario TOML file.
+        scenario: PathBuf,
+        /// Write JUnit XML report to this path.
+        #[arg(long, value_name = "FILE")]
+        junit: Option<PathBuf>,
+        /// Override fail_fast setting from the scenario file.
+        #[arg(long)]
+        no_fail_fast: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -214,10 +214,10 @@ pub(crate) enum Command {
     Run {
         /// Path to scenario TOML file.
         scenario: PathBuf,
-        /// Write JUnit XML report to this path.
+        /// Write `JUnit` XML report to this path.
         #[arg(long, value_name = "FILE")]
         junit: Option<PathBuf>,
-        /// Override fail_fast setting from the scenario file.
+        /// Override `fail_fast` setting from the scenario file.
         #[arg(long)]
         no_fail_fast: bool,
     },

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1279,8 +1279,7 @@ async fn run_scenario_command(
                 .as_ref()
                 .and_then(|c| c.socket.clone())
         })
-        .map(Ok)
-        .unwrap_or_else(|| resolve_socket(None))?;
+        .map_or_else(|| resolve_socket(None), Ok)?;
 
     let mut client = Client::connect(&socket).await?;
 

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -3,6 +3,7 @@ mod client;
 mod mcp;
 mod output;
 mod protocol;
+mod scenario;
 mod style;
 
 use std::fmt::Write as _;
@@ -39,6 +40,22 @@ async fn main() -> Result<()> {
 
     if is_mcp {
         return mcp::run_mcp_server(args.socket, args.window).await;
+    }
+
+    if let Command::Run {
+        ref scenario,
+        ref junit,
+        no_fail_fast,
+    } = args.command
+    {
+        return run_scenario_command(
+            scenario,
+            junit.as_deref(),
+            no_fail_fast,
+            args.socket,
+            args.window.as_deref(),
+        )
+        .await;
     }
 
     let socket = resolve_socket(args.socket)?;
@@ -316,6 +333,7 @@ async fn run_command(
 ) -> Result<serde_json::Value> {
     match command {
         Command::Mcp => anyhow::bail!("mcp must be handled before run_command"),
+        Command::Run { .. } => anyhow::bail!("run must be handled before run_command"),
         Command::Windows => client.call("windows.list", None).await,
         Command::Ping => client.call("ping", with_window(None, window)).await,
         Command::State => client.call("state", with_window(None, window)).await,
@@ -1242,6 +1260,44 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
             format!("# unknown action: {safe}")
         }
     }
+}
+
+async fn run_scenario_command(
+    scenario_path: &std::path::Path,
+    junit: Option<&std::path::Path>,
+    no_fail_fast: bool,
+    explicit_socket: Option<PathBuf>,
+    window: Option<&str>,
+) -> Result<()> {
+    let loaded = scenario::load_scenario(scenario_path)?;
+
+    // Socket resolution: CLI flag > TOML [connect].socket > auto-detect
+    let socket = explicit_socket
+        .or_else(|| {
+            loaded
+                .connect
+                .as_ref()
+                .and_then(|c| c.socket.clone())
+        })
+        .map(Ok)
+        .unwrap_or_else(|| resolve_socket(None))?;
+
+    let mut client = Client::connect(&socket).await?;
+
+    let fail_fast_override = if no_fail_fast { Some(false) } else { None };
+    let report = scenario::run_scenario(&mut client, &loaded, window, fail_fast_override).await?;
+
+    scenario::print_report(&report);
+
+    if let Some(xml_path) = junit {
+        scenario::write_junit_xml(&report, xml_path)?;
+        eprintln!("JUnit XML written to {}", xml_path.display());
+    }
+
+    if !report.all_passed() {
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 /// Resolve the socket path from explicit arg, env var, or auto-detection.

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1273,12 +1273,7 @@ async fn run_scenario_command(
 
     // Socket resolution: CLI flag > TOML [connect].socket > auto-detect
     let socket = explicit_socket
-        .or_else(|| {
-            loaded
-                .connect
-                .as_ref()
-                .and_then(|c| c.socket.clone())
-        })
+        .or_else(|| loaded.connect.as_ref().and_then(|c| c.socket.clone()))
         .map_or_else(|| resolve_socket(None), Ok)?;
 
     let mut client = Client::connect(&socket).await?;

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -673,11 +673,11 @@ mod tests {
 
     #[test]
     fn test_toml_parse_minimal() {
-        let toml_str = r#"
+        let toml_str = r##"
 [[step]]
 action = "click"
 target = "#btn"
-"#;
+"##;
         let scenario: Scenario = toml::from_str(toml_str).expect("valid toml");
         assert_eq!(scenario.step.len(), 1);
         assert_eq!(scenario.step[0].action, "click");

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -312,10 +312,7 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
                 params.insert("selector".into(), json!(sel));
             }
             client
-                .call(
-                    "watch",
-                    with_window(Some(Value::Object(params)), window),
-                )
+                .call("watch", with_window(Some(Value::Object(params)), window))
                 .await
         }
         "eval" => {
@@ -324,10 +321,7 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("eval step requires 'script'"))?;
             client
-                .call(
-                    "eval",
-                    with_window(Some(json!({"script": script})), window),
-                )
+                .call("eval", with_window(Some(json!({"script": script})), window))
                 .await
         }
         "screenshot" => {
@@ -585,7 +579,9 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
     writer.write_event(Event::End(BytesEnd::new("testsuites")))?;
     writer.write_event(Event::Text(BytesText::new("\n")))?;
 
-    if let Some(parent) = path.parent() && !parent.as_os_str().is_empty() {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, &buf)
@@ -703,10 +699,7 @@ expected = "Login"
         assert_eq!(scenario.step.len(), 2);
 
         let connect = scenario.connect.as_ref().expect("connect section");
-        assert_eq!(
-            connect.socket.as_deref(),
-            Some(Path::new("/tmp/test.sock"))
-        );
+        assert_eq!(connect.socket.as_deref(), Some(Path::new("/tmp/test.sock")));
         assert_eq!(connect.timeout_ms, Some(5000));
 
         let step = &scenario.step[1];
@@ -831,5 +824,4 @@ action = "ping"
         assert!(xml.contains(r#"message="oops &amp; done""#));
         assert!(xml.contains("<skipped"));
     }
-
 }

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -465,11 +465,8 @@ async fn take_failure_screenshot(
         .call("screenshot", with_window(Some(json!({})), window))
         .await?;
     save_screenshot_result(&result, &path)?;
-    eprintln!(
-        "  {} {}",
-        crate::style::dim("failure screenshot →"),
-        path.display()
-    );
+    let arrow = crate::style::dim("failure screenshot →");
+    eprintln!("  {arrow} {}", path.display());
     Ok(())
 }
 
@@ -493,23 +490,20 @@ fn save_screenshot_result(result: &Value, path: &Path) -> Result<()> {
 // ── Terminal output helpers ───────────────────────────────────────────────────
 
 fn print_step_line(idx: usize, total: usize, name: &str, status: &str) {
+    let step_num = idx + 1;
     let colored = match status {
         "ok" => crate::style::success(status),
         "SKIP" => crate::style::dim(status),
         _ => crate::style::failure(status),
     };
-    eprintln!("  [{}/{}] {} {}", idx + 1, total, name, colored);
+    eprintln!("  [{step_num}/{total}] {name} {colored}");
 }
 
 fn print_step_fail(idx: usize, total: usize, name: &str, msg: &str) {
-    eprintln!(
-        "  [{}/{}] {} {}\n    {}",
-        idx + 1,
-        total,
-        name,
-        crate::style::failure("FAIL"),
-        crate::style::failure(msg)
-    );
+    let step_num = idx + 1;
+    let fail_label = crate::style::failure("FAIL");
+    let fail_msg = crate::style::failure(msg);
+    eprintln!("  [{step_num}/{total}] {name} {fail_label}\n    {fail_msg}");
 }
 
 pub(crate) fn print_report(report: &ScenarioReport) {
@@ -517,13 +511,11 @@ pub(crate) fn print_report(report: &ScenarioReport) {
     let failed = report.failed();
     let skipped = report.skipped();
     let secs = report.total_duration.as_secs_f64();
+    let name = crate::style::bold(&report.name);
 
     eprintln!();
-    eprintln!("Scenario: {}", crate::style::bold(&report.name));
-    eprintln!(
-        "  {} passed · {} failed · {} skipped  ({:.3}s)",
-        passed, failed, skipped, secs
-    );
+    eprintln!("Scenario: {name}");
+    eprintln!("  {passed} passed · {failed} failed · {skipped} skipped  ({secs:.3}s)");
     eprintln!();
 }
 
@@ -538,7 +530,8 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
     let total_str = report.results.len().to_string();
     let failures_str = failures.to_string();
     let skipped_str = skipped.to_string();
-    let elapsed_str = format!("{:.3}", report.total_duration.as_secs_f64());
+    let elapsed = report.total_duration.as_secs_f64();
+    let elapsed_str = format!("{elapsed:.3}");
 
     let mut buf = Vec::new();
     let mut writer = Writer::new(&mut buf);
@@ -563,7 +556,8 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
         writer.write_event(Event::Text(BytesText::new("\n    ")))?;
         let dur_str = match &result.outcome {
             StepOutcome::Passed { duration } | StepOutcome::Failed { duration, .. } => {
-                format!("{:.3}", duration.as_secs_f64())
+                let d = duration.as_secs_f64();
+                format!("{d:.3}")
             }
             StepOutcome::Skipped => "0.000".to_string(),
         };

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -570,9 +570,8 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
                 writer.write_event(Event::Empty(BytesStart::new("skipped")))?;
             }
             StepOutcome::Failed { message, .. } => {
-                let escaped = xml_attr_escape(message);
                 let mut failure = BytesStart::new("failure");
-                failure.push_attribute(("message", escaped.as_str()));
+                failure.push_attribute(("message", message.as_str()));
                 writer.write_event(Event::Empty(failure))?;
             }
         }
@@ -593,13 +592,6 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
         .with_context(|| format!("Failed to write JUnit XML to {}", path.display()))?;
 
     Ok(())
-}
-
-fn xml_attr_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('"', "&quot;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -840,10 +832,4 @@ action = "ping"
         assert!(xml.contains("<skipped"));
     }
 
-    #[test]
-    fn test_xml_attr_escape() {
-        assert_eq!(xml_attr_escape("a & b"), "a &amp; b");
-        assert_eq!(xml_attr_escape(r#"say "hi""#), "say &quot;hi&quot;");
-        assert_eq!(xml_attr_escape("<tag>"), "&lt;tag&gt;");
-    }
 }

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -11,7 +11,7 @@ use crate::{target_params, with_window};
 
 // ── TOML schema ──────────────────────────────────────────────────────────────
 
-#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::module_name_repetitions, clippy::struct_field_names)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Scenario {
     pub(crate) connect: Option<Connect>,
@@ -24,6 +24,7 @@ pub(crate) struct Scenario {
 #[derive(Debug, Deserialize, Default)]
 pub(crate) struct Connect {
     pub(crate) socket: Option<PathBuf>,
+    #[allow(dead_code)]
     pub(crate) timeout_ms: Option<u64>,
 }
 
@@ -33,6 +34,7 @@ pub(crate) struct ScenarioMeta {
     pub(crate) name: Option<String>,
     #[serde(default = "default_true")]
     pub(crate) fail_fast: bool,
+    #[allow(dead_code)]
     pub(crate) global_timeout_ms: Option<u64>,
 }
 
@@ -50,6 +52,7 @@ fn default_true() -> bool {
     true
 }
 
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Step {
     pub(crate) name: Option<String>,
@@ -354,9 +357,7 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
             let actual = result.as_str().unwrap_or_default();
             anyhow::ensure!(
                 actual == expected,
-                "expected text {:?}, got {:?}",
-                expected,
-                actual
+                "expected text {expected:?}, got {actual:?}"
             );
             Ok(json!({"ok": true}))
         }
@@ -403,9 +404,7 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
             let actual = result.as_str().unwrap_or_default();
             anyhow::ensure!(
                 actual == expected,
-                "expected value {:?}, got {:?}",
-                expected,
-                actual
+                "expected value {expected:?}, got {actual:?}"
             );
             Ok(json!({"ok": true}))
         }
@@ -418,13 +417,11 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
             let actual = result.as_str().unwrap_or_default();
             anyhow::ensure!(
                 actual.contains(expected),
-                "URL does not contain {:?}, got {:?}",
-                expected,
-                actual
+                "URL does not contain {expected:?}, got {actual:?}"
             );
             Ok(json!({"ok": true}))
         }
-        other => anyhow::bail!("unknown step action: {:?}", other),
+        other => anyhow::bail!("unknown step action: {other:?}"),
     }
 }
 
@@ -589,10 +586,8 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
     writer.write_event(Event::End(BytesEnd::new("testsuites")))?;
     writer.write_event(Event::Text(BytesText::new("\n")))?;
 
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = path.parent() && !parent.as_os_str().is_empty() {
+        std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, &buf)
         .with_context(|| format!("Failed to write JUnit XML to {}", path.display()))?;

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -11,27 +11,29 @@ use crate::{target_params, with_window};
 
 // ── TOML schema ──────────────────────────────────────────────────────────────
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Deserialize)]
-pub struct Scenario {
-    pub connect: Option<Connect>,
+pub(crate) struct Scenario {
+    pub(crate) connect: Option<Connect>,
     #[serde(default)]
-    pub scenario: ScenarioMeta,
+    pub(crate) scenario: ScenarioMeta,
     #[serde(default)]
-    pub step: Vec<Step>,
+    pub(crate) step: Vec<Step>,
 }
 
 #[derive(Debug, Deserialize, Default)]
-pub struct Connect {
-    pub socket: Option<PathBuf>,
-    pub timeout_ms: Option<u64>,
+pub(crate) struct Connect {
+    pub(crate) socket: Option<PathBuf>,
+    pub(crate) timeout_ms: Option<u64>,
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Deserialize)]
-pub struct ScenarioMeta {
-    pub name: Option<String>,
+pub(crate) struct ScenarioMeta {
+    pub(crate) name: Option<String>,
     #[serde(default = "default_true")]
-    pub fail_fast: bool,
-    pub global_timeout_ms: Option<u64>,
+    pub(crate) fail_fast: bool,
+    pub(crate) global_timeout_ms: Option<u64>,
 }
 
 impl Default for ScenarioMeta {
@@ -49,26 +51,26 @@ fn default_true() -> bool {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Step {
-    pub name: Option<String>,
-    pub action: String,
-    pub timeout_ms: Option<u64>,
-    pub target: Option<String>,
-    pub value: Option<String>,
-    pub text: Option<String>,
-    pub key: Option<String>,
-    pub url: Option<String>,
-    pub script: Option<String>,
-    pub expected: Option<String>,
-    pub selector: Option<String>,
-    pub direction: Option<String>,
-    pub amount: Option<i32>,
+pub(crate) struct Step {
+    pub(crate) name: Option<String>,
+    pub(crate) action: String,
+    pub(crate) timeout_ms: Option<u64>,
+    pub(crate) target: Option<String>,
+    pub(crate) value: Option<String>,
+    pub(crate) text: Option<String>,
+    pub(crate) key: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) script: Option<String>,
+    pub(crate) expected: Option<String>,
+    pub(crate) selector: Option<String>,
+    pub(crate) direction: Option<String>,
+    pub(crate) amount: Option<i32>,
     #[serde(rename = "ref")]
-    pub step_ref: Option<String>,
-    pub gone: Option<bool>,
-    pub stable: Option<u64>,
-    pub require_mutation: Option<bool>,
-    pub path: Option<PathBuf>,
+    pub(crate) step_ref: Option<String>,
+    pub(crate) gone: Option<bool>,
+    pub(crate) stable: Option<u64>,
+    pub(crate) require_mutation: Option<bool>,
+    pub(crate) path: Option<PathBuf>,
 }
 
 impl Step {
@@ -82,63 +84,67 @@ impl Step {
 // ── Execution result types ────────────────────────────────────────────────────
 
 #[derive(Debug)]
-pub enum StepOutcome {
+pub(crate) enum StepOutcome {
     Passed { duration: Duration },
     Failed { duration: Duration, message: String },
     Skipped,
 }
 
 #[derive(Debug)]
-pub struct StepResult {
-    pub name: String,
-    pub outcome: StepOutcome,
+pub(crate) struct StepResult {
+    pub(crate) name: String,
+    pub(crate) outcome: StepOutcome,
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
-pub struct ScenarioReport {
-    pub name: String,
-    pub results: Vec<StepResult>,
-    pub total_duration: Duration,
+pub(crate) struct ScenarioReport {
+    pub(crate) name: String,
+    pub(crate) results: Vec<StepResult>,
+    pub(crate) total_duration: Duration,
 }
 
 impl ScenarioReport {
-    pub fn passed(&self) -> usize {
+    #[must_use]
+    pub(crate) fn passed(&self) -> usize {
         self.results
             .iter()
             .filter(|r| matches!(r.outcome, StepOutcome::Passed { .. }))
             .count()
     }
 
-    pub fn failed(&self) -> usize {
+    #[must_use]
+    pub(crate) fn failed(&self) -> usize {
         self.results
             .iter()
             .filter(|r| matches!(r.outcome, StepOutcome::Failed { .. }))
             .count()
     }
 
-    pub fn skipped(&self) -> usize {
+    #[must_use]
+    pub(crate) fn skipped(&self) -> usize {
         self.results
             .iter()
             .filter(|r| matches!(r.outcome, StepOutcome::Skipped))
             .count()
     }
 
-    pub fn all_passed(&self) -> bool {
+    #[must_use]
+    pub(crate) fn all_passed(&self) -> bool {
         self.failed() == 0
     }
 }
 
 // ── Main runner ───────────────────────────────────────────────────────────────
 
-pub fn load_scenario(path: &Path) -> Result<Scenario> {
+pub(crate) fn load_scenario(path: &Path) -> Result<Scenario> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read scenario file: {}", path.display()))?;
-    toml::from_str(&content).with_context(|| {
-        format!("Failed to parse scenario TOML: {}", path.display())
-    })
+    toml::from_str(&content)
+        .with_context(|| format!("Failed to parse scenario TOML: {}", path.display()))
 }
 
-pub async fn run_scenario(
+pub(crate) async fn run_scenario(
     client: &mut Client,
     scenario: &Scenario,
     window: Option<&str>,
@@ -179,7 +185,6 @@ pub async fn run_scenario(
                 let dur = step_start.elapsed();
                 let msg = format!("{e:#}");
                 print_step_fail(idx, scenario.step.len(), &step_name, &msg);
-                // Capture screenshot on failure
                 let _ = take_failure_screenshot(client, &step_name, window).await;
                 failed = true;
                 StepOutcome::Failed {
@@ -202,6 +207,7 @@ pub async fn run_scenario(
     })
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Result<Value> {
     let timeout_ms = step.timeout_ms;
     match step.action.as_str() {
@@ -356,7 +362,6 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
         }
         "assert-exists" => {
             let t = require_target(step)?;
-            // Call visible; if it returns any valid response, element exists
             client
                 .call("visible", with_window(Some(target_params(t)), window))
                 .await?;
@@ -441,16 +446,20 @@ async fn take_failure_screenshot(
 
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_millis());
 
-    // Sanitize step name for use in a filename
     let safe_name: String = step_name
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     let filename = format!("{safe_name}-{ts}.png");
-    let path = dir.join(&filename);
+    let path = dir.join(filename.as_str());
 
     let result = client
         .call("screenshot", with_window(Some(json!({})), window))
@@ -503,18 +512,14 @@ fn print_step_fail(idx: usize, total: usize, name: &str, msg: &str) {
     );
 }
 
-pub fn print_report(report: &ScenarioReport) {
-    let total = report.results.len();
+pub(crate) fn print_report(report: &ScenarioReport) {
     let passed = report.passed();
     let failed = report.failed();
     let skipped = report.skipped();
     let secs = report.total_duration.as_secs_f64();
 
     eprintln!();
-    eprintln!(
-        "Scenario: {}",
-        crate::style::bold(&report.name)
-    );
+    eprintln!("Scenario: {}", crate::style::bold(&report.name));
     eprintln!(
         "  {} passed · {} failed · {} skipped  ({:.3}s)",
         passed, failed, skipped, secs
@@ -524,14 +529,16 @@ pub fn print_report(report: &ScenarioReport) {
 
 // ── JUnit XML output ──────────────────────────────────────────────────────────
 
-pub fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()> {
+pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()> {
     use quick_xml::Writer;
     use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 
-    let total = report.results.len();
     let failures = report.failed();
     let skipped = report.skipped();
-    let elapsed = report.total_duration.as_secs_f64();
+    let total_str = report.results.len().to_string();
+    let failures_str = failures.to_string();
+    let skipped_str = skipped.to_string();
+    let elapsed_str = format!("{:.3}", report.total_duration.as_secs_f64());
 
     let mut buf = Vec::new();
     let mut writer = Writer::new(&mut buf);
@@ -539,31 +546,31 @@ pub fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()> {
     writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
     writer.write_event(Event::Text(BytesText::new("\n")))?;
 
-    let mut testsuites = BytesStart::new("testsuites");
+    let testsuites = BytesStart::new("testsuites");
     writer.write_event(Event::Start(testsuites))?;
     writer.write_event(Event::Text(BytesText::new("\n  ")))?;
 
     let mut suite = BytesStart::new("testsuite");
     suite.push_attribute(("name", report.name.as_str()));
-    suite.push_attribute(("tests", total.to_string().as_str()));
-    suite.push_attribute(("failures", failures.to_string().as_str()));
+    suite.push_attribute(("tests", total_str.as_str()));
+    suite.push_attribute(("failures", failures_str.as_str()));
     suite.push_attribute(("errors", "0"));
-    suite.push_attribute(("skipped", skipped.to_string().as_str()));
-    suite.push_attribute(("time", format!("{elapsed:.3}").as_str()));
+    suite.push_attribute(("skipped", skipped_str.as_str()));
+    suite.push_attribute(("time", elapsed_str.as_str()));
     writer.write_event(Event::Start(suite))?;
 
     for result in &report.results {
         writer.write_event(Event::Text(BytesText::new("\n    ")))?;
-        let dur = match &result.outcome {
+        let dur_str = match &result.outcome {
             StepOutcome::Passed { duration } | StepOutcome::Failed { duration, .. } => {
-                duration.as_secs_f64()
+                format!("{:.3}", duration.as_secs_f64())
             }
-            StepOutcome::Skipped => 0.0,
+            StepOutcome::Skipped => "0.000".to_string(),
         };
 
         let mut tc = BytesStart::new("testcase");
         tc.push_attribute(("name", result.name.as_str()));
-        tc.push_attribute(("time", format!("{dur:.3}").as_str()));
+        tc.push_attribute(("time", dur_str.as_str()));
         writer.write_event(Event::Start(tc))?;
 
         match &result.outcome {
@@ -572,9 +579,8 @@ pub fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()> {
                 writer.write_event(Event::Empty(BytesStart::new("skipped")))?;
             }
             StepOutcome::Failed { message, .. } => {
-                let mut failure = BytesStart::new("failure");
-                // Escape message for XML attribute
                 let escaped = xml_attr_escape(message);
+                let mut failure = BytesStart::new("failure");
                 failure.push_attribute(("message", escaped.as_str()));
                 writer.write_event(Event::Empty(failure))?;
             }
@@ -631,8 +637,19 @@ mod tests {
     #[test]
     fn test_scenario_report_counts() {
         let report = make_report(vec![
-            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(100) }),
-            ("step-2", StepOutcome::Failed { duration: Duration::from_millis(50), message: "oops".into() }),
+            (
+                "step-1",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(100),
+                },
+            ),
+            (
+                "step-2",
+                StepOutcome::Failed {
+                    duration: Duration::from_millis(50),
+                    message: "oops".into(),
+                },
+            ),
             ("step-3", StepOutcome::Skipped),
         ]);
         assert_eq!(report.passed(), 1);
@@ -644,29 +661,39 @@ mod tests {
     #[test]
     fn test_scenario_report_all_passed() {
         let report = make_report(vec![
-            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(10) }),
-            ("step-2", StepOutcome::Passed { duration: Duration::from_millis(20) }),
+            (
+                "step-1",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(10),
+                },
+            ),
+            (
+                "step-2",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(20),
+                },
+            ),
         ]);
         assert!(report.all_passed());
     }
 
     #[test]
     fn test_toml_parse_minimal() {
-        let toml = r#"
+        let toml_str = r#"
 [[step]]
 action = "click"
 target = "#btn"
 "#;
-        let scenario: Scenario = toml::from_str(toml).unwrap();
+        let scenario: Scenario = toml::from_str(toml_str).expect("valid toml");
         assert_eq!(scenario.step.len(), 1);
         assert_eq!(scenario.step[0].action, "click");
         assert_eq!(scenario.step[0].target.as_deref(), Some("#btn"));
-        assert!(scenario.scenario.fail_fast); // default true
+        assert!(scenario.scenario.fail_fast);
     }
 
     #[test]
     fn test_toml_parse_full_meta() {
-        let toml = r#"
+        let toml_str = r#"
 [connect]
 socket = "/tmp/test.sock"
 timeout_ms = 5000
@@ -688,14 +715,17 @@ action = "assert-text"
 target = "h1"
 expected = "Login"
 "#;
-        let scenario: Scenario = toml::from_str(toml).unwrap();
+        let scenario: Scenario = toml::from_str(toml_str).expect("valid toml");
         assert_eq!(scenario.scenario.name.as_deref(), Some("login flow"));
         assert!(!scenario.scenario.fail_fast);
         assert_eq!(scenario.scenario.global_timeout_ms, Some(60000));
         assert_eq!(scenario.step.len(), 2);
 
-        let connect = scenario.connect.as_ref().unwrap();
-        assert_eq!(connect.socket.as_deref(), Some(Path::new("/tmp/test.sock")));
+        let connect = scenario.connect.as_ref().expect("connect section");
+        assert_eq!(
+            connect.socket.as_deref(),
+            Some(Path::new("/tmp/test.sock"))
+        );
         assert_eq!(connect.timeout_ms, Some(5000));
 
         let step = &scenario.step[1];
@@ -707,11 +737,11 @@ expected = "Login"
 
     #[test]
     fn test_toml_default_fail_fast() {
-        let toml = r#"
+        let toml_str = r#"
 [[step]]
 action = "ping"
 "#;
-        let scenario: Scenario = toml::from_str(toml).unwrap();
+        let scenario: Scenario = toml::from_str(toml_str).expect("valid toml");
         assert!(scenario.scenario.fail_fast);
     }
 
@@ -768,13 +798,23 @@ action = "ping"
     #[test]
     fn test_junit_xml_all_passed() {
         let report = make_report(vec![
-            ("click button", StepOutcome::Passed { duration: Duration::from_millis(123) }),
-            ("fill form", StepOutcome::Passed { duration: Duration::from_millis(45) }),
+            (
+                "click button",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(123),
+                },
+            ),
+            (
+                "fill form",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(45),
+                },
+            ),
         ]);
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("results.xml");
-        write_junit_xml(&report, &path).unwrap();
-        let xml = std::fs::read_to_string(&path).unwrap();
+        write_junit_xml(&report, &path).expect("write junit xml");
+        let xml = std::fs::read_to_string(&path).expect("read xml");
         assert!(xml.contains(r#"name="test-scenario""#));
         assert!(xml.contains(r#"failures="0""#));
         assert!(xml.contains(r#"name="click button""#));
@@ -786,14 +826,25 @@ action = "ping"
     #[test]
     fn test_junit_xml_with_failures_and_skips() {
         let report = make_report(vec![
-            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(10) }),
-            ("step-2", StepOutcome::Failed { duration: Duration::from_millis(20), message: "oops & done".into() }),
+            (
+                "step-1",
+                StepOutcome::Passed {
+                    duration: Duration::from_millis(10),
+                },
+            ),
+            (
+                "step-2",
+                StepOutcome::Failed {
+                    duration: Duration::from_millis(20),
+                    message: "oops & done".into(),
+                },
+            ),
             ("step-3", StepOutcome::Skipped),
         ]);
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("results.xml");
-        write_junit_xml(&report, &path).unwrap();
-        let xml = std::fs::read_to_string(&path).unwrap();
+        write_junit_xml(&report, &path).expect("write junit xml");
+        let xml = std::fs::read_to_string(&path).expect("read xml");
         assert!(xml.contains(r#"failures="1""#));
         assert!(xml.contains(r#"skipped="1""#));
         assert!(xml.contains(r#"message="oops &amp; done""#));

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -1,0 +1,809 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::client::Client;
+use crate::{target_params, with_window};
+
+// ── TOML schema ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct Scenario {
+    pub connect: Option<Connect>,
+    #[serde(default)]
+    pub scenario: ScenarioMeta,
+    #[serde(default)]
+    pub step: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Connect {
+    pub socket: Option<PathBuf>,
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScenarioMeta {
+    pub name: Option<String>,
+    #[serde(default = "default_true")]
+    pub fail_fast: bool,
+    pub global_timeout_ms: Option<u64>,
+}
+
+impl Default for ScenarioMeta {
+    fn default() -> Self {
+        Self {
+            name: None,
+            fail_fast: true,
+            global_timeout_ms: None,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Step {
+    pub name: Option<String>,
+    pub action: String,
+    pub timeout_ms: Option<u64>,
+    pub target: Option<String>,
+    pub value: Option<String>,
+    pub text: Option<String>,
+    pub key: Option<String>,
+    pub url: Option<String>,
+    pub script: Option<String>,
+    pub expected: Option<String>,
+    pub selector: Option<String>,
+    pub direction: Option<String>,
+    pub amount: Option<i32>,
+    #[serde(rename = "ref")]
+    pub step_ref: Option<String>,
+    pub gone: Option<bool>,
+    pub stable: Option<u64>,
+    pub require_mutation: Option<bool>,
+    pub path: Option<PathBuf>,
+}
+
+impl Step {
+    fn display_name(&self, idx: usize) -> String {
+        self.name
+            .clone()
+            .unwrap_or_else(|| format!("step-{}", idx + 1))
+    }
+}
+
+// ── Execution result types ────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum StepOutcome {
+    Passed { duration: Duration },
+    Failed { duration: Duration, message: String },
+    Skipped,
+}
+
+#[derive(Debug)]
+pub struct StepResult {
+    pub name: String,
+    pub outcome: StepOutcome,
+}
+
+#[derive(Debug)]
+pub struct ScenarioReport {
+    pub name: String,
+    pub results: Vec<StepResult>,
+    pub total_duration: Duration,
+}
+
+impl ScenarioReport {
+    pub fn passed(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| matches!(r.outcome, StepOutcome::Passed { .. }))
+            .count()
+    }
+
+    pub fn failed(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| matches!(r.outcome, StepOutcome::Failed { .. }))
+            .count()
+    }
+
+    pub fn skipped(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| matches!(r.outcome, StepOutcome::Skipped))
+            .count()
+    }
+
+    pub fn all_passed(&self) -> bool {
+        self.failed() == 0
+    }
+}
+
+// ── Main runner ───────────────────────────────────────────────────────────────
+
+pub fn load_scenario(path: &Path) -> Result<Scenario> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read scenario file: {}", path.display()))?;
+    toml::from_str(&content).with_context(|| {
+        format!("Failed to parse scenario TOML: {}", path.display())
+    })
+}
+
+pub async fn run_scenario(
+    client: &mut Client,
+    scenario: &Scenario,
+    window: Option<&str>,
+    fail_fast_override: Option<bool>,
+) -> Result<ScenarioReport> {
+    let meta = &scenario.scenario;
+    let name = meta
+        .name
+        .clone()
+        .unwrap_or_else(|| "unnamed scenario".to_string());
+    let fail_fast = fail_fast_override.unwrap_or(meta.fail_fast);
+
+    let total_start = Instant::now();
+    let mut results = Vec::with_capacity(scenario.step.len());
+    let mut failed = false;
+
+    for (idx, step) in scenario.step.iter().enumerate() {
+        let step_name = step.display_name(idx);
+
+        if failed && fail_fast {
+            print_step_line(idx, scenario.step.len(), &step_name, "SKIP");
+            results.push(StepResult {
+                name: step_name,
+                outcome: StepOutcome::Skipped,
+            });
+            continue;
+        }
+
+        let step_start = Instant::now();
+
+        let outcome = match run_step(client, step, window).await {
+            Ok(_) => {
+                let dur = step_start.elapsed();
+                print_step_line(idx, scenario.step.len(), &step_name, "ok");
+                StepOutcome::Passed { duration: dur }
+            }
+            Err(e) => {
+                let dur = step_start.elapsed();
+                let msg = format!("{e:#}");
+                print_step_fail(idx, scenario.step.len(), &step_name, &msg);
+                // Capture screenshot on failure
+                let _ = take_failure_screenshot(client, &step_name, window).await;
+                failed = true;
+                StepOutcome::Failed {
+                    duration: dur,
+                    message: msg,
+                }
+            }
+        };
+
+        results.push(StepResult {
+            name: step_name,
+            outcome,
+        });
+    }
+
+    Ok(ScenarioReport {
+        name,
+        results,
+        total_duration: total_start.elapsed(),
+    })
+}
+
+async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Result<Value> {
+    let timeout_ms = step.timeout_ms;
+    match step.action.as_str() {
+        "click" => {
+            let t = require_target(step)?;
+            client
+                .call("click", with_window(Some(target_params(t)), window))
+                .await
+        }
+        "fill" => {
+            let t = require_target(step)?;
+            let value = step.value.as_deref().unwrap_or("");
+            let mut p = target_params(t);
+            p["value"] = json!(value);
+            client.call("fill", with_window(Some(p), window)).await
+        }
+        "type" => {
+            let t = require_target(step)?;
+            let text = step.text.as_deref().unwrap_or("");
+            let mut p = target_params(t);
+            p["text"] = json!(text);
+            client.call("type", with_window(Some(p), window)).await
+        }
+        "press" => {
+            let key = step
+                .key
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("press step requires 'key'"))?;
+            client
+                .call("press", with_window(Some(json!({"key": key})), window))
+                .await
+        }
+        "select" => {
+            let t = require_target(step)?;
+            let value = step.value.as_deref().unwrap_or("");
+            let mut p = target_params(t);
+            p["value"] = json!(value);
+            client.call("select", with_window(Some(p), window)).await
+        }
+        "check" => {
+            let t = require_target(step)?;
+            client
+                .call("check", with_window(Some(target_params(t)), window))
+                .await
+        }
+        "scroll" => {
+            let direction = step.direction.as_deref().unwrap_or("down");
+            client
+                .call(
+                    "scroll",
+                    with_window(
+                        Some(json!({
+                            "direction": direction,
+                            "amount": step.amount,
+                            "ref": step.step_ref,
+                        })),
+                        window,
+                    ),
+                )
+                .await
+        }
+        "navigate" => {
+            let url = step
+                .url
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("navigate step requires 'url'"))?;
+            client
+                .call("navigate", with_window(Some(json!({"url": url})), window))
+                .await
+        }
+        "wait" => {
+            let timeout = timeout_ms.unwrap_or(10_000);
+            client
+                .call(
+                    "wait",
+                    with_window(
+                        Some(json!({
+                            "target": step.target,
+                            "selector": step.selector,
+                            "gone": step.gone.unwrap_or(false),
+                            "timeout": timeout,
+                        })),
+                        window,
+                    ),
+                )
+                .await
+        }
+        "watch" => {
+            let timeout = timeout_ms.unwrap_or(10_000);
+            let stable = step.stable.unwrap_or(300);
+            let require_mutation = step.require_mutation.unwrap_or(false);
+            let mut params = serde_json::Map::new();
+            params.insert("timeout".into(), json!(timeout));
+            params.insert("stable".into(), json!(stable));
+            if require_mutation {
+                params.insert("requireMutation".into(), json!(true));
+            }
+            if let Some(sel) = &step.selector {
+                params.insert("selector".into(), json!(sel));
+            }
+            client
+                .call(
+                    "watch",
+                    with_window(Some(Value::Object(params)), window),
+                )
+                .await
+        }
+        "eval" => {
+            let script = step
+                .script
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("eval step requires 'script'"))?;
+            client
+                .call(
+                    "eval",
+                    with_window(Some(json!({"script": script})), window),
+                )
+                .await
+        }
+        "screenshot" => {
+            let result = client
+                .call(
+                    "screenshot",
+                    with_window(
+                        Some(json!({"path": step.path, "selector": step.selector})),
+                        window,
+                    ),
+                )
+                .await?;
+            if let Some(path) = &step.path {
+                save_screenshot_result(&result, path)?;
+            }
+            Ok(result)
+        }
+        "assert-text" => {
+            let t = require_target(step)?;
+            let expected = step
+                .expected
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("assert-text requires 'expected'"))?;
+            let result = client
+                .call("text", with_window(Some(target_params(t)), window))
+                .await?;
+            let actual = result.as_str().unwrap_or_default();
+            anyhow::ensure!(
+                actual == expected,
+                "expected text {:?}, got {:?}",
+                expected,
+                actual
+            );
+            Ok(json!({"ok": true}))
+        }
+        "assert-exists" => {
+            let t = require_target(step)?;
+            // Call visible; if it returns any valid response, element exists
+            client
+                .call("visible", with_window(Some(target_params(t)), window))
+                .await?;
+            Ok(json!({"ok": true}))
+        }
+        "assert-visible" => {
+            let t = require_target(step)?;
+            let result = client
+                .call("visible", with_window(Some(target_params(t)), window))
+                .await?;
+            let visible = result
+                .get("visible")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            anyhow::ensure!(visible, "element is not visible");
+            Ok(json!({"ok": true}))
+        }
+        "assert-hidden" => {
+            let t = require_target(step)?;
+            let result = client
+                .call("visible", with_window(Some(target_params(t)), window))
+                .await?;
+            let visible = result
+                .get("visible")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            anyhow::ensure!(!visible, "element is visible");
+            Ok(json!({"ok": true}))
+        }
+        "assert-value" => {
+            let t = require_target(step)?;
+            let expected = step
+                .expected
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("assert-value requires 'expected'"))?;
+            let result = client
+                .call("value", with_window(Some(target_params(t)), window))
+                .await?;
+            let actual = result.as_str().unwrap_or_default();
+            anyhow::ensure!(
+                actual == expected,
+                "expected value {:?}, got {:?}",
+                expected,
+                actual
+            );
+            Ok(json!({"ok": true}))
+        }
+        "assert-url" => {
+            let expected = step
+                .expected
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("assert-url requires 'expected'"))?;
+            let result = client.call("url", with_window(None, window)).await?;
+            let actual = result.as_str().unwrap_or_default();
+            anyhow::ensure!(
+                actual.contains(expected),
+                "URL does not contain {:?}, got {:?}",
+                expected,
+                actual
+            );
+            Ok(json!({"ok": true}))
+        }
+        other => anyhow::bail!("unknown step action: {:?}", other),
+    }
+}
+
+fn require_target(step: &Step) -> Result<&str> {
+    step.target
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("step '{}' requires 'target'", step.action))
+}
+
+// ── Screenshot on failure ─────────────────────────────────────────────────────
+
+async fn take_failure_screenshot(
+    client: &mut Client,
+    step_name: &str,
+    window: Option<&str>,
+) -> Result<()> {
+    let dir = Path::new("tauri-pilot-failures");
+    std::fs::create_dir_all(dir)?;
+
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+
+    // Sanitize step name for use in a filename
+    let safe_name: String = step_name
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect();
+    let filename = format!("{safe_name}-{ts}.png");
+    let path = dir.join(&filename);
+
+    let result = client
+        .call("screenshot", with_window(Some(json!({})), window))
+        .await?;
+    save_screenshot_result(&result, &path)?;
+    eprintln!(
+        "  {} {}",
+        crate::style::dim("failure screenshot →"),
+        path.display()
+    );
+    Ok(())
+}
+
+fn save_screenshot_result(result: &Value, path: &Path) -> Result<()> {
+    let data_url = result
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("screenshot result is not a string"))?;
+    let base64_data = data_url
+        .strip_prefix("data:image/png;base64,")
+        .unwrap_or(data_url);
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64_data)
+        .map_err(|e| anyhow::anyhow!("Failed to decode base64 screenshot: {e}"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+// ── Terminal output helpers ───────────────────────────────────────────────────
+
+fn print_step_line(idx: usize, total: usize, name: &str, status: &str) {
+    let colored = match status {
+        "ok" => crate::style::success(status),
+        "SKIP" => crate::style::dim(status),
+        _ => crate::style::failure(status),
+    };
+    eprintln!("  [{}/{}] {} {}", idx + 1, total, name, colored);
+}
+
+fn print_step_fail(idx: usize, total: usize, name: &str, msg: &str) {
+    eprintln!(
+        "  [{}/{}] {} {}\n    {}",
+        idx + 1,
+        total,
+        name,
+        crate::style::failure("FAIL"),
+        crate::style::failure(msg)
+    );
+}
+
+pub fn print_report(report: &ScenarioReport) {
+    let total = report.results.len();
+    let passed = report.passed();
+    let failed = report.failed();
+    let skipped = report.skipped();
+    let secs = report.total_duration.as_secs_f64();
+
+    eprintln!();
+    eprintln!(
+        "Scenario: {}",
+        crate::style::bold(&report.name)
+    );
+    eprintln!(
+        "  {} passed · {} failed · {} skipped  ({:.3}s)",
+        passed, failed, skipped, secs
+    );
+    eprintln!();
+}
+
+// ── JUnit XML output ──────────────────────────────────────────────────────────
+
+pub fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()> {
+    use quick_xml::Writer;
+    use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+
+    let total = report.results.len();
+    let failures = report.failed();
+    let skipped = report.skipped();
+    let elapsed = report.total_duration.as_secs_f64();
+
+    let mut buf = Vec::new();
+    let mut writer = Writer::new(&mut buf);
+
+    writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+    writer.write_event(Event::Text(BytesText::new("\n")))?;
+
+    let mut testsuites = BytesStart::new("testsuites");
+    writer.write_event(Event::Start(testsuites))?;
+    writer.write_event(Event::Text(BytesText::new("\n  ")))?;
+
+    let mut suite = BytesStart::new("testsuite");
+    suite.push_attribute(("name", report.name.as_str()));
+    suite.push_attribute(("tests", total.to_string().as_str()));
+    suite.push_attribute(("failures", failures.to_string().as_str()));
+    suite.push_attribute(("errors", "0"));
+    suite.push_attribute(("skipped", skipped.to_string().as_str()));
+    suite.push_attribute(("time", format!("{elapsed:.3}").as_str()));
+    writer.write_event(Event::Start(suite))?;
+
+    for result in &report.results {
+        writer.write_event(Event::Text(BytesText::new("\n    ")))?;
+        let dur = match &result.outcome {
+            StepOutcome::Passed { duration } | StepOutcome::Failed { duration, .. } => {
+                duration.as_secs_f64()
+            }
+            StepOutcome::Skipped => 0.0,
+        };
+
+        let mut tc = BytesStart::new("testcase");
+        tc.push_attribute(("name", result.name.as_str()));
+        tc.push_attribute(("time", format!("{dur:.3}").as_str()));
+        writer.write_event(Event::Start(tc))?;
+
+        match &result.outcome {
+            StepOutcome::Passed { .. } => {}
+            StepOutcome::Skipped => {
+                writer.write_event(Event::Empty(BytesStart::new("skipped")))?;
+            }
+            StepOutcome::Failed { message, .. } => {
+                let mut failure = BytesStart::new("failure");
+                // Escape message for XML attribute
+                let escaped = xml_attr_escape(message);
+                failure.push_attribute(("message", escaped.as_str()));
+                writer.write_event(Event::Empty(failure))?;
+            }
+        }
+
+        writer.write_event(Event::End(BytesEnd::new("testcase")))?;
+    }
+
+    writer.write_event(Event::Text(BytesText::new("\n  ")))?;
+    writer.write_event(Event::End(BytesEnd::new("testsuite")))?;
+    writer.write_event(Event::Text(BytesText::new("\n")))?;
+    writer.write_event(Event::End(BytesEnd::new("testsuites")))?;
+    writer.write_event(Event::Text(BytesText::new("\n")))?;
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, &buf)
+        .with_context(|| format!("Failed to write JUnit XML to {}", path.display()))?;
+
+    Ok(())
+}
+
+fn xml_attr_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_report(results: Vec<(&str, StepOutcome)>) -> ScenarioReport {
+        ScenarioReport {
+            name: "test-scenario".to_string(),
+            results: results
+                .into_iter()
+                .map(|(name, outcome)| StepResult {
+                    name: name.to_string(),
+                    outcome,
+                })
+                .collect(),
+            total_duration: Duration::from_millis(1234),
+        }
+    }
+
+    #[test]
+    fn test_scenario_report_counts() {
+        let report = make_report(vec![
+            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(100) }),
+            ("step-2", StepOutcome::Failed { duration: Duration::from_millis(50), message: "oops".into() }),
+            ("step-3", StepOutcome::Skipped),
+        ]);
+        assert_eq!(report.passed(), 1);
+        assert_eq!(report.failed(), 1);
+        assert_eq!(report.skipped(), 1);
+        assert!(!report.all_passed());
+    }
+
+    #[test]
+    fn test_scenario_report_all_passed() {
+        let report = make_report(vec![
+            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(10) }),
+            ("step-2", StepOutcome::Passed { duration: Duration::from_millis(20) }),
+        ]);
+        assert!(report.all_passed());
+    }
+
+    #[test]
+    fn test_toml_parse_minimal() {
+        let toml = r#"
+[[step]]
+action = "click"
+target = "#btn"
+"#;
+        let scenario: Scenario = toml::from_str(toml).unwrap();
+        assert_eq!(scenario.step.len(), 1);
+        assert_eq!(scenario.step[0].action, "click");
+        assert_eq!(scenario.step[0].target.as_deref(), Some("#btn"));
+        assert!(scenario.scenario.fail_fast); // default true
+    }
+
+    #[test]
+    fn test_toml_parse_full_meta() {
+        let toml = r#"
+[connect]
+socket = "/tmp/test.sock"
+timeout_ms = 5000
+
+[scenario]
+name = "login flow"
+fail_fast = false
+global_timeout_ms = 60000
+
+[[step]]
+name = "navigate"
+action = "navigate"
+url = "http://localhost:5173"
+timeout_ms = 3000
+
+[[step]]
+name = "assert title"
+action = "assert-text"
+target = "h1"
+expected = "Login"
+"#;
+        let scenario: Scenario = toml::from_str(toml).unwrap();
+        assert_eq!(scenario.scenario.name.as_deref(), Some("login flow"));
+        assert!(!scenario.scenario.fail_fast);
+        assert_eq!(scenario.scenario.global_timeout_ms, Some(60000));
+        assert_eq!(scenario.step.len(), 2);
+
+        let connect = scenario.connect.as_ref().unwrap();
+        assert_eq!(connect.socket.as_deref(), Some(Path::new("/tmp/test.sock")));
+        assert_eq!(connect.timeout_ms, Some(5000));
+
+        let step = &scenario.step[1];
+        assert_eq!(step.name.as_deref(), Some("assert title"));
+        assert_eq!(step.action, "assert-text");
+        assert_eq!(step.target.as_deref(), Some("h1"));
+        assert_eq!(step.expected.as_deref(), Some("Login"));
+    }
+
+    #[test]
+    fn test_toml_default_fail_fast() {
+        let toml = r#"
+[[step]]
+action = "ping"
+"#;
+        let scenario: Scenario = toml::from_str(toml).unwrap();
+        assert!(scenario.scenario.fail_fast);
+    }
+
+    #[test]
+    fn test_toml_step_display_name_uses_name_field() {
+        let step = Step {
+            name: Some("my step".to_string()),
+            action: "click".to_string(),
+            timeout_ms: None,
+            target: None,
+            value: None,
+            text: None,
+            key: None,
+            url: None,
+            script: None,
+            expected: None,
+            selector: None,
+            direction: None,
+            amount: None,
+            step_ref: None,
+            gone: None,
+            stable: None,
+            require_mutation: None,
+            path: None,
+        };
+        assert_eq!(step.display_name(0), "my step");
+    }
+
+    #[test]
+    fn test_toml_step_display_name_fallback() {
+        let step = Step {
+            name: None,
+            action: "click".to_string(),
+            timeout_ms: None,
+            target: None,
+            value: None,
+            text: None,
+            key: None,
+            url: None,
+            script: None,
+            expected: None,
+            selector: None,
+            direction: None,
+            amount: None,
+            step_ref: None,
+            gone: None,
+            stable: None,
+            require_mutation: None,
+            path: None,
+        };
+        assert_eq!(step.display_name(2), "step-3");
+    }
+
+    #[test]
+    fn test_junit_xml_all_passed() {
+        let report = make_report(vec![
+            ("click button", StepOutcome::Passed { duration: Duration::from_millis(123) }),
+            ("fill form", StepOutcome::Passed { duration: Duration::from_millis(45) }),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("results.xml");
+        write_junit_xml(&report, &path).unwrap();
+        let xml = std::fs::read_to_string(&path).unwrap();
+        assert!(xml.contains(r#"name="test-scenario""#));
+        assert!(xml.contains(r#"failures="0""#));
+        assert!(xml.contains(r#"name="click button""#));
+        assert!(xml.contains(r#"name="fill form""#));
+        assert!(!xml.contains("<failure"));
+        assert!(!xml.contains("<skipped"));
+    }
+
+    #[test]
+    fn test_junit_xml_with_failures_and_skips() {
+        let report = make_report(vec![
+            ("step-1", StepOutcome::Passed { duration: Duration::from_millis(10) }),
+            ("step-2", StepOutcome::Failed { duration: Duration::from_millis(20), message: "oops & done".into() }),
+            ("step-3", StepOutcome::Skipped),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("results.xml");
+        write_junit_xml(&report, &path).unwrap();
+        let xml = std::fs::read_to_string(&path).unwrap();
+        assert!(xml.contains(r#"failures="1""#));
+        assert!(xml.contains(r#"skipped="1""#));
+        assert!(xml.contains(r#"message="oops &amp; done""#));
+        assert!(xml.contains("<skipped"));
+    }
+
+    #[test]
+    fn test_xml_attr_escape() {
+        assert_eq!(xml_attr_escape("a & b"), "a &amp; b");
+        assert_eq!(xml_attr_escape(r#"say "hi""#), "say &quot;hi&quot;");
+        assert_eq!(xml_attr_escape("<tag>"), "&lt;tag&gt;");
+    }
+}

--- a/crates/tauri-pilot-cli/src/style.rs
+++ b/crates/tauri-pilot-cli/src/style.rs
@@ -34,6 +34,11 @@ pub(crate) fn bold(msg: impl Display) -> String {
     format!("{}", msg.if_supports_color(Stdout, |t| t.bold()))
 }
 
+/// Format a failure message in red (no icon, unlike `error`).
+pub(crate) fn failure(msg: impl Display) -> String {
+    format!("{}", msg.if_supports_color(Stdout, |t| t.red()))
+}
+
 /// Format a warning message in yellow.
 pub(crate) fn warn(msg: impl Display) -> String {
     format!("{}", msg.if_supports_color(Stdout, |t| t.yellow()))

--- a/docs/examples/login-flow.toml
+++ b/docs/examples/login-flow.toml
@@ -1,0 +1,82 @@
+# tauri-pilot scenario example — login flow
+#
+# Run with:
+#   tauri-pilot run docs/examples/login-flow.toml
+#   tauri-pilot run docs/examples/login-flow.toml --junit results.xml
+
+# [connect] is optional. When omitted, the socket is auto-detected.
+[connect]
+# socket = "/tmp/tauri-pilot-myapp.sock"  # override auto-detection
+timeout_ms = 5000
+
+[scenario]
+name = "Login flow"
+fail_fast = true           # stop on first failure (default: true)
+global_timeout_ms = 60000  # hard cap for the entire scenario (ms)
+
+# ── Navigation ──────────────────────────────────────────────────────────────
+
+[[step]]
+name = "open login page"
+action = "navigate"
+url = "http://localhost:1420/login"
+
+[[step]]
+name = "wait for form"
+action = "wait"
+selector = "#login-form"
+timeout_ms = 5000
+
+# ── Interaction ──────────────────────────────────────────────────────────────
+
+[[step]]
+name = "fill email"
+action = "fill"
+target = "#email"
+value = "user@example.com"
+
+[[step]]
+name = "fill password"
+action = "fill"
+target = "#password"
+value = "secret"
+
+[[step]]
+name = "click submit"
+action = "click"
+target = "#submit-btn"
+
+# ── Wait for redirect ─────────────────────────────────────────────────────────
+
+[[step]]
+name = "watch for dashboard"
+action = "watch"
+selector = "#dashboard"
+timeout_ms = 10000
+stable = 300
+require_mutation = true
+
+# ── Assertions ────────────────────────────────────────────────────────────────
+
+[[step]]
+name = "assert dashboard url"
+action = "assert-url"
+expected = "/dashboard"
+
+[[step]]
+name = "assert welcome heading"
+action = "assert-text"
+target = "h1"
+expected = "Welcome"
+
+[[step]]
+name = "assert logout button visible"
+action = "assert-visible"
+target = "#logout-btn"
+
+# ── Screenshot ────────────────────────────────────────────────────────────────
+
+[[step]]
+name = "capture final state"
+action = "screenshot"
+path = "screenshots/dashboard.png"


### PR DESCRIPTION
## Summary

- Adds `tauri-pilot run <scenario.toml>` command for declarative, assertion-native scenario execution
- TOML schema with `[connect]`, `[scenario]`, and `[[step]]` array tables
- 18 action types: click, fill, type, press, select, check, scroll, navigate, wait, watch, eval, screenshot, assert-text, assert-exists, assert-visible, assert-hidden, assert-value, assert-url
- `fail_fast = true` by default; skipped steps shown in output
- `--junit <output.xml>` flag for CI integration (valid JUnit XML via quick-xml 0.36)
- Auto-captures failure screenshots → `./tauri-pilot-failures/<step-name>-<timestamp>.png`
- Exit code 0 = all pass, 1 = any failure
- Unit tests for TOML parsing, report counters, JUnit XML generation, XML escaping
- Example scenario: `docs/examples/login-flow.toml`
- CONTRIBUTING.md: `run` vs `record`/`replay` distinction

Closes [MPI-70](/MPI/issues/MPI-70)

## Test plan

- [ ] `cargo test -p tauri-pilot-cli` passes (TOML parser, JUnit XML, fail-fast logic)
- [ ] `tauri-pilot run docs/examples/login-flow.toml` parses without panic against a running app
- [ ] `--junit results.xml` produces valid JUnit XML (validate with xmllint)
- [ ] failure screenshot appears in `./tauri-pilot-failures/` on a failing step
- [ ] exit code 1 when any step fails; exit code 0 when all pass
- [ ] `--no-fail-fast` overrides `fail_fast = true` in TOML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tauri-pilot run` for TOML-driven scenarios: step-by-step execution with assertions, per-step timeouts, `--no-fail-fast`, `--junit <FILE>`, and exit codes (0 = success, 1 = failure)
  * Failure screenshots are captured locally and a consolidated pass/fail/skip report is printed

* **Documentation**
  * New guide comparing `run` (declarative TOML) vs `record`/`replay` (timing-accurate), plus an example login-flow scenario and note about shell export for replays (`replay --export sh`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->