### PR TITLE
fix(cli): scenario runner review follow-up — wire timeouts and fix assert-exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ tauri-pilot offers two complementary automation modes:
 
 | Mode | Command | Format | Use case |
 |------|---------|--------|----------|
-| **Declarative** | `tauri-pilot run <file.toml>` | TOML scenario | Structured tests with assertions and assertions (CI-friendly) |
+| **Declarative** | `tauri-pilot run <file.toml>` | TOML scenario | Structured tests with assertions and timeouts (CI-friendly) |
 | **Capture-replay** | `tauri-pilot record start` / `replay` | JSON session | Quick capture of manual interactions for later replay |
 
 **`run` (TOML scenario)** — define steps declaratively with action types, assertions, and

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1276,10 +1276,32 @@ async fn run_scenario_command(
         .or_else(|| loaded.connect.as_ref().and_then(|c| c.socket.clone()))
         .map_or_else(|| resolve_socket(None), Ok)?;
 
-    let mut client = Client::connect(&socket).await?;
+    let connect_timeout = loaded
+        .connect
+        .as_ref()
+        .and_then(|c| c.timeout_ms)
+        .map(std::time::Duration::from_millis);
+    let mut client = match connect_timeout {
+        Some(t) => tokio::time::timeout(t, Client::connect(&socket))
+            .await
+            .map_err(|_| anyhow::anyhow!("connection timed out after {}ms", t.as_millis()))??,
+        None => Client::connect(&socket).await?,
+    };
 
     let fail_fast_override = if no_fail_fast { Some(false) } else { None };
-    let report = scenario::run_scenario(&mut client, &loaded, window, fail_fast_override).await?;
+    let global_ms = loaded.scenario.global_timeout_ms;
+    let report = match global_ms {
+        Some(ms) => {
+            let t = std::time::Duration::from_millis(ms);
+            tokio::time::timeout(
+                t,
+                scenario::run_scenario(&mut client, &loaded, window, fail_fast_override),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("scenario exceeded global timeout of {ms}ms"))??
+        }
+        None => scenario::run_scenario(&mut client, &loaded, window, fail_fast_override).await?,
+    };
 
     scenario::print_report(&report);
 

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -369,13 +369,10 @@ async fn dispatch_step(client: &mut Client, step: &Step, window: Option<&str>) -
         }
         "assert-exists" => {
             let t = require_target(step)?;
-            let result = client
+            client
                 .call("visible", with_window(Some(target_params(t)), window))
-                .await?;
-            anyhow::ensure!(
-                result.get("visible").is_some(),
-                "element '{t}' was not found in the DOM"
-            );
+                .await
+                .with_context(|| format!("element '{t}' was not found in the DOM"))?;
             Ok(json!({"ok": true}))
         }
         "assert-visible" => {

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -24,7 +24,6 @@ pub(crate) struct Scenario {
 #[derive(Debug, Deserialize, Default)]
 pub(crate) struct Connect {
     pub(crate) socket: Option<PathBuf>,
-    #[allow(dead_code)]
     pub(crate) timeout_ms: Option<u64>,
 }
 
@@ -34,7 +33,6 @@ pub(crate) struct ScenarioMeta {
     pub(crate) name: Option<String>,
     #[serde(default = "default_true")]
     pub(crate) fail_fast: bool,
-    #[allow(dead_code)]
     pub(crate) global_timeout_ms: Option<u64>,
 }
 
@@ -210,8 +208,22 @@ pub(crate) async fn run_scenario(
     })
 }
 
-#[allow(clippy::too_many_lines)]
 async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Result<Value> {
+    // wait/watch send timeout in RPC params; all other actions use a tokio deadline
+    let is_rpc_timed = matches!(step.action.as_str(), "wait" | "watch");
+    match (is_rpc_timed, step.timeout_ms) {
+        (false, Some(ms)) => tokio::time::timeout(
+            Duration::from_millis(ms),
+            dispatch_step(client, step, window),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("step '{}' timed out after {ms}ms", step.action))?,
+        _ => dispatch_step(client, step, window).await,
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn dispatch_step(client: &mut Client, step: &Step, window: Option<&str>) -> Result<Value> {
     let timeout_ms = step.timeout_ms;
     match step.action.as_str() {
         "click" => {
@@ -357,9 +369,13 @@ async fn run_step(client: &mut Client, step: &Step, window: Option<&str>) -> Res
         }
         "assert-exists" => {
             let t = require_target(step)?;
-            client
+            let result = client
                 .call("visible", with_window(Some(target_params(t)), window))
                 .await?;
+            anyhow::ensure!(
+                result.get("visible").is_some(),
+                "element '{t}' was not found in the DOM"
+            );
             Ok(json!({"ok": true}))
         }
         "assert-visible" => {
@@ -530,7 +546,12 @@ pub(crate) fn write_junit_xml(report: &ScenarioReport, path: &Path) -> Result<()
     writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
     writer.write_event(Event::Text(BytesText::new("\n")))?;
 
-    let testsuites = BytesStart::new("testsuites");
+    let mut testsuites = BytesStart::new("testsuites");
+    testsuites.push_attribute(("tests", total_str.as_str()));
+    testsuites.push_attribute(("failures", failures_str.as_str()));
+    testsuites.push_attribute(("errors", "0"));
+    testsuites.push_attribute(("skipped", skipped_str.as_str()));
+    testsuites.push_attribute(("time", elapsed_str.as_str()));
     writer.write_event(Event::Start(testsuites))?;
     writer.write_event(Event::Text(BytesText::new("\n  ")))?;
 
@@ -790,7 +811,9 @@ action = "ping"
         write_junit_xml(&report, &path).expect("write junit xml");
         let xml = std::fs::read_to_string(&path).expect("read xml");
         assert!(xml.contains(r#"name="test-scenario""#));
+        assert!(xml.contains(r#"tests="2""#));
         assert!(xml.contains(r#"failures="0""#));
+        assert!(xml.contains(r#"skipped="0""#));
         assert!(xml.contains(r#"name="click button""#));
         assert!(xml.contains(r#"name="fill form""#));
         assert!(!xml.contains("<failure"));


### PR DESCRIPTION
## Summary

Follow-up to #62, addressing reviewer comments from CodeRabbit, Greptile, and cubic-dev that arrived after the merge.

- **Wire `connect.timeout_ms`**: `Client::connect` is now wrapped in `tokio::time::timeout` when the TOML `[connect].timeout_ms` field is set
- **Enforce `global_timeout_ms`**: `run_scenario` is now wrapped in a `tokio::time::timeout` hard deadline
- **Per-step timeout for all actions**: `run_step` split into a small timeout-wrapper (`run_step`) + `dispatch_step` body; `tokio::time::timeout` applied for all non-`wait`/`watch` actions (those two manage timeout via RPC params)
- **Fix `assert-exists`**: now verifies the `visible` key is present in the RPC response to catch missing DOM elements
- **`<testsuites>` aggregate attributes**: add `tests`, `failures`, `errors`, `skipped`, `time` to the root element for CI reporters (Jenkins, GitHub Actions, Allure)
- **Fix CONTRIBUTING.md typo**: "assertions and assertions" → "assertions and timeouts"
- Remove `#[allow(dead_code)]` on `timeout_ms` and `global_timeout_ms` (fields now used in non-test code)

## Test plan

- [ ] `cargo test --workspace` — existing JUnit XML tests updated to assert `tests=` and `skipped=` on `<testsuites>`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional connection timeout for socket establishment.
  * Optional global scenario timeout to limit overall test execution time.

* **Bug Fixes**
  * Stronger "assert exists" validation to ensure elements are present.
  * JUnit XML reports include test/run-level metadata (tests, failures, errors, skipped, time).

* **Documentation**
  * CONTRIBUTING guide clarified scenario descriptions to reference assertions and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires connection, per-step, and global timeouts in `tauri-pilot-cli` to enforce predictable run limits. Improves `assert-exists` to surface clear errors when elements are missing.

- **New Features**
  - Respect `connect.timeout_ms`: wrap `Client::connect` with `tokio::time::timeout`.
  - Enforce `global_timeout_ms`: hard deadline around `run_scenario`.
  - Apply per-step `timeout_ms` to all non-`wait`/`watch` actions; those two keep RPC timeouts.
  - Add `tests`, `failures`, `errors`, `skipped`, `time` to JUnit `<testsuites>` for CI.

- **Bug Fixes**
  - `assert-exists` now uses `.with_context()` to show a clear "element was not found" error; removes an unreachable guard.
  - Remove dead-code allowances on timeout fields; fix CONTRIBUTING typo.

<sup>Written for commit a76ebe546bbddd2133df6d0f1ee8bb6aca7b46c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

