### PR TITLE
feat: Windows IPC support via Named Pipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 
-# Claude Code
+# AI Agents
 .claude/
+.sisyphus/
 CLAUDE.md
 
 # Node (for bridge build step)

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@ Thumbs.db
 
 # AI Agents
 .claude/
-.sisyphus/
-.agents/
-skills-lock.json
-CLAUDE.md
 
 # Node (for bridge build step)
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ Thumbs.db
 # AI Agents
 .claude/
 .sisyphus/
+.agents/
+skills-lock.json
 CLAUDE.md
 
 # Node (for bridge build step)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Windows support** — named pipe server and client for Windows, with security hardening (DACL, SID validation), registry-based instance discovery, and platform-specific tests ([#64])
+
 ## [0.4.0] - 2026-04-17
 
 ### Added
@@ -189,3 +193,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/mpiton/tauri-pilot/issues/8
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
+[#64]: https://github.com/mpiton/tauri-pilot/pull/64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Windows security hardening** — fixed heap overflow in ACL allocation, use-after-free on the SID buffer, a no-op peer-SID check (`OpenProcessToken` on the impersonated thread replaced with `OpenThreadToken`), UB on the alloc-failure path, silent fallback to a broader default DACL, and a permanently-aborting accept loop. Also switched `instances_dir` creation to `std::fs::create_dir_all` for correctness on clean profiles, and added a regression test asserting the bound pipe carries a user-only DACL with one ACE ([#64])
+- `tauri-pilot-cli` Windows builds now enable the `Win32_Foundation` and `Win32_System_Threading` features on the `windows` crate so `is_pid_alive` compiles on Windows CI ([#64])
+- `tauri-plugin-pilot` marks the Linux-target `enigo` entry as `optional = true` so `--no-default-features` actually drops the dependency — previously the `press` feature gate was silently defeated by cargo merging the target-specific entry with the top-level one ([#64])
+- `tauri-plugin-pilot` server now caps per-line reads using `AsyncReadExt::take` before invoking `read_line`, so a peer flooding bytes without a newline can no longer OOM the host process — the existing `MAX_LINE_LENGTH` check was applied after the full line had already been buffered ([#64])
+- `tauri-pilot-cli` Unix client tests use a per-process, atomic-counter socket path instead of hard-coded `/tmp/tauri-pilot-test-*.sock` paths, so parallel `cargo test` runs no longer cross-wire through the same socket file ([#64])
+- `tauri-pilot-cli` Windows registry-resolution tests mock entries with `std::process::id()` instead of a fabricated dead PID, so the liveness filter added in the Windows support work doesn't skip them ([#64])
+
+### Changed
+
+- `tauri-plugin-pilot` `init()` doc comment clarifies the no-op fallback now excludes Windows too and mentions the Named Pipe server path ([#64])
+
+### Removed
+
+- `.gitignore` no longer ignores `CLAUDE.md`, `.sisyphus/`, `.agents/`, or `skills-lock.json` — these are personal tooling entries that belong in a user-level `~/.gitignore_global`, not in the repo ([#64])
 
 ## [0.4.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows support** — named pipe server and client for Windows, with security hardening (DACL, SID validation), registry-based instance discovery, and platform-specific tests ([#64])
 
+### Fixed
+
+- **Windows security hardening** — fixed heap overflow in ACL allocation, use-after-free on the SID buffer, a no-op peer-SID check (`OpenProcessToken` on the impersonated thread replaced with `OpenThreadToken`), UB on the alloc-failure path, silent fallback to a broader default DACL, and a permanently-aborting accept loop. Also switched `instances_dir` creation to `std::fs::create_dir_all` for correctness on clean profiles, and added a regression test asserting the bound pipe carries a user-only DACL with one ACE ([#64])
+
 ## [0.4.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://crates.io/crates/tauri-plugin-pilot"><img src="https://img.shields.io/crates/v/tauri-plugin-pilot.svg" alt="crates.io"></a>
   <a href="https://github.com/mpiton/tauri-pilot/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/rust-1.95.0+-orange.svg" alt="Rust 1.95.0+">
-  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS-lightgrey.svg" alt="Platform: Linux | macOS">
+  <img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg" alt="Platform: Linux | macOS | Windows">
   <img src="https://img.shields.io/badge/tauri-v2-24C8D8.svg" alt="Tauri v2">
 </p>
 
@@ -38,24 +38,24 @@ ok
 
 ## Why?
 
-There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't work (Tauri uses system WebViews — WebKitGTK on Linux, WebKit on macOS — not Chromium). tauri-pilot bridges this gap with a lightweight plugin + CLI that speaks a protocol optimized for LLM consumption.
+There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't work (Tauri uses system WebViews — WebKitGTK on Linux, WebKit on macOS, WebView2 on Windows — not Chromium). tauri-pilot bridges this gap with a lightweight plugin + CLI that speaks a protocol optimized for LLM consumption.
 
 ## How it works
 
 ```
-┌──────────────┐   Unix Socket    ┌─────────────────────────────┐
-│  tauri-pilot  │ ◄──────────────► │  tauri-plugin-pilot (Rust)  │
-│  (CLI)        │   JSON-RPC       │  embedded in your app       │
-└──────────────┘                   │                             │
-                                   │  ┌─────────────────────┐   │
-                                   │  │  JS Bridge (injected)│   │
-                                   │  │  window.__PILOT__    │   │
-                                   │  └─────────────────────┘   │
-                                   │  WebView                    │
-                                   └─────────────────────────────┘
+┌──────────────┐   Unix Socket /     ┌─────────────────────────────┐
+│  tauri-pilot  │   Named Pipe (Win) │  tauri-plugin-pilot (Rust)  │
+│  (CLI)        │ ◄─────────────────► │  embedded in your app       │
+└──────────────┘   JSON-RPC           │                             │
+                                     │  ┌─────────────────────┐   │
+                                     │  │  JS Bridge (injected)│   │
+                                     │  │  window.__PILOT__    │   │
+                                     │  └─────────────────────┘   │
+                                     │  WebView                    │
+                                     └─────────────────────────────┘
 ```
 
-1. **Plugin** embeds in your Tauri app (debug builds only), starts a Unix socket server
+1. **Plugin** embeds in your Tauri app (debug builds only), starts a Unix socket / Named Pipe server
 2. **CLI** connects to the socket, sends JSON-RPC commands
 3. **JS Bridge** injected into the WebView handles DOM inspection and interaction
 
@@ -222,7 +222,7 @@ window:
 
 ## Requirements
 
-- **Linux** (WebKitGTK) or **macOS** (WebKit) — Windows planned
+- **Linux** (WebKitGTK), **macOS** (WebKit), or **Windows** (WebView2)
 - **Tauri v2** (v1 not supported)
 - **Rust 1.95.0+** (edition 2024)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There's no tool for AI agents to interact with Tauri app UIs. Playwright doesn't
 
 ## How it works
 
-```
+```text
 ┌──────────────┐   Unix Socket /     ┌─────────────────────────────┐
 │  tauri-pilot  │   Named Pipe (Win) │  tauri-plugin-pilot (Rust)  │
 │  (CLI)        │ ◄─────────────────► │  embedded in your app       │

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -30,10 +30,15 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22.1"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 indicatif = "0.17"
-libc = "0.2.184"
 rmcp = { version = "1.4.0", default-features = false, features = ["server", "transport-io"] }
 toml = "0.8"
 quick-xml = "0.36"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.184"
+
+[target.'cfg(windows)'.dependencies]
+windows = "0.52"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -38,7 +38,10 @@ quick-xml = "0.36"
 libc = "0.2.184"
 
 [target.'cfg(windows)'.dependencies]
-windows = "0.52"
+windows = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -59,7 +59,7 @@ impl Client {
 
         let response: Response = serde_json::from_str(line.trim())?;
 
-        if response.id != id {
+        if response.id != serde_json::Value::Number(id.into()) {
             bail!("Response ID mismatch: expected {id}, got {}", response.id);
         }
 
@@ -103,7 +103,7 @@ mod tests {
                 let resp = if req.method == "ping" {
                     Response::success(req.id, serde_json::json!({"status": "ok"}))
                 } else {
-                    Response::error(req.id, -32601, "Method not found")
+                    Response::error(serde_json::Value::Number(req.id.into()), -32601, "Method not found")
                 };
                 let mut bytes = serde_json::to_vec(&resp).unwrap();
                 bytes.push(b'\n');

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -90,7 +90,7 @@ mod tests {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::UnixListener;
 
-    async fn mock_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
+    fn mock_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let _ = std::fs::remove_file(path);
         let listener = UnixListener::bind(path).unwrap();
         tokio::spawn(async move {
@@ -130,7 +130,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_ping_returns_ok() {
         let socket = PathBuf::from("/tmp/tauri-pilot-test-t05a.sock");
-        let handle = mock_server(&socket).await;
+        let handle = mock_server(&socket);
 
         let mut client = connect_with_retry(&socket).await;
         let result = client.call("ping", None).await.unwrap();
@@ -207,7 +207,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_unknown_method_returns_error() {
         let socket = PathBuf::from("/tmp/tauri-pilot-test-t05b.sock");
-        let handle = mock_server(&socket).await;
+        let handle = mock_server(&socket);
 
         let mut client = connect_with_retry(&socket).await;
         let result = client.call("nonexistent", None).await;

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -82,6 +82,7 @@ pub mod unix;
 pub mod windows;
 
 #[cfg(all(test, unix))]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -1,31 +1,33 @@
 use crate::protocol::{Request, Response};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use std::path::Path;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
-use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 
-/// JSON-RPC client over a Unix socket.
+/// JSON-RPC client over a platform-specific transport (Unix socket or Named Pipe).
 pub(crate) struct Client {
-    reader: BufReader<OwnedReadHalf>,
-    writer: OwnedWriteHalf,
+    #[cfg(unix)]
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    #[cfg(unix)]
+    writer: tokio::net::unix::OwnedWriteHalf,
+    #[cfg(windows)]
+    reader: BufReader<tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>>,
+    #[cfg(windows)]
+    writer: tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>,
     next_id: u64,
 }
 
 impl Client {
-    /// Connect to the tauri-pilot socket.
+    /// Connect to the tauri-pilot transport.
     pub async fn connect(path: &Path) -> Result<Self> {
-        let stream = UnixStream::connect(path)
-            .await
-            .with_context(|| format!("Cannot connect to socket: {}", path.display()))?;
-
-        let (reader, writer) = stream.into_split();
-        Ok(Self {
-            reader: BufReader::new(reader),
-            writer,
-            next_id: 1,
-        })
+        #[cfg(unix)]
+        {
+            unix::connect(path).await
+        }
+        #[cfg(windows)]
+        {
+            windows::connect(path).await
+        }
     }
 
     /// Send a JSON-RPC request and return the result value.
@@ -74,7 +76,12 @@ impl Client {
     }
 }
 
-#[cfg(test)]
+#[cfg(unix)]
+pub mod unix;
+#[cfg(windows)]
+pub mod windows;
+
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -86,9 +86,25 @@ pub mod windows;
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::UnixListener;
+
+    static TEST_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Build a unique socket path per test invocation so parallel `cargo test`
+    /// runs (same process, different tests) don't clobber each other's sockets
+    /// or leak a previous test's bind into the next one.
+    fn unique_socket_path(tag: &str) -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(format!(
+            "/tmp/tauri-pilot-test-{}-{}-{}.sock",
+            tag,
+            std::process::id(),
+            n
+        ))
+    }
 
     fn mock_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
         let _ = std::fs::remove_file(path);
@@ -103,7 +119,11 @@ mod tests {
                 let resp = if req.method == "ping" {
                     Response::success(req.id, serde_json::json!({"status": "ok"}))
                 } else {
-                    Response::error(serde_json::Value::Number(req.id.into()), -32601, "Method not found")
+                    Response::error(
+                        serde_json::Value::Number(req.id.into()),
+                        -32601,
+                        "Method not found",
+                    )
                 };
                 let mut bytes = serde_json::to_vec(&resp).unwrap();
                 bytes.push(b'\n');
@@ -129,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_ping_returns_ok() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05a.sock");
+        let socket = unique_socket_path("t05a");
         let handle = mock_server(&socket);
 
         let mut client = connect_with_retry(&socket).await;
@@ -146,7 +166,7 @@ mod tests {
         // success with Value::Null — not a protocol error. This happens when an
         // eval'd JS expression legitimately returns `undefined` (e.g.,
         // `element.click()`, void functions). Regression test for #48.
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05c.sock");
+        let socket = unique_socket_path("t05c");
         let _ = std::fs::remove_file(&socket);
         let listener = UnixListener::bind(&socket).unwrap();
         let handle = tokio::spawn(async move {
@@ -179,7 +199,7 @@ mod tests {
         // `"result": null`); this test pins down the companion shape where
         // the field is omitted entirely. Both end up as `Value::Null` via
         // `unwrap_or`.
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05d.sock");
+        let socket = unique_socket_path("t05d");
         let _ = std::fs::remove_file(&socket);
         let listener = UnixListener::bind(&socket).unwrap();
         let handle = tokio::spawn(async move {
@@ -206,7 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_unknown_method_returns_error() {
-        let socket = PathBuf::from("/tmp/tauri-pilot-test-t05b.sock");
+        let socket = unique_socket_path("t05b");
         let handle = mock_server(&socket);
 
         let mut client = connect_with_retry(&socket).await;

--- a/crates/tauri-pilot-cli/src/client/unix.rs
+++ b/crates/tauri-pilot-cli/src/client/unix.rs
@@ -1,0 +1,17 @@
+use super::Client;
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::io::BufReader;
+use tokio::net::UnixStream;
+
+pub async fn connect(path: &Path) -> Result<Client> {
+    let stream = UnixStream::connect(path)
+        .await
+        .with_context(|| format!("Cannot connect to socket: {}", path.display()))?;
+    let (reader, writer) = stream.into_split();
+    Ok(Client {
+        reader: BufReader::new(reader),
+        writer,
+        next_id: 1,
+    })
+}

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -1,0 +1,149 @@
+use super::Client;
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::io::BufReader;
+use tokio::net::windows::named_pipe::ClientOptions;
+
+pub async fn connect(path: &Path) -> Result<Client> {
+    let client = ClientOptions::new()
+        .open(path)
+        .with_context(|| format!("Cannot connect to named pipe: {}", path.display()))?;
+    let (reader, writer) = tokio::io::split(client);
+    Ok(Client {
+        reader: BufReader::new(reader),
+        writer,
+        next_id: 1,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{Request, Response};
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    async fn mock_server(path: &str) -> tokio::task::JoinHandle<()> {
+        let server = ServerOptions::new()
+            .create(path)
+            .expect("create named pipe server");
+        tokio::spawn(async move {
+            server.connect().await.expect("server accept");
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            while reader.read_line(&mut line).await.unwrap() > 0 {
+                let req: Request = serde_json::from_str(line.trim()).unwrap();
+                let resp = if req.method == "ping" {
+                    Response::success(req.id, serde_json::json!({"status": "ok"}))
+                } else {
+                    Response::error(req.id, -32601, "Method not found")
+                };
+                let mut bytes = serde_json::to_vec(&resp).unwrap();
+                bytes.push(b'\n');
+                writer.write_all(&bytes).await.unwrap();
+                writer.flush().await.unwrap();
+                line.clear();
+            }
+        })
+    }
+
+    async fn connect_with_retry(path: &Path) -> Client {
+        for _ in 0..20 {
+            match Client::connect(path).await {
+                Ok(c) => return c,
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+        Client::connect(path)
+            .await
+            .expect("Failed to connect after retries")
+    }
+
+    #[tokio::test]
+    async fn test_client_ping_returns_ok() {
+        let pipe = r"\\.\pipe\tauri-pilot-test-t05a";
+        let handle = mock_server(pipe).await;
+
+        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let result = client.call("ping", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({"status": "ok"}));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_client_null_result_is_success() {
+        let pipe = r"\\.\pipe\tauri-pilot-test-t05c";
+        let server = ServerOptions::new()
+            .create(pipe)
+            .expect("create named pipe server");
+        let handle = tokio::spawn(async move {
+            server.connect().await.expect("server accept");
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let req: Request = serde_json::from_str(line.trim()).unwrap();
+            let raw = format!(r#"{{"jsonrpc":"2.0","id":{},"result":null}}"#, req.id);
+            writer.write_all(raw.as_bytes()).await.unwrap();
+            writer.write_all(b"\n").await.unwrap();
+            writer.flush().await.unwrap();
+        });
+
+        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let result = client.call("eval", None).await.unwrap();
+        assert_eq!(result, serde_json::Value::Null);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_client_missing_result_is_success() {
+        let pipe = r"\\.\pipe\tauri-pilot-test-t05d";
+        let server = ServerOptions::new()
+            .create(pipe)
+            .expect("create named pipe server");
+        let handle = tokio::spawn(async move {
+            server.connect().await.expect("server accept");
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let req: Request = serde_json::from_str(line.trim()).unwrap();
+            let raw = format!(r#"{{"jsonrpc":"2.0","id":{}}}"#, req.id);
+            writer.write_all(raw.as_bytes()).await.unwrap();
+            writer.write_all(b"\n").await.unwrap();
+            writer.flush().await.unwrap();
+        });
+
+        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let result = client.call("eval", None).await.unwrap();
+        assert_eq!(result, serde_json::Value::Null);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_client_unknown_method_returns_error() {
+        let pipe = r"\\.\pipe\tauri-pilot-test-t05b";
+        let handle = mock_server(pipe).await;
+
+        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let result = client.call("nonexistent", None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("-32601"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_client_connect_failure() {
+        let err = Client::connect(Path::new(r"\\.\pipe\tauri-pilot-nonexistent"))
+            .await
+            .map(|_| ())
+            .expect_err("should fail to connect");
+        assert!(err.to_string().contains("Cannot connect"));
+    }
+}

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -47,7 +47,11 @@ mod tests {
                 let resp = if req.method == "ping" {
                     Response::success(req.id, serde_json::json!({"status": "ok"}))
                 } else {
-                    Response::error(serde_json::Value::Number(req.id.into()), -32601, "Method not found")
+                    Response::error(
+                        serde_json::Value::Number(req.id.into()),
+                        -32601,
+                        "Method not found",
+                    )
                 };
                 let mut bytes = serde_json::to_vec(&resp).unwrap();
                 bytes.push(b'\n');

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -25,7 +25,7 @@ mod tests {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::windows::named_pipe::ServerOptions;
 
-    async fn mock_server(path: &str) -> tokio::task::JoinHandle<()> {
+    fn mock_server(path: &str) -> tokio::task::JoinHandle<()> {
         let server = ServerOptions::new()
             .create(path)
             .expect("create named pipe server");
@@ -65,7 +65,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_ping_returns_ok() {
         let pipe = r"\\.\pipe\tauri-pilot-test-t05a";
-        let handle = mock_server(pipe).await;
+        let handle = mock_server(pipe);
 
         let mut client = connect_with_retry(Path::new(pipe)).await;
         let result = client.call("ping", None).await.unwrap();
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_unknown_method_returns_error() {
         let pipe = r"\\.\pipe\tauri-pilot-test-t05b";
-        let handle = mock_server(pipe).await;
+        let handle = mock_server(pipe);
 
         let mut client = connect_with_retry(Path::new(pipe)).await;
         let result = client.call("nonexistent", None).await;

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -39,7 +39,7 @@ mod tests {
                 let resp = if req.method == "ping" {
                     Response::success(req.id, serde_json::json!({"status": "ok"}))
                 } else {
-                    Response::error(req.id, -32601, "Method not found")
+                    Response::error(serde_json::Value::Number(req.id.into()), -32601, "Method not found")
                 };
                 let mut bytes = serde_json::to_vec(&resp).unwrap();
                 bytes.push(b'\n');

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use tokio::io::BufReader;
 use tokio::net::windows::named_pipe::ClientOptions;
 
-#[allow(unused_async)]
+#[allow(clippy::unused_async)]
 pub async fn connect(path: &Path) -> Result<Client> {
     let client = ClientOptions::new()
         .open(path)

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -21,9 +21,17 @@ pub async fn connect(path: &Path) -> Result<Client> {
 mod tests {
     use super::*;
     use crate::protocol::{Request, Response};
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::windows::named_pipe::ServerOptions;
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_pipe_path() -> String {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!(r"\\.\pipe\tauri-pilot-test-{}-{}", std::process::id(), n)
+    }
 
     fn mock_server(path: &str) -> tokio::task::JoinHandle<()> {
         let server = ServerOptions::new()
@@ -64,10 +72,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_ping_returns_ok() {
-        let pipe = r"\\.\pipe\tauri-pilot-test-t05a";
-        let handle = mock_server(pipe);
+        let pipe = unique_pipe_path();
+        let handle = mock_server(&pipe);
 
-        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let mut client = connect_with_retry(Path::new(&pipe)).await;
         let result = client.call("ping", None).await.unwrap();
         assert_eq!(result, serde_json::json!({"status": "ok"}));
 
@@ -76,9 +84,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_null_result_is_success() {
-        let pipe = r"\\.\pipe\tauri-pilot-test-t05c";
+        let pipe = unique_pipe_path();
         let server = ServerOptions::new()
-            .create(pipe)
+            .create(&pipe)
             .expect("create named pipe server");
         let handle = tokio::spawn(async move {
             server.connect().await.expect("server accept");
@@ -93,7 +101,7 @@ mod tests {
             writer.flush().await.unwrap();
         });
 
-        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let mut client = connect_with_retry(Path::new(&pipe)).await;
         let result = client.call("eval", None).await.unwrap();
         assert_eq!(result, serde_json::Value::Null);
 
@@ -102,9 +110,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_missing_result_is_success() {
-        let pipe = r"\\.\pipe\tauri-pilot-test-t05d";
+        let pipe = unique_pipe_path();
         let server = ServerOptions::new()
-            .create(pipe)
+            .create(&pipe)
             .expect("create named pipe server");
         let handle = tokio::spawn(async move {
             server.connect().await.expect("server accept");
@@ -119,7 +127,7 @@ mod tests {
             writer.flush().await.unwrap();
         });
 
-        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let mut client = connect_with_retry(Path::new(&pipe)).await;
         let result = client.call("eval", None).await.unwrap();
         assert_eq!(result, serde_json::Value::Null);
 
@@ -128,10 +136,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_unknown_method_returns_error() {
-        let pipe = r"\\.\pipe\tauri-pilot-test-t05b";
-        let handle = mock_server(pipe);
+        let pipe = unique_pipe_path();
+        let handle = mock_server(&pipe);
 
-        let mut client = connect_with_retry(Path::new(pipe)).await;
+        let mut client = connect_with_retry(Path::new(&pipe)).await;
         let result = client.call("nonexistent", None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("-32601"));

--- a/crates/tauri-pilot-cli/src/client/windows.rs
+++ b/crates/tauri-pilot-cli/src/client/windows.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use tokio::io::BufReader;
 use tokio::net::windows::named_pipe::ClientOptions;
 
+#[allow(unused_async)]
 pub async fn connect(path: &Path) -> Result<Client> {
     let client = ClientOptions::new()
         .open(path)

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1351,7 +1351,11 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
                                 entry.get("created_at").and_then(|v| v.as_u64())
                             {
                                 if let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str()) {
-                                    if newest.is_none() || created_at > newest.as_ref().unwrap().0 {
+                                    let should_update = match newest {
+                                        None => true,
+                                        Some((current_max, _)) => created_at > *current_max,
+                                    };
+                                    if should_update {
                                         newest = Some((created_at, PathBuf::from(pipe)));
                                     }
                                 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -13,7 +13,9 @@ use base64::Engine;
 use clap::Parser;
 use serde_json::{Value, json};
 use std::io::IsTerminal;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use cli::{
@@ -1353,7 +1355,7 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
                                 if let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str()) {
                                     let should_update = match newest {
                                         None => true,
-                                        Some((current_max, _)) => created_at > *current_max,
+                                        Some((current_max, _)) => created_at > current_max,
                                     };
                                     if should_update {
                                         newest = Some((created_at, PathBuf::from(pipe)));

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1335,38 +1335,93 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
 
     #[cfg(windows)]
     {
-        let reg_path = std::env::var_os("LOCALAPPDATA")
-            .map(PathBuf::from)
-            .map(|p| p.join("tauri-pilot").join("instances.json"));
-
-        if let Some(path) = reg_path
-            && let Ok(data) = std::fs::read_to_string(&path)
-            && let Ok(reg) = serde_json::from_str::<serde_json::Value>(&data)
-            && let Some(instances) = reg.get("instances").and_then(|v| v.as_object())
-        {
-            let mut newest: Option<(u64, PathBuf)> = None;
-            for (_, entry) in instances {
-                if let Some(created_at) =
-                    entry.get("created_at").and_then(serde_json::Value::as_u64)
-                    && let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str())
-                {
-                    let should_update = match newest {
-                        None => true,
-                        Some((current_max, _)) => created_at > current_max,
-                    };
-                    if should_update {
-                        newest = Some((created_at, PathBuf::from(pipe)));
-                    }
-                }
-            }
-            if let Some((_, pipe)) = newest {
-                return Ok(pipe);
-            }
-        }
-        Err(anyhow::anyhow!(
-            "No tauri-pilot pipe found. Is a Tauri app running?"
-        ))
+        return resolve_socket_windows();
     }
+}
+
+#[cfg(windows)]
+fn resolve_socket_windows() -> Result<PathBuf> {
+    use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    fn is_pid_alive(pid: u32) -> bool {
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) };
+        match handle {
+            Ok(h) => {
+                let alive = unsafe {
+                    let mut exit_code: u32 = 0;
+                    GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
+                };
+                unsafe { CloseHandle(h) };
+                alive
+            }
+            Err(_) => false,
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct InstanceEntry {
+        pid: u32,
+        pipe: String,
+        created_at: u64,
+    }
+
+    let local_app_data =
+        std::env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "LOCALAPPDATA environment variable is not set or empty. \
+                 Is a Tauri app running?"
+            )
+        })?;
+
+    let instances_dir = PathBuf::from(local_app_data)
+        .join("tauri-pilot")
+        .join("instances");
+
+    if !instances_dir.exists() {
+        anyhow::bail!(
+            "No tauri-pilot instances directory found at {}. \
+             Is a Tauri app running?",
+            instances_dir.display()
+        );
+    }
+
+    let mut newest: Option<(u64, PathBuf)> = None;
+    for entry in std::fs::read_dir(&instances_dir)?.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping corrupted instance file");
+                continue;
+            }
+        };
+        let info: InstanceEntry = match serde_json::from_str(&content) {
+            Ok(i) => i,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping malformed instance file");
+                continue;
+            }
+        };
+        if !is_pid_alive(info.pid) {
+            tracing::debug!(pid = info.pid, path = %path.display(), "skipping stale instance");
+            continue;
+        }
+        let should_update = match newest {
+            None => true,
+            Some((current_max, _)) => info.created_at > current_max,
+        };
+        if should_update {
+            newest = Some((info.created_at, PathBuf::from(info.pipe)));
+        }
+    }
+
+    newest
+        .map(|(_, pipe)| pipe)
+        .ok_or_else(|| anyhow::anyhow!("No active tauri-pilot instance found. Is a Tauri app running?"))
 }
 
 #[cfg(not(windows))]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1350,7 +1350,7 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
                         let mut newest: Option<(u64, PathBuf)> = None;
                         for (_, entry) in instances {
                             if let Some(created_at) =
-                                entry.get("created_at").and_then(|v| v.as_u64())
+                                entry.get("created_at").and_then(serde_json::Value::as_u64)
                             {
                                 if let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str()) {
                                     let should_update = match newest {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1335,7 +1335,7 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
 
     #[cfg(windows)]
     {
-        return resolve_socket_windows();
+        resolve_socket_windows()
     }
 }
 
@@ -1352,7 +1352,7 @@ fn resolve_socket_windows() -> Result<PathBuf> {
             Ok(h) => {
                 let alive = unsafe {
                     let mut exit_code: u32 = 0;
-                    GetExitCodeProcess(h, &mut exit_code).is_ok()
+                    GetExitCodeProcess(h, &raw mut exit_code).is_ok()
                         && exit_code == STILL_ACTIVE.0 as u32
                 };
                 unsafe {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1342,7 +1342,9 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
 #[cfg(windows)]
 fn resolve_socket_windows() -> Result<PathBuf> {
     use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
-    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    use windows::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
 
     fn is_pid_alive(pid: u32) -> bool {
         let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) };
@@ -1366,8 +1368,9 @@ fn resolve_socket_windows() -> Result<PathBuf> {
         created_at: u64,
     }
 
-    let local_app_data =
-        std::env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()).ok_or_else(|| {
+    let local_app_data = std::env::var_os("LOCALAPPDATA")
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
             anyhow::anyhow!(
                 "LOCALAPPDATA environment variable is not set or empty. \
                  Is a Tauri app running?"
@@ -1419,9 +1422,9 @@ fn resolve_socket_windows() -> Result<PathBuf> {
         }
     }
 
-    newest
-        .map(|(_, pipe)| pipe)
-        .ok_or_else(|| anyhow::anyhow!("No active tauri-pilot instance found. Is a Tauri app running?"))
+    newest.map(|(_, pipe)| pipe).ok_or_else(|| {
+        anyhow::anyhow!("No active tauri-pilot instance found. Is a Tauri app running?")
+    })
 }
 
 #[cfg(not(windows))]
@@ -1633,12 +1636,14 @@ mod tests {
         std::fs::create_dir_all(&instances_dir).expect("create reg test dir");
 
         let pipe = r"\\.\pipe\tauri-pilot-testapp";
+        // Use the current process id so the liveness check in
+        // `resolve_socket_windows` doesn't skip this mock entry as stale.
         std::fs::write(
             instances_dir.join("testapp.json"),
             serde_json::to_string_pretty(&serde_json::json!({
-                "pid": 1234,
+                "pid": std::process::id(),
                 "pipe": pipe,
-                "created_at": 1745200000
+                "created_at": 1745200000u64
             }))
             .unwrap(),
         )
@@ -1672,20 +1677,30 @@ mod tests {
         let instances_dir = dir.join("tauri-pilot").join("instances");
         std::fs::create_dir_all(&instances_dir).expect("create reg test dir");
 
+        // Both entries must use live PIDs — otherwise the liveness filter in
+        // `resolve_socket_windows` would skip them as stale and the test
+        // would flake. Using the current process id keeps both "alive".
+        let live_pid = std::process::id();
         let old_entry = serde_json::json!({
-            "pid": 1111,
+            "pid": live_pid,
             "pipe": r"\\.\pipe\tauri-pilot-old",
             "created_at": 1000
         });
         let new_entry = serde_json::json!({
-            "pid": 2222,
+            "pid": live_pid,
             "pipe": r"\\.\pipe\tauri-pilot-new",
             "created_at": 2000
         });
-        std::fs::write(instances_dir.join("old_app.json"), serde_json::to_string(&old_entry).unwrap())
-            .expect("write mock old instance");
-        std::fs::write(instances_dir.join("new_app.json"), serde_json::to_string(&new_entry).unwrap())
-            .expect("write mock new instance");
+        std::fs::write(
+            instances_dir.join("old_app.json"),
+            serde_json::to_string(&old_entry).unwrap(),
+        )
+        .expect("write mock old instance");
+        std::fs::write(
+            instances_dir.join("new_app.json"),
+            serde_json::to_string(&new_entry).unwrap(),
+        )
+        .expect("write mock new instance");
 
         unsafe { std::env::set_var("LOCALAPPDATA", &dir) };
         let result = resolve_socket(None);

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1573,9 +1573,10 @@ mod tests {
     #[cfg(windows)]
     fn test_resolve_socket_windows_reads_registry() {
         let dir = std::env::temp_dir().join(format!("tauri-pilot-reg-test-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create reg test dir");
+        let tauri_dir = dir.join("tauri-pilot");
+        std::fs::create_dir_all(&tauri_dir).expect("create reg test dir");
 
-        let reg_path = dir.join("instances.json");
+        let reg_path = tauri_dir.join("instances.json");
         let pipe = r"\\.\pipe\tauri-pilot-testapp";
         let reg_data = serde_json::json!({
             "instances": {
@@ -1593,8 +1594,7 @@ mod tests {
         let result = resolve_socket(None);
         unsafe { std::env::remove_var("LOCALAPPDATA") };
 
-        let _ = std::fs::remove_file(&reg_path);
-        let _ = std::fs::remove_dir(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
 
         assert_eq!(result.expect("pipe found"), std::path::PathBuf::from(pipe));
     }
@@ -1614,9 +1614,10 @@ mod tests {
             "tauri-pilot-reg-newest-test-{}",
             std::process::id()
         ));
-        std::fs::create_dir_all(&dir).expect("create reg test dir");
+        let tauri_dir = dir.join("tauri-pilot");
+        std::fs::create_dir_all(&tauri_dir).expect("create reg test dir");
 
-        let reg_path = dir.join("instances.json");
+        let reg_path = tauri_dir.join("instances.json");
         let reg_data = serde_json::json!({
             "instances": {
                 "old_app": {
@@ -1638,8 +1639,7 @@ mod tests {
         let result = resolve_socket(None);
         unsafe { std::env::remove_var("LOCALAPPDATA") };
 
-        let _ = std::fs::remove_file(&reg_path);
-        let _ = std::fs::remove_dir(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
 
         assert_eq!(
             result.expect("pipe found"),

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1339,31 +1339,28 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
             .map(PathBuf::from)
             .map(|p| p.join("tauri-pilot").join("instances.json"));
 
-        if let Some(path) = reg_path {
-            if let Ok(data) = std::fs::read_to_string(&path) {
-                if let Ok(reg) = serde_json::from_str::<serde_json::Value>(&data) {
-                    if let Some(instances) = reg.get("instances").and_then(|v| v.as_object()) {
-                        let mut newest: Option<(u64, PathBuf)> = None;
-                        for (_, entry) in instances {
-                            if let Some(created_at) =
-                                entry.get("created_at").and_then(serde_json::Value::as_u64)
-                            {
-                                if let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str()) {
-                                    let should_update = match newest {
-                                        None => true,
-                                        Some((current_max, _)) => created_at > current_max,
-                                    };
-                                    if should_update {
-                                        newest = Some((created_at, PathBuf::from(pipe)));
-                                    }
-                                }
-                            }
-                        }
-                        if let Some((_, pipe)) = newest {
-                            return Ok(pipe);
-                        }
+        if let Some(path) = reg_path
+            && let Ok(data) = std::fs::read_to_string(&path)
+            && let Ok(reg) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(instances) = reg.get("instances").and_then(|v| v.as_object())
+        {
+            let mut newest: Option<(u64, PathBuf)> = None;
+            for (_, entry) in instances {
+                if let Some(created_at) =
+                    entry.get("created_at").and_then(serde_json::Value::as_u64)
+                    && let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str())
+                {
+                    let should_update = match newest {
+                        None => true,
+                        Some((current_max, _)) => created_at > current_max,
+                    };
+                    if should_update {
+                        newest = Some((created_at, PathBuf::from(pipe)));
                     }
                 }
+            }
+            if let Some((_, pipe)) = newest {
+                return Ok(pipe);
             }
         }
         Err(anyhow::anyhow!(

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1352,7 +1352,8 @@ fn resolve_socket_windows() -> Result<PathBuf> {
             Ok(h) => {
                 let alive = unsafe {
                     let mut exit_code: u32 = 0;
-                    GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
+                    GetExitCodeProcess(h, &mut exit_code).is_ok()
+                        && exit_code == STILL_ACTIVE.0 as u32
                 };
                 unsafe {
                     let _ = CloseHandle(h);

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1559,7 +1559,10 @@ mod tests {
             .and_then(|n| n.to_str())
             .expect("socket has a filename");
         assert!(
-            name.starts_with("tauri-pilot-") && name.ends_with(".sock"),
+            name.starts_with("tauri-pilot-")
+                && std::path::Path::new(name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("sock")),
             "expected a tauri-pilot-*.sock path, got: {found:?}"
         );
     }
@@ -1650,12 +1653,14 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_read_script_valid() {
         let mut reader = std::io::Cursor::new(b"document.title");
         assert_eq!(read_script(&mut reader).unwrap(), "document.title");
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_read_script_empty_errors() {
         let mut reader = std::io::Cursor::new(b"");
         let err = read_script(&mut reader).unwrap_err();
@@ -1663,6 +1668,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_read_script_blank_errors() {
         let mut reader = std::io::Cursor::new(b"   \n  ");
         let err = read_script(&mut reader).unwrap_err();

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1322,17 +1322,55 @@ pub(crate) fn resolve_socket(explicit: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
-        let xdg = PathBuf::from(xdg);
-        if let Some(socket) = newest_socket_in_dir(&xdg) {
-            return Ok(socket);
+    #[cfg(unix)]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR").filter(|v| !v.is_empty()) {
+            let xdg = PathBuf::from(xdg);
+            if let Some(socket) = newest_socket_in_dir(&xdg) {
+                return Ok(socket);
+            }
         }
+
+        newest_socket_in_dir(Path::new("/tmp"))
+            .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
     }
 
-    newest_socket_in_dir(Path::new("/tmp"))
-        .ok_or_else(|| anyhow::anyhow!("No tauri-pilot socket found. Is a Tauri app running?"))
+    #[cfg(windows)]
+    {
+        let reg_path = std::env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .map(|p| p.join("tauri-pilot").join("instances.json"));
+
+        if let Some(path) = reg_path {
+            if let Ok(data) = std::fs::read_to_string(&path) {
+                if let Ok(reg) = serde_json::from_str::<serde_json::Value>(&data) {
+                    if let Some(instances) = reg.get("instances").and_then(|v| v.as_object()) {
+                        let mut newest: Option<(u64, PathBuf)> = None;
+                        for (_, entry) in instances {
+                            if let Some(created_at) =
+                                entry.get("created_at").and_then(|v| v.as_u64())
+                            {
+                                if let Some(pipe) = entry.get("pipe").and_then(|v| v.as_str()) {
+                                    if newest.is_none() || created_at > newest.as_ref().unwrap().0 {
+                                        newest = Some((created_at, PathBuf::from(pipe)));
+                                    }
+                                }
+                            }
+                        }
+                        if let Some((_, pipe)) = newest {
+                            return Ok(pipe);
+                        }
+                    }
+                }
+            }
+        }
+        Err(anyhow::anyhow!(
+            "No tauri-pilot pipe found. Is a Tauri app running?"
+        ))
+    }
 }
 
+#[cfg(not(windows))]
 fn newest_socket_in_dir(dir: &Path) -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = std::fs::read_dir(dir)
         .ok()?
@@ -1441,6 +1479,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     #[serial]
     fn test_resolve_socket_finds_socket_in_xdg_runtime_dir() {
         let dir =
@@ -1462,6 +1501,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     #[serial]
     fn test_resolve_socket_prefers_xdg_runtime_dir_over_tmp() {
         let dir = std::env::temp_dir().join(format!(
@@ -1491,6 +1531,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     #[serial]
     fn test_resolve_socket_falls_back_to_tmp_when_xdg_unset() {
         let tmp_sock = std::path::PathBuf::from(format!(
@@ -1524,6 +1565,84 @@ mod tests {
         let explicit = std::path::PathBuf::from("/tmp/my-explicit.sock");
         let result = resolve_socket(Some(explicit.clone()));
         assert_eq!(result.expect("explicit path returned"), explicit);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_socket_windows_reads_registry() {
+        let dir = std::env::temp_dir().join(format!("tauri-pilot-reg-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create reg test dir");
+
+        let reg_path = dir.join("instances.json");
+        let pipe = r"\\.\pipe\tauri-pilot-testapp";
+        let reg_data = serde_json::json!({
+            "instances": {
+                "testapp": {
+                    "pipe": pipe,
+                    "pid": 1234,
+                    "created_at": 1745200000
+                }
+            }
+        });
+        std::fs::write(&reg_path, serde_json::to_string(&reg_data).unwrap())
+            .expect("write mock registry");
+
+        unsafe { std::env::set_var("LOCALAPPDATA", &dir) };
+        let result = resolve_socket(None);
+        unsafe { std::env::remove_var("LOCALAPPDATA") };
+
+        let _ = std::fs::remove_file(&reg_path);
+        let _ = std::fs::remove_dir(&dir);
+
+        assert_eq!(result.expect("pipe found"), std::path::PathBuf::from(pipe));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_socket_windows_returns_explicit() {
+        let explicit = std::path::PathBuf::from(r"\\.\pipe\my-explicit");
+        let result = resolve_socket(Some(explicit.clone()));
+        assert_eq!(result.expect("explicit path returned"), explicit);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_resolve_socket_windows_picks_newest_instance() {
+        let dir = std::env::temp_dir().join(format!(
+            "tauri-pilot-reg-newest-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create reg test dir");
+
+        let reg_path = dir.join("instances.json");
+        let reg_data = serde_json::json!({
+            "instances": {
+                "old_app": {
+                    "pipe": r"\\.\pipe\tauri-pilot-old",
+                    "pid": 1111,
+                    "created_at": 1000
+                },
+                "new_app": {
+                    "pipe": r"\\.\pipe\tauri-pilot-new",
+                    "pid": 2222,
+                    "created_at": 2000
+                }
+            }
+        });
+        std::fs::write(&reg_path, serde_json::to_string(&reg_data).unwrap())
+            .expect("write mock registry");
+
+        unsafe { std::env::set_var("LOCALAPPDATA", &dir) };
+        let result = resolve_socket(None);
+        unsafe { std::env::remove_var("LOCALAPPDATA") };
+
+        let _ = std::fs::remove_file(&reg_path);
+        let _ = std::fs::remove_dir(&dir);
+
+        assert_eq!(
+            result.expect("pipe found"),
+            std::path::PathBuf::from(r"\\.\pipe\tauri-pilot-new")
+        );
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1626,24 +1626,23 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
+    #[serial]
     fn test_resolve_socket_windows_reads_registry() {
         let dir = std::env::temp_dir().join(format!("tauri-pilot-reg-test-{}", std::process::id()));
-        let tauri_dir = dir.join("tauri-pilot");
-        std::fs::create_dir_all(&tauri_dir).expect("create reg test dir");
+        let instances_dir = dir.join("tauri-pilot").join("instances");
+        std::fs::create_dir_all(&instances_dir).expect("create reg test dir");
 
-        let reg_path = tauri_dir.join("instances.json");
         let pipe = r"\\.\pipe\tauri-pilot-testapp";
-        let reg_data = serde_json::json!({
-            "instances": {
-                "testapp": {
-                    "pipe": pipe,
-                    "pid": 1234,
-                    "created_at": 1745200000
-                }
-            }
-        });
-        std::fs::write(&reg_path, serde_json::to_string(&reg_data).unwrap())
-            .expect("write mock registry");
+        std::fs::write(
+            instances_dir.join("testapp.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "pid": 1234,
+                "pipe": pipe,
+                "created_at": 1745200000
+            }))
+            .unwrap(),
+        )
+        .expect("write mock registry file");
 
         unsafe { std::env::set_var("LOCALAPPDATA", &dir) };
         let result = resolve_socket(None);
@@ -1664,31 +1663,29 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
+    #[serial]
     fn test_resolve_socket_windows_picks_newest_instance() {
         let dir = std::env::temp_dir().join(format!(
             "tauri-pilot-reg-newest-test-{}",
             std::process::id()
         ));
-        let tauri_dir = dir.join("tauri-pilot");
-        std::fs::create_dir_all(&tauri_dir).expect("create reg test dir");
+        let instances_dir = dir.join("tauri-pilot").join("instances");
+        std::fs::create_dir_all(&instances_dir).expect("create reg test dir");
 
-        let reg_path = tauri_dir.join("instances.json");
-        let reg_data = serde_json::json!({
-            "instances": {
-                "old_app": {
-                    "pipe": r"\\.\pipe\tauri-pilot-old",
-                    "pid": 1111,
-                    "created_at": 1000
-                },
-                "new_app": {
-                    "pipe": r"\\.\pipe\tauri-pilot-new",
-                    "pid": 2222,
-                    "created_at": 2000
-                }
-            }
+        let old_entry = serde_json::json!({
+            "pid": 1111,
+            "pipe": r"\\.\pipe\tauri-pilot-old",
+            "created_at": 1000
         });
-        std::fs::write(&reg_path, serde_json::to_string(&reg_data).unwrap())
-            .expect("write mock registry");
+        let new_entry = serde_json::json!({
+            "pid": 2222,
+            "pipe": r"\\.\pipe\tauri-pilot-new",
+            "created_at": 2000
+        });
+        std::fs::write(instances_dir.join("old_app.json"), serde_json::to_string(&old_entry).unwrap())
+            .expect("write mock old instance");
+        std::fs::write(instances_dir.join("new_app.json"), serde_json::to_string(&new_entry).unwrap())
+            .expect("write mock new instance");
 
         unsafe { std::env::set_var("LOCALAPPDATA", &dir) };
         let result = resolve_socket(None);

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1354,7 +1354,9 @@ fn resolve_socket_windows() -> Result<PathBuf> {
                     let mut exit_code: u32 = 0;
                     GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
                 };
-                unsafe { CloseHandle(h) };
+                unsafe {
+                    let _ = CloseHandle(h);
+                }
                 alive
             }
             Err(_) => false,

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -231,10 +231,8 @@ async fn follow_logs(
         if let Some(l) = level {
             params.insert("level".into(), json!(l));
         }
-        if first_poll {
-            if let Some(n) = last {
-                params.insert("last".into(), json!(n));
-            }
+        if first_poll && let Some(n) = last {
+            params.insert("last".into(), json!(n));
             first_poll = false;
         }
         let result = client
@@ -285,10 +283,8 @@ async fn follow_network(
         if failed {
             params.insert("failedOnly".into(), json!(true));
         }
-        if first_poll {
-            if let Some(n) = last {
-                params.insert("last".into(), json!(n));
-            }
+        if first_poll && let Some(n) = last {
+            params.insert("last".into(), json!(n));
             first_poll = false;
         }
         let result = client

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1704,7 +1704,7 @@ mod tests {
         let _ = std::fs::remove_file(&old_socket);
         let _ = std::fs::remove_file(&new_socket);
 
-        let old_server = spawn_click_server(old_socket.clone(), "old", 2);
+        let old_server = spawn_click_server(&old_socket, "old", 2);
 
         // SAFETY: serial attribute serializes tests that touch XDG_RUNTIME_DIR.
         unsafe { std::env::set_var("XDG_RUNTIME_DIR", &dir) };
@@ -1713,7 +1713,7 @@ mod tests {
         let first = call_click(&pilot).await;
         assert_eq!(tool_result_source(&first), Some("old"));
 
-        let new_server = spawn_click_server(new_socket.clone(), "new", 1);
+        let new_server = spawn_click_server(&new_socket, "new", 1);
         let second = call_click(&pilot).await;
         assert_eq!(tool_result_source(&second), Some("old"));
 
@@ -1784,12 +1784,8 @@ mod tests {
             .and_then(Value::as_str)
     }
 
-    fn spawn_click_server(
-        socket: PathBuf,
-        source: &'static str,
-        requests: usize,
-    ) -> JoinHandle<()> {
-        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+    fn spawn_click_server(socket: &Path, source: &'static str, requests: usize) -> JoinHandle<()> {
+        let listener = UnixListener::bind(socket).expect("bind mock socket");
         tokio::spawn(async move {
             for _ in 0..requests {
                 let (stream, _) = listener.accept().await.expect("accept");

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1562,9 +1562,10 @@ mod tests {
     use super::*;
     use crate::protocol::{Request, Response};
     use serial_test::serial;
+    #[cfg(unix)]
+    use tokio::net::UnixListener;
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-        net::UnixListener,
         task::JoinHandle,
     };
 
@@ -1695,6 +1696,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn auto_detected_socket_is_pinned_after_first_connection() {
         let dir =
             std::env::temp_dir().join(format!("tauri-pilot-mcp-pin-test-{}", std::process::id()));
@@ -1726,6 +1728,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn click_tool_sends_json_rpc_request() {
         let socket = std::env::temp_dir().join(format!(
             "tauri-pilot-mcp-click-test-{}.sock",
@@ -1784,6 +1787,7 @@ mod tests {
             .and_then(Value::as_str)
     }
 
+    #[cfg(unix)]
     fn spawn_click_server(socket: &Path, source: &'static str, requests: usize) -> JoinHandle<()> {
         let listener = UnixListener::bind(socket).expect("bind mock socket");
         tokio::spawn(async move {

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -818,6 +818,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_format_json_does_not_panic() {
         format_json(&json!({"status": "ok"})).unwrap();
     }
@@ -886,8 +887,8 @@ mod tests {
     #[test]
     fn test_format_logs_with_entries() {
         let logs = json!([
-            {"id": 1, "timestamp": 3661123_u64, "level": "error", "args": ["fail"], "source": null},
-            {"id": 2, "timestamp": 3661500_u64, "level": "info", "args": ["ok", 42], "source": null},
+            {"id": 1, "timestamp": 3_661_123_u64, "level": "error", "args": ["fail"], "source": null},
+            {"id": 2, "timestamp": 3_661_500_u64, "level": "info", "args": ["ok", 42], "source": null},
         ]);
         let output = format_logs(&logs);
         assert!(output.contains("01:01:01.123"));
@@ -910,8 +911,8 @@ mod tests {
     #[test]
     fn test_format_network_with_entries() {
         let requests = json!([
-            {"id": 1, "timestamp": 3661123_u64, "method": "GET", "url": "/api/users", "status": 200, "duration_ms": 150, "error": null, "request_size": 0, "response_size": 1024},
-            {"id": 2, "timestamp": 3661500_u64, "method": "POST", "url": "/api/login", "status": 500, "duration_ms": 2000, "error": "Internal Server Error", "request_size": 42, "response_size": 128},
+            {"id": 1, "timestamp": 3_661_123_u64, "method": "GET", "url": "/api/users", "status": 200, "duration_ms": 150, "error": null, "request_size": 0, "response_size": 1024},
+            {"id": 2, "timestamp": 3_661_500_u64, "method": "POST", "url": "/api/login", "status": 500, "duration_ms": 2000, "error": "Internal Server Error", "request_size": 42, "response_size": 128},
         ]);
         let output = format_network(&requests);
         assert!(output.contains("01:01:01.123"));

--- a/crates/tauri-pilot-cli/src/protocol.rs
+++ b/crates/tauri-pilot-cli/src/protocol.rs
@@ -26,7 +26,7 @@ pub struct Request {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Response {
     pub jsonrpc: String,
-    pub id: u64,
+    pub id: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,7 +49,7 @@ impl Response {
     pub fn success(id: u64, result: serde_json::Value) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
-            id,
+            id: serde_json::Value::Number(id.into()),
             result: Some(result),
             error: None,
         }
@@ -57,7 +57,7 @@ impl Response {
 
     /// Create an error response.
     #[must_use]
-    pub fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+    pub fn error(id: serde_json::Value, code: i32, message: impl Into<String>) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
             id,
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_serialize_error_response() {
-        let resp = Response::error(1, -32601, "Method not found");
+        let resp = Response::error(serde_json::Value::Number(1.into()), -32601, "Method not found");
         let s = serde_json::to_string(&resp).expect("serialize");
         assert!(s.contains(r#""error""#));
         assert!(!s.contains(r#""result""#));
@@ -130,7 +130,7 @@ mod tests {
         let resp = Response::success(7, json!([1, 2, 3]));
         let serialized = serde_json::to_string(&resp).expect("serialize");
         let deserialized: Response = serde_json::from_str(&serialized).expect("deserialize");
-        assert_eq!(deserialized.id, 7);
+        assert_eq!(deserialized.id, serde_json::json!(7));
         assert_eq!(deserialized.result, Some(json!([1, 2, 3])));
         assert!(deserialized.error.is_none());
     }

--- a/crates/tauri-pilot-cli/src/protocol.rs
+++ b/crates/tauri-pilot-cli/src/protocol.rs
@@ -104,7 +104,11 @@ mod tests {
 
     #[test]
     fn test_serialize_error_response() {
-        let resp = Response::error(serde_json::Value::Number(1.into()), -32601, "Method not found");
+        let resp = Response::error(
+            serde_json::Value::Number(1.into()),
+            -32601,
+            "Method not found",
+        );
         let s = serde_json::to_string(&resp).expect("serialize");
         assert!(s.contains(r#""error""#));
         assert!(!s.contains(r#""result""#));

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -45,7 +45,7 @@ windows = { version = "0.52", features = [
 ] }
 
 [target.'cfg(target_os="linux")'.dependencies]
-enigo = { version = "0.6.1", features = ["wayland"] }
+enigo = { version = "0.6.1", features = ["wayland"], optional = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -43,6 +43,7 @@ windows = { version = "0.52", features = ["Win32_Security", "Win32_System_Thread
 enigo = { version = "0.6.1", features = ["wayland"] }
 
 [dev-dependencies]
+serial_test = "3"
 tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [build-dependencies]

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -40,7 +40,7 @@ libc = "0.2.184"
 windows = { version = "0.52", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
-    "Win32_System_Memory",
+    "Win32_System_Pipes",
     "Win32_System_Threading",
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Tauri v2 plugin for runtime UI testing and automation via Unix socket JSON-RPC"
+description = "Tauri v2 plugin for runtime UI testing and automation via IPC JSON-RPC"
 keywords = ["tauri", "plugin", "testing", "automation", "accessibility"]
 categories = ["development-tools::testing", "gui"]
 readme = "README.md"
@@ -31,10 +31,16 @@ tokio = { workspace = true, features = ["net", "rt", "sync", "time", "io-util"] 
 tracing.workspace = true
 thiserror = "2"
 tauri = { version = "2", features = ["unstable"] }
+enigo = { version = "0.6.1", optional = true }
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2.184"
-# `wayland` enables the libei-based Wayland backend so `press` works on
-# modern Linux sessions, not just X11.
-enigo = { version = "0.6.1", features = ["wayland"], optional = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.52", features = ["Win32_Security", "Win32_System_Threading", "Win32_Foundation"] }
+
+[target.'cfg(target_os="linux")'.dependencies]
+enigo = { version = "0.6.1", features = ["wayland"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -37,7 +37,12 @@ enigo = { version = "0.6.1", optional = true }
 libc = "0.2.184"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.52", features = ["Win32_Security", "Win32_System_Threading", "Win32_Foundation"] }
+windows = { version = "0.52", features = [
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 enigo = { version = "0.6.1", features = ["wayland"] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -39,6 +39,8 @@ libc = "0.2.184"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.52", features = [
     "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Memory",
     "Win32_System_Threading",
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -7,23 +7,23 @@ mod handler;
 pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 pub(crate) mod server;
 
 pub use error::Error;
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use eval::EvalEngine;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use recorder::Recorder;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use server::{EvalFn, FocusFn, ListWindowsFn};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::sync::Arc;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use tauri::Manager;
 
-#[cfg(all(unix, debug_assertions))]
+#[cfg(all(any(unix, windows), debug_assertions))]
 const BRIDGE_JS: &str = concat!(
     include_str!("../js/vendor/html-to-image.iife.js"),
     "\n",
@@ -37,12 +37,12 @@ const BRIDGE_JS: &str = concat!(
 /// and starts a Unix socket server at `$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock` (falls back to `/tmp` if unavailable).
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
-    #[cfg(not(all(unix, debug_assertions)))]
+    #[cfg(not(all(any(unix, windows), debug_assertions)))]
     {
         return tauri::plugin::Builder::new("pilot").build();
     }
 
-    #[cfg(all(unix, debug_assertions))]
+    #[cfg(all(any(unix, windows), debug_assertions))]
     {
         tauri::plugin::Builder::new("pilot")
             .js_init_script(BRIDGE_JS.to_owned())
@@ -83,7 +83,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
 /// Strip path separators and unsafe characters from the app identifier
 /// so it can be safely used in a socket filename.
-#[cfg(all(unix, debug_assertions))]
+#[cfg(all(any(unix, windows), debug_assertions))]
 fn sanitize_identifier(raw: &str) -> String {
     let sanitized: String = raw
         .chars()
@@ -106,7 +106,7 @@ fn sanitize_identifier(raw: &str) -> String {
 ///
 /// If `window` is `Some(label)`, targets that specific window (error if not found).
 /// If `window` is `None`, tries "main" first then falls back to the first available window.
-#[cfg(all(unix, debug_assertions))]
+#[cfg(all(any(unix, windows), debug_assertions))]
 fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
     let handle = app.clone();
     Arc::new(move |window: Option<&str>, script: String| {
@@ -134,7 +134,7 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
 /// the first window. The call is best-effort — failures are returned to the
 /// caller (which logs and continues), since the press still has a chance of
 /// landing on whatever window currently holds focus.
-#[cfg(all(unix, debug_assertions))]
+#[cfg(all(any(unix, windows), debug_assertions))]
 fn make_focus_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> FocusFn {
     let handle = app.clone();
     Arc::new(move |window: Option<&str>| {
@@ -157,7 +157,7 @@ fn make_focus_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> FocusFn {
 }
 
 /// Create a list function that enumerates all available webview windows.
-#[cfg(all(unix, debug_assertions))]
+#[cfg(all(any(unix, windows), debug_assertions))]
 fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
     let handle = app.clone();
     Arc::new(move || {
@@ -179,7 +179,7 @@ fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(unix, debug_assertions))]
+    #[cfg(all(any(unix, windows), debug_assertions))]
     #[test]
     fn bridge_js_contains_html_to_image_and_pilot() {
         let js = super::BRIDGE_JS;
@@ -201,7 +201,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(unix, debug_assertions))]
+    #[cfg(all(any(unix, windows), debug_assertions))]
     #[test]
     fn bridge_click_dispatches_pointer_sequence() {
         let js = super::BRIDGE_JS;

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -32,9 +32,11 @@ const BRIDGE_JS: &str = concat!(
 
 /// Initialize the tauri-pilot plugin.
 ///
-/// On non-Unix platforms or in release builds, returns a no-op plugin.
+/// On non-Unix, non-Windows platforms or in release builds, returns a no-op plugin.
 /// In debug builds on Unix, injects the JS bridge, stores an `EvalEngine`,
 /// and starts a Unix socket server at `$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock` (falls back to `/tmp` if unavailable).
+/// In debug builds on Windows, starts a Named Pipe server at
+/// `\\.\pipe\tauri-pilot-{identifier}` and registers the instance under `%LOCALAPPDATA%\tauri-pilot\instances\`.
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     #[cfg(not(all(any(unix, windows), debug_assertions)))]

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -205,6 +205,7 @@ mod tests {
     #[test]
     fn bridge_click_dispatches_pointer_sequence() {
         let js = super::BRIDGE_JS;
+        let js_normalized: String = js.lines().collect::<Vec<_>>().join("\n");
         let pointer_down_idx = js
             .find(r#"dispatchPointerEvent(el, "pointerdown""#)
             .expect("click must dispatch pointerdown for Radix triggers");
@@ -233,13 +234,15 @@ mod tests {
             "pointer events must include mouse pointer metadata"
         );
         assert!(
-            js.contains(
+            js_normalized.contains(
                 "if (pointerDownOk) {\n      const mouseDownOk = el.dispatchEvent(new MouseEvent(\"mousedown\""
             ),
             "mousedown must only dispatch when pointerdown was not canceled"
         );
         assert!(
-            js.contains("if (pointerDownOk) {\n      el.dispatchEvent(new MouseEvent(\"mouseup\""),
+            js_normalized.contains(
+                "if (pointerDownOk) {\n      el.dispatchEvent(new MouseEvent(\"mouseup\""
+            ),
             "mouseup must only dispatch when pointerdown was not canceled"
         );
     }

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -103,7 +103,11 @@ mod tests {
 
     #[test]
     fn test_serialize_error_response() {
-        let resp = Response::error(serde_json::Value::Number(1.into()), -32601, "Method not found");
+        let resp = Response::error(
+            serde_json::Value::Number(1.into()),
+            -32601,
+            "Method not found",
+        );
         let s = serde_json::to_string(&resp).expect("serialize");
         assert!(s.contains(r#""error""#));
         assert!(!s.contains(r#""result""#));

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -26,7 +26,7 @@ pub(crate) struct Request {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Response {
     pub jsonrpc: String,
-    pub id: u64,
+    pub id: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,7 +48,7 @@ impl Response {
     pub(crate) fn success(id: u64, result: serde_json::Value) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
-            id,
+            id: serde_json::Value::Number(id.into()),
             result: Some(result),
             error: None,
         }
@@ -56,7 +56,7 @@ impl Response {
 
     /// Create an error response.
     #[must_use]
-    pub(crate) fn error(id: u64, code: i32, message: impl Into<String>) -> Self {
+    pub(crate) fn error(id: serde_json::Value, code: i32, message: impl Into<String>) -> Self {
         Self {
             jsonrpc: "2.0".to_owned(),
             id,
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_serialize_error_response() {
-        let resp = Response::error(1, -32601, "Method not found");
+        let resp = Response::error(serde_json::Value::Number(1.into()), -32601, "Method not found");
         let s = serde_json::to_string(&resp).expect("serialize");
         assert!(s.contains(r#""error""#));
         assert!(!s.contains(r#""result""#));
@@ -129,7 +129,7 @@ mod tests {
         let resp = Response::success(7, json!([1, 2, 3]));
         let serialized = serde_json::to_string(&resp).expect("serialize");
         let deserialized: Response = serde_json::from_str(&serialized).expect("deserialize");
-        assert_eq!(deserialized.id, 7);
+        assert_eq!(deserialized.id, serde_json::json!(7));
         assert_eq!(deserialized.result, Some(json!([1, 2, 3])));
         assert!(deserialized.error.is_none());
     }

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -51,7 +51,11 @@ where
         }
 
         if line.len() > MAX_LINE_LENGTH {
-            let response = Response::error(serde_json::Value::Null, -32700, "Request line exceeds maximum length");
+            let response = Response::error(
+                serde_json::Value::Null,
+                -32700,
+                "Request line exceeds maximum length",
+            );
             let mut resp_bytes = serde_json::to_vec(&response)?;
             resp_bytes.push(b'\n');
             writer.write_all(&resp_bytes).await?;

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -100,6 +100,6 @@ pub mod unix;
 pub mod windows;
 
 #[cfg(unix)]
-pub use unix::{SocketGuard, bind, run, socket_path};
+pub use unix::{bind, run, socket_path};
 #[cfg(windows)]
 pub use windows::{bind, run, socket_path};

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -30,6 +30,8 @@ pub(crate) async fn handle_connection<S>(
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
+    const MAX_LINE_LENGTH: usize = 1_048_576;
+
     let (mut reader, mut writer) = tokio::io::split(stream);
     let mut reader = BufReader::new(&mut reader);
     let mut line = String::new();
@@ -38,6 +40,15 @@ where
         line.clear();
         let n = reader.read_line(&mut line).await?;
         if n == 0 {
+            break;
+        }
+
+        if line.len() > MAX_LINE_LENGTH {
+            let response = Response::error(serde_json::Value::Null, -32700, "Request line exceeds maximum length");
+            let mut resp_bytes = serde_json::to_vec(&response)?;
+            resp_bytes.push(b'\n');
+            writer.write_all(&resp_bytes).await?;
+            writer.flush().await?;
             break;
         }
 
@@ -87,7 +98,7 @@ pub(crate) async fn dispatch_request(
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {
             jsonrpc: "2.0".to_owned(),
-            id: serde_json::Value::Number(req.id.into()),
+            id: serde_json::Value::from(req.id),
             result: None,
             error: Some(rpc_err),
         },

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -48,12 +48,12 @@ where
 
         let response = match serde_json::from_str::<Request>(trimmed) {
             Ok(req) if req.jsonrpc != "2.0" => Response::error(
-                req.id,
+                serde_json::Value::Number(req.id.into()),
                 -32600,
                 "Invalid JSON-RPC version (expected \"2.0\")",
             ),
             Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, focus_fn, recorder).await,
-            Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
+            Err(e) => Response::error(serde_json::Value::Null, -32700, format!("Parse error: {e}")),
         };
 
         let mut resp_bytes = serde_json::to_vec(&response)?;
@@ -87,7 +87,7 @@ pub(crate) async fn dispatch_request(
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {
             jsonrpc: "2.0".to_owned(),
-            id: req.id,
+            id: serde_json::Value::Number(req.id.into()),
             result: None,
             error: Some(rpc_err),
         },

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -5,7 +5,7 @@ use crate::protocol::{Request, Response};
 use crate::recorder::Recorder;
 
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 /// A function that evaluates JS in the webview.
 /// The first argument is an optional window label (`None` means "use default window").
@@ -38,7 +38,14 @@ where
 
     loop {
         line.clear();
-        let n = reader.read_line(&mut line).await?;
+        // Bound the per-line read so a peer flooding bytes without a newline
+        // can't OOM us. `Take<R>` re-implements `AsyncBufRead`, so `read_line`
+        // still works through it; constructing a fresh `Take` per iteration
+        // resets the remaining-byte budget for each line.
+        let n = (&mut reader)
+            .take(MAX_LINE_LENGTH as u64 + 1)
+            .read_line(&mut line)
+            .await?;
         if n == 0 {
             break;
         }

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -1,0 +1,105 @@
+use crate::error::Error;
+use crate::eval::EvalEngine;
+use crate::handler;
+use crate::protocol::{Request, Response};
+use crate::recorder::Recorder;
+
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+/// A function that evaluates JS in the webview.
+/// The first argument is an optional window label (`None` means "use default window").
+pub(crate) type EvalFn = Arc<dyn Fn(Option<&str>, String) -> Result<(), String> + Send + Sync>;
+
+/// A function that lists all available webview windows and returns their metadata.
+pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;
+
+/// A function that requests focus for a webview window.
+/// `None` means "default window" (same resolution as `EvalFn`).
+/// Used before native key injection so synthesised OS events reach the right window.
+pub(crate) type FocusFn = Arc<dyn Fn(Option<&str>) -> Result<(), String> + Send + Sync>;
+
+pub(crate) async fn handle_connection<S>(
+    stream: S,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+    list_fn: Option<&ListWindowsFn>,
+    focus_fn: Option<&FocusFn>,
+    recorder: &Recorder,
+) -> Result<(), Error>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(&mut reader);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<Request>(trimmed) {
+            Ok(req) if req.jsonrpc != "2.0" => Response::error(
+                req.id,
+                -32600,
+                "Invalid JSON-RPC version (expected \"2.0\")",
+            ),
+            Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, focus_fn, recorder).await,
+            Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
+        };
+
+        let mut resp_bytes = serde_json::to_vec(&response)?;
+        resp_bytes.push(b'\n');
+        writer.write_all(&resp_bytes).await?;
+        writer.flush().await?;
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn dispatch_request(
+    req: &Request,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+    list_fn: Option<&ListWindowsFn>,
+    focus_fn: Option<&FocusFn>,
+    recorder: &Recorder,
+) -> Response {
+    match handler::dispatch(
+        &req.method,
+        req.params.as_ref(),
+        engine,
+        eval_fn,
+        list_fn,
+        focus_fn,
+        recorder,
+    )
+    .await
+    {
+        Ok(result) => Response::success(req.id, result),
+        Err(rpc_err) => Response {
+            jsonrpc: "2.0".to_owned(),
+            id: req.id,
+            result: None,
+            error: Some(rpc_err),
+        },
+    }
+}
+
+#[cfg(unix)]
+pub mod unix;
+#[cfg(windows)]
+pub mod windows;
+
+#[cfg(unix)]
+pub use unix::{SocketGuard, bind, run, socket_path};
+#[cfg(windows)]
+pub use windows::{bind, run, socket_path};

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -14,7 +14,10 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 #[allow(unused_imports)]
 use tokio::net::{UnixListener, UnixStream};
 
-pub(crate) struct SocketGuard {
+/// RAII guard that removes the socket file on drop (normal shutdown or panic).
+/// Stores the inode at bind time so it only unlinks its own socket, not one
+/// created by an overlapping instance.
+pub struct SocketGuard {
     path: std::path::PathBuf,
     inode: u64,
 }
@@ -22,6 +25,7 @@ pub(crate) struct SocketGuard {
 impl Drop for SocketGuard {
     fn drop(&mut self) {
         use std::os::unix::fs::MetadataExt;
+        // Only unlink if the on-disk inode still matches ours
         if let Ok(meta) = std::fs::metadata(&self.path)
             && meta.ino() == self.inode
         {
@@ -31,7 +35,10 @@ impl Drop for SocketGuard {
     }
 }
 
+/// Get inode from a raw file descriptor via `fstat`.
+/// This is race-free: it queries the kernel FD, not the filesystem path.
 fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
+    // SAFETY: fstat only reads from a valid fd and writes to our stack buffer.
     unsafe {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
         if libc::fstat(fd, stat.as_mut_ptr()) == 0 {
@@ -42,10 +49,12 @@ fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
     }
 }
 
+/// Returns true if `path` is a directory owned by the current user with no group/world permissions.
 fn is_private_dir(path: &std::path::Path) -> bool {
     use std::os::unix::fs::MetadataExt;
     match std::fs::metadata(path) {
         Ok(m) => {
+            // SAFETY: getuid() has no preconditions.
             let my_uid = unsafe { libc::getuid() };
             m.is_dir() && m.uid() == my_uid && m.mode().trailing_zeros() >= 6
         }
@@ -53,6 +62,8 @@ fn is_private_dir(path: &std::path::Path) -> bool {
     }
 }
 
+/// Core implementation — accepts the XDG value directly so tests can call it without mutating
+/// the process environment.
 fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
     if let Some(val) = xdg.filter(|v| !v.is_empty()) {
         let path = std::path::PathBuf::from(&val);
@@ -67,24 +78,39 @@ fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
     std::path::PathBuf::from("/tmp")
 }
 
+/// Returns the directory for the socket file.
+/// Prefers `$XDG_RUNTIME_DIR` when it is a private directory (owned by current user, no
+/// group/world access). Falls back to `/tmp` with a warning if the directory is not private.
 fn socket_dir() -> std::path::PathBuf {
     socket_dir_from(std::env::var_os("XDG_RUNTIME_DIR"))
 }
 
-pub(crate) fn socket_path(identifier: &str) -> std::path::PathBuf {
+/// Build the full socket path for the given app identifier.
+pub fn socket_path(identifier: &str) -> std::path::PathBuf {
     socket_dir().join(format!("tauri-pilot-{identifier}.sock"))
 }
 
-pub(crate) fn bind(
+/// Bind the socket using the **std** (sync) listener so this can be called
+/// outside a tokio runtime (e.g. from Tauri plugin `setup`).
+///
+/// Tries bind first; only removes stale files on `AddrInUse` after verifying
+/// no live server is listening.
+/// Returns a std listener and a [`SocketGuard`] that cleans up on drop.
+pub fn bind(
     socket_path: &std::path::Path,
 ) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
+    // SAFETY: umask is always safe to call; we restore the old mask immediately.
     let old_mask = unsafe { libc::umask(0o177) };
     let first_bind = std::os::unix::net::UnixListener::bind(socket_path);
+    // SAFETY: restoring the umask we just saved.
     unsafe { libc::umask(old_mask) };
 
     let listener = match first_bind {
         Ok(l) => l,
         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            // Probe: if a live server answers, the socket is truly in use.
+            // Only treat ConnectionRefused as "stale" — other errors (e.g.
+            // PermissionDenied) should propagate rather than blindly unlinking.
             match std::os::unix::net::UnixStream::connect(socket_path) {
                 Ok(_) => {
                     return Err(Error::Io(std::io::Error::new(
@@ -93,9 +119,12 @@ pub(crate) fn bind(
                     )));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                    // Stale socket from a crashed process — safe to remove and retry.
                     let _ = std::fs::remove_file(socket_path);
+                    // SAFETY: umask is always safe to call; we restore the old mask immediately.
                     let old_mask = unsafe { libc::umask(0o177) };
                     let retry_bind = std::os::unix::net::UnixListener::bind(socket_path);
+                    // SAFETY: restoring the umask we just saved.
                     unsafe { libc::umask(old_mask) };
                     retry_bind?
                 }
@@ -107,8 +136,10 @@ pub(crate) fn bind(
         Err(e) => return Err(Error::Io(e)),
     };
 
+    // Restrict socket to owner-only access (defense-in-depth alongside XDG_RUNTIME_DIR).
     std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))?;
 
+    // Must be non-blocking for tokio conversion
     listener.set_nonblocking(true)?;
 
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
@@ -123,8 +154,10 @@ pub(crate) fn bind(
     ))
 }
 
-pub(crate) async fn run(
-    std_listener: std::os::unix::net::UnixListener,
+/// Run the accept loop on a pre-bound std listener. Converts to tokio internally.
+/// The `_guard` is held for its `Drop` cleanup.
+pub async fn run(
+    listener: std::os::unix::net::UnixListener,
     _guard: SocketGuard,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
@@ -132,7 +165,7 @@ pub(crate) async fn run(
     focus_fn: Option<FocusFn>,
     recorder: Recorder,
 ) {
-    let listener = match UnixListener::from_std(std_listener) {
+    let listener = match UnixListener::from_std(listener) {
         Ok(l) => l,
         Err(e) => {
             tracing::error!("failed to convert listener to tokio: {e}");
@@ -162,8 +195,11 @@ async fn accept_loop(
                 continue;
             }
         };
+
+        // Verify the connecting process belongs to the same user.
         match stream.peer_cred() {
             Ok(cred) => {
+                // SAFETY: getuid() is always safe to call; it has no preconditions.
                 let my_uid = unsafe { libc::getuid() };
                 if cred.uid() != my_uid {
                     tracing::warn!(
@@ -302,6 +338,7 @@ mod tests {
     #[test]
     fn test_socket_dir_from_returns_xdg_runtime_dir_when_set_and_private() {
         use std::os::unix::fs::PermissionsExt;
+        // Create a private temp dir (0o700) to simulate a valid XDG_RUNTIME_DIR.
         let dir = std::env::temp_dir().join(format!("tauri-pilot-xdg-test-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -279,7 +279,7 @@ mod tests {
         reader.read_line(&mut line).await.unwrap();
         let resp: Response = serde_json::from_str(&line).unwrap();
 
-        assert_eq!(resp.id, 1);
+        assert_eq!(resp.id, serde_json::json!(1));
         assert!(resp.error.is_none());
         assert_eq!(resp.result, Some(serde_json::json!({"status": "ok"})));
 
@@ -303,7 +303,7 @@ mod tests {
         reader.read_line(&mut line).await.unwrap();
         let resp: Response = serde_json::from_str(&line).unwrap();
 
-        assert_eq!(resp.id, 0);
+        assert_eq!(resp.id, serde_json::Value::Null);
         let err = resp.error.unwrap();
         assert_eq!(err.code, -32700);
 
@@ -328,7 +328,7 @@ mod tests {
             let mut line = String::new();
             reader.read_line(&mut line).await.unwrap();
             let resp: Response = serde_json::from_str(&line).unwrap();
-            assert_eq!(resp.id, i);
+            assert_eq!(resp.id, serde_json::json!(i));
         }
 
         handle.abort();

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -1,30 +1,19 @@
+use super::{EvalFn, FocusFn, ListWindowsFn, handle_connection};
+
 use crate::error::Error;
 use crate::eval::EvalEngine;
-use crate::handler;
-use crate::protocol::{Request, Response};
+#[allow(unused_imports)]
+use crate::protocol::Response;
 use crate::recorder::Recorder;
 
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
+#[allow(unused_imports)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[allow(unused_imports)]
 use tokio::net::{UnixListener, UnixStream};
 
-/// A function that evaluates JS in the webview.
-/// The first argument is an optional window label (`None` means "use default window").
-pub(crate) type EvalFn = Arc<dyn Fn(Option<&str>, String) -> Result<(), String> + Send + Sync>;
-
-/// A function that lists all available webview windows and returns their metadata.
-pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;
-
-/// A function that requests focus for a webview window.
-/// `None` means "default window" (same resolution as `EvalFn`).
-/// Used before native key injection so synthesised OS events reach the right window.
-pub(crate) type FocusFn = Arc<dyn Fn(Option<&str>) -> Result<(), String> + Send + Sync>;
-
-/// RAII guard that removes the socket file on drop (normal shutdown or panic).
-/// Stores the inode at bind time so it only unlinks its own socket, not one
-/// created by an overlapping instance.
 pub(crate) struct SocketGuard {
     path: std::path::PathBuf,
     inode: u64,
@@ -33,7 +22,6 @@ pub(crate) struct SocketGuard {
 impl Drop for SocketGuard {
     fn drop(&mut self) {
         use std::os::unix::fs::MetadataExt;
-        // Only unlink if the on-disk inode still matches ours
         if let Ok(meta) = std::fs::metadata(&self.path)
             && meta.ino() == self.inode
         {
@@ -43,10 +31,7 @@ impl Drop for SocketGuard {
     }
 }
 
-/// Get inode from a raw file descriptor via `fstat`.
-/// This is race-free: it queries the kernel FD, not the filesystem path.
 fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
-    // SAFETY: fstat only reads from a valid fd and writes to our stack buffer.
     unsafe {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
         if libc::fstat(fd, stat.as_mut_ptr()) == 0 {
@@ -57,12 +42,10 @@ fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
     }
 }
 
-/// Returns true if `path` is a directory owned by the current user with no group/world permissions.
 fn is_private_dir(path: &std::path::Path) -> bool {
     use std::os::unix::fs::MetadataExt;
     match std::fs::metadata(path) {
         Ok(m) => {
-            // SAFETY: getuid() has no preconditions.
             let my_uid = unsafe { libc::getuid() };
             m.is_dir() && m.uid() == my_uid && m.mode().trailing_zeros() >= 6
         }
@@ -70,8 +53,6 @@ fn is_private_dir(path: &std::path::Path) -> bool {
     }
 }
 
-/// Core implementation — accepts the XDG value directly so tests can call it without mutating
-/// the process environment.
 fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
     if let Some(val) = xdg.filter(|v| !v.is_empty()) {
         let path = std::path::PathBuf::from(&val);
@@ -86,39 +67,24 @@ fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
     std::path::PathBuf::from("/tmp")
 }
 
-/// Returns the directory for the socket file.
-/// Prefers `$XDG_RUNTIME_DIR` when it is a private directory (owned by current user, no
-/// group/world access). Falls back to `/tmp` with a warning if the directory is not private.
 fn socket_dir() -> std::path::PathBuf {
     socket_dir_from(std::env::var_os("XDG_RUNTIME_DIR"))
 }
 
-/// Build the full socket path for the given app identifier.
 pub(crate) fn socket_path(identifier: &str) -> std::path::PathBuf {
     socket_dir().join(format!("tauri-pilot-{identifier}.sock"))
 }
 
-/// Bind the socket using the **std** (sync) listener so this can be called
-/// outside a tokio runtime (e.g. from Tauri plugin `setup`).
-///
-/// Tries bind first; only removes stale files on `AddrInUse` after verifying
-/// no live server is listening.
-/// Returns a std listener and a [`SocketGuard`] that cleans up on drop.
 pub(crate) fn bind(
     socket_path: &std::path::Path,
 ) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
-    // SAFETY: umask is always safe to call; we restore the old mask immediately.
     let old_mask = unsafe { libc::umask(0o177) };
     let first_bind = std::os::unix::net::UnixListener::bind(socket_path);
-    // SAFETY: restoring the umask we just saved.
     unsafe { libc::umask(old_mask) };
 
     let listener = match first_bind {
         Ok(l) => l,
         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-            // Probe: if a live server answers, the socket is truly in use.
-            // Only treat ConnectionRefused as "stale" — other errors (e.g.
-            // PermissionDenied) should propagate rather than blindly unlinking.
             match std::os::unix::net::UnixStream::connect(socket_path) {
                 Ok(_) => {
                     return Err(Error::Io(std::io::Error::new(
@@ -127,12 +93,9 @@ pub(crate) fn bind(
                     )));
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-                    // Stale socket from a crashed process — safe to remove and retry.
                     let _ = std::fs::remove_file(socket_path);
-                    // SAFETY: umask is always safe to call; we restore the old mask immediately.
                     let old_mask = unsafe { libc::umask(0o177) };
                     let retry_bind = std::os::unix::net::UnixListener::bind(socket_path);
-                    // SAFETY: restoring the umask we just saved.
                     unsafe { libc::umask(old_mask) };
                     retry_bind?
                 }
@@ -144,10 +107,8 @@ pub(crate) fn bind(
         Err(e) => return Err(Error::Io(e)),
     };
 
-    // Restrict socket to owner-only access (defense-in-depth alongside XDG_RUNTIME_DIR).
     std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))?;
 
-    // Must be non-blocking for tokio conversion
     listener.set_nonblocking(true)?;
 
     tracing::info!(path = %socket_path.display(), "tauri-pilot socket listening");
@@ -162,8 +123,6 @@ pub(crate) fn bind(
     ))
 }
 
-/// Run the accept loop on a pre-bound std listener. Converts to tokio internally.
-/// The `_guard` is held for its `Drop` cleanup.
 pub(crate) async fn run(
     std_listener: std::os::unix::net::UnixListener,
     _guard: SocketGuard,
@@ -203,10 +162,8 @@ async fn accept_loop(
                 continue;
             }
         };
-        // Verify the connecting process belongs to the same user.
         match stream.peer_cred() {
             Ok(cred) => {
-                // SAFETY: getuid() is always safe to call; it has no preconditions.
                 let my_uid = unsafe { libc::getuid() };
                 if cred.uid() != my_uid {
                     tracing::warn!(
@@ -237,78 +194,6 @@ async fn accept_loop(
                 tracing::warn!("connection error: {e}");
             }
         });
-    }
-}
-
-async fn handle_connection(
-    stream: UnixStream,
-    engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-    list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
-    recorder: &Recorder,
-) -> Result<(), Error> {
-    let (reader, mut writer) = stream.into_split();
-    let mut reader = BufReader::new(reader);
-    let mut line = String::new();
-
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line).await?;
-        if n == 0 {
-            break;
-        }
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let response = match serde_json::from_str::<Request>(trimmed) {
-            Ok(req) if req.jsonrpc != "2.0" => Response::error(
-                req.id,
-                -32600,
-                "Invalid JSON-RPC version (expected \"2.0\")",
-            ),
-            Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, focus_fn, recorder).await,
-            Err(e) => Response::error(0, -32700, format!("Parse error: {e}")),
-        };
-
-        let mut resp_bytes = serde_json::to_vec(&response)?;
-        resp_bytes.push(b'\n');
-        writer.write_all(&resp_bytes).await?;
-        writer.flush().await?;
-    }
-
-    Ok(())
-}
-
-async fn dispatch_request(
-    req: &Request,
-    engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-    list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
-    recorder: &Recorder,
-) -> Response {
-    match handler::dispatch(
-        &req.method,
-        req.params.as_ref(),
-        engine,
-        eval_fn,
-        list_fn,
-        focus_fn,
-        recorder,
-    )
-    .await
-    {
-        Ok(result) => Response::success(req.id, result),
-        Err(rpc_err) => Response {
-            jsonrpc: "2.0".to_owned(),
-            id: req.id,
-            result: None,
-            error: Some(rpc_err),
-        },
     }
 }
 
@@ -417,7 +302,6 @@ mod tests {
     #[test]
     fn test_socket_dir_from_returns_xdg_runtime_dir_when_set_and_private() {
         use std::os::unix::fs::PermissionsExt;
-        // Create a private temp dir (0o700) to simulate a valid XDG_RUNTIME_DIR.
         let dir = std::env::temp_dir().join(format!("tauri-pilot-xdg-test-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
 use windows::Win32::Security::{
-    ACL_REVISION, AddAccessAllowedAce, GetLengthSid, GetTokenInformation, InitializeAcl,
+    ACL, ACL_REVISION, AddAccessAllowedAce, GetLengthSid, GetTokenInformation, InitializeAcl,
     InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
     SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
 };
@@ -133,6 +133,7 @@ impl Drop for SecurityAttributesGuard {
 /// The returned guard must stay alive for as long as the `SECURITY_ATTRIBUTES` is
 /// passed to Windows APIs (the kernel copies the security descriptor, so the guard
 /// can be dropped immediately after the pipe is created).
+#[allow(clippy::cast_ptr_alignment)]
 fn create_user_only_security_attributes()
 -> std::io::Result<(SECURITY_ATTRIBUTES, SecurityAttributesGuard)> {
     unsafe {
@@ -156,7 +157,7 @@ fn create_user_only_security_attributes()
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-        let token_user = &*(token_user_buf.as_ptr() as *const TOKEN_USER);
+        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
         let user_sid = token_user.User.Sid;
 
         // 3. Allocate and initialise an ACL with a single ACE for the user.
@@ -167,7 +168,7 @@ fn create_user_only_security_attributes()
         let acl_size = (acl_size + 3) & !3;
 
         let mut acl_buf = vec![0u8; acl_size];
-        let acl_ptr = acl_buf.as_mut_ptr() as *mut _;
+        let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
 
         InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
             .map_err(|e| std::io::Error::other(e.to_string()))?;

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -25,22 +25,6 @@ pub fn socket_path(identifier: &str) -> PathBuf {
     PathBuf::from(format!(r"\\.\pipe\tauri-pilot-{identifier}"))
 }
 
-fn registry_dir() -> Option<PathBuf> {
-    std::env::var_os("LOCALAPPDATA")
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .map(|p| p.join("tauri-pilot"))
-}
-
-fn registry_path() -> Option<PathBuf> {
-    registry_dir().map(|d| d.join("instances.json"))
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Default)]
-struct Registry {
-    instances: std::collections::BTreeMap<String, InstanceEntry>,
-}
-
 #[derive(serde::Serialize, serde::Deserialize)]
 struct InstanceEntry {
     pipe: String,
@@ -48,49 +32,125 @@ struct InstanceEntry {
     created_at: u64,
 }
 
-fn read_registry(path: &Path) -> Registry {
-    match std::fs::read_to_string(path) {
-        Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
-        Err(_) => Registry::default(),
-    }
+fn instances_dir() -> std::io::Result<PathBuf> {
+    let local_app_data =
+        std::env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "LOCALAPPDATA environment variable is not set or empty",
+            )
+        })?;
+    Ok(PathBuf::from(local_app_data).join("tauri-pilot").join("instances"))
 }
 
-fn write_registry(path: &Path, reg: &Registry) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+fn instance_file_path(identifier: &str) -> std::io::Result<PathBuf> {
+    let dir = instances_dir()?;
+    if !dir.exists() {
+        let wide_path: Vec<u16> = dir.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+        let mut sa = SECURITY_ATTRIBUTES {
+            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
+                .expect("SECURITY_ATTRIBUTES size must fit in u32"),
+            lpSecurityDescriptor: std::ptr::null_mut(),
+            bInheritHandle: windows::Win32::Foundation::BOOL(0),
+        };
+        let sd = windows::Win32::Security::SECURITY_DESCRIPTOR {};
+        sa.lpSecurityDescriptor = &sd as *const _ as *mut _;
+        unsafe {
+            windows::Win32::FileSystem::CreateDirectoryW(
+                windows::core::PCWSTR::from_raw(wide_path.as_ptr()),
+                Some(&sa),
+            )
+        }
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::PermissionDenied, e))?;
     }
-    let data = serde_json::to_string_pretty(reg)?;
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, &data)?;
-    std::fs::rename(&tmp, path)
+    Ok(dir.join(format!("{identifier}.json")))
+}
+
+fn atomic_write_instance(path: &Path, entry: &InstanceEntry) -> std::io::Result<()> {
+    let json = serde_json::to_string(entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
 }
 
 fn register_instance(identifier: &str, pipe_path: &Path) -> std::io::Result<()> {
-    let Some(reg_path) = registry_path() else {
-        return Ok(());
+    let path = instance_file_path(identifier)?;
+    let entry = InstanceEntry {
+        pipe: pipe_path.to_string_lossy().into_owned(),
+        pid: std::process::id(),
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
     };
-    let mut reg = read_registry(&reg_path);
-    reg.instances.insert(
-        identifier.to_string(),
-        InstanceEntry {
-            pipe: pipe_path.to_string_lossy().into_owned(),
-            pid: std::process::id(),
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-        },
-    );
-    write_registry(&reg_path, &reg)
+    atomic_write_instance(&path, &entry)
 }
 
-fn unregister_instance(identifier: &str) {
-    let Some(reg_path) = registry_path() else {
-        return;
-    };
-    let mut reg = read_registry(&reg_path);
-    reg.instances.remove(identifier);
-    let _ = write_registry(&reg_path, &reg);
+fn unregister_instance(identifier: &str) -> std::io::Result<()> {
+    let path = instance_file_path(identifier)?;
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+fn is_pid_alive(pid: u32) -> bool {
+    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) };
+    match handle {
+        Ok(h) => {
+            let alive = unsafe {
+                let mut exit_code: u32 = 0;
+                GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
+            };
+            unsafe { let _ = CloseHandle(h) };
+            alive
+        }
+        Err(_) => false,
+    }
+}
+
+pub(crate) fn discover_instances() -> std::io::Result<Vec<InstanceEntry>> {
+    let dir = instances_dir()?;
+    let mut instances = Vec::new();
+    if !dir.exists() {
+        return Ok(instances);
+    }
+    let entries = std::fs::read_dir(&dir)?;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping corrupted instance file");
+                continue;
+            }
+        };
+        let info: InstanceEntry = match serde_json::from_str(&content) {
+            Ok(i) => i,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping malformed instance file");
+                continue;
+            }
+        };
+        if !is_pid_alive(info.pid) {
+            tracing::debug!(pid = info.pid, path = %path.display(), "skipping stale instance");
+            continue;
+        }
+        instances.push(info);
+    }
+    Ok(instances)
+}
+
+pub(crate) fn find_newest_instance() -> std::io::Result<Option<InstanceEntry>> {
+    let instances = discover_instances()?;
+    Ok(instances.into_iter().max_by_key(|i| i.created_at))
 }
 
 pub struct RegistryGuard {
@@ -99,8 +159,11 @@ pub struct RegistryGuard {
 
 impl Drop for RegistryGuard {
     fn drop(&mut self) {
-        unregister_instance(&self.identifier);
-        tracing::info!(identifier = %self.identifier, "registry entry removed");
+        if let Err(e) = unregister_instance(&self.identifier) {
+            tracing::warn!(identifier = %self.identifier, error = %e, "failed to remove registry entry");
+        } else {
+            tracing::info!(identifier = %self.identifier, "registry entry removed");
+        }
     }
 }
 
@@ -127,86 +190,82 @@ impl Drop for SecurityAttributesGuard {
     }
 }
 
-/// Build a [`SECURITY_ATTRIBUTES`] whose DACL grants `GENERIC_READ | GENERIC_WRITE`
-/// **only** to the current user.  No other principals receive access.
-///
-/// The returned guard must stay alive for as long as the `SECURITY_ATTRIBUTES` is
-/// passed to Windows APIs (the kernel copies the security descriptor, so the guard
-/// can be dropped immediately after the pipe is created).
+fn get_current_user_sid(
+    token: HANDLE,
+) -> std::io::Result<(*mut windows::Win32::Security::SID, HANDLE)> {
+    let mut return_length = 0u32;
+    let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
+    let mut token_user_buf = vec![0u8; return_length as usize];
+    GetTokenInformation(
+        token,
+        TokenUser,
+        Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
+        return_length,
+        &raw mut return_length,
+    )
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+    let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
+    Ok((token_user.User.Sid, token))
+}
+
+#[allow(clippy::cast_ptr_alignment)]
+fn create_security_descriptor_dacl(
+    user_sid: *mut windows::Win32::Security::SID,
+) -> std::io::Result<(Vec<u8>, Vec<u8>, *mut ACL)> {
+    let sid_length = GetLengthSid(user_sid) as usize;
+    let acl_size = (8 + 4 + 4 + sid_length + 3) & !3;
+    let mut acl_buf = vec![0u8; acl_size];
+    let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
+    InitializeAcl(
+        acl_ptr,
+        acl_size.try_into().map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large")
+        })?,
+        ACL_REVISION,
+    )
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+    AddAccessAllowedAce(
+        acl_ptr,
+        ACL_REVISION,
+        (GENERIC_READ | GENERIC_WRITE).0,
+        user_sid,
+    )
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+    let mut sd_buf = vec![0u8; 40];
+    let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr().cast::<c_void>());
+    InitializeSecurityDescriptor(sd_ptr, 1)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    Ok((sd_buf, acl_buf, acl_ptr))
+}
+
 #[allow(clippy::cast_ptr_alignment)]
 fn create_user_only_security_attributes()
 -> std::io::Result<(SECURITY_ATTRIBUTES, SecurityAttributesGuard)> {
     unsafe {
-        // 1. Open the current process token (TOKEN_QUERY only).
         let process = GetCurrentProcess();
         let mut token = HANDLE(0);
         OpenProcessToken(process, TOKEN_QUERY, &raw mut token)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-        // 2. Retrieve TokenUser information.
-        //    First call: discover required buffer size.
-        let mut return_length = 0u32;
-        let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
-        let mut token_user_buf = vec![0u8; return_length as usize];
-        GetTokenInformation(
+        // Guard created immediately so CloseHandle is called on any early return.
+        let mut guard = SecurityAttributesGuard {
+            sd: Vec::new(),
+            acl: Vec::new(),
             token,
-            TokenUser,
-            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
-            return_length,
-            &raw mut return_length,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
+        };
 
-        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
-        let user_sid = token_user.User.Sid;
+        let (user_sid, _token) = get_current_user_sid(guard.token)?;
+        let (sd, acl, _acl_ptr) = create_security_descriptor_dacl(user_sid)?;
+        guard.sd = sd;
+        guard.acl = acl;
 
-        // 3. Allocate and initialise an ACL with a single ACE for the user.
-        let sid_length = GetLengthSid(user_sid) as usize;
-        // ACL header (8) + ACE header (4) + access-mask (4) + SID
-        let acl_size = 8 + 4 + 4 + sid_length;
-        // Align to DWORD boundary.
-        let acl_size = (acl_size + 3) & !3;
-
-        let mut acl_buf = vec![0u8; acl_size];
-        let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
-
-        InitializeAcl(
-            acl_ptr,
-            acl_size.try_into().map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large")
-            })?,
-            ACL_REVISION,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-        AddAccessAllowedAce(
-            acl_ptr,
-            ACL_REVISION,
-            (GENERIC_READ | GENERIC_WRITE).0,
-            user_sid,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        // 4. Initialise an absolute security descriptor and attach the DACL.
-        let mut sd_buf = vec![0u8; 40];
-        let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr().cast::<c_void>());
-
-        InitializeSecurityDescriptor(sd_ptr, 1)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-        SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        // 5. Build SECURITY_ATTRIBUTES pointing into our buffers.
         let sa = SECURITY_ATTRIBUTES {
             nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
                 .expect("SECURITY_ATTRIBUTES size must fit in u32"),
-            lpSecurityDescriptor: sd_buf.as_mut_ptr().cast::<c_void>(),
+            lpSecurityDescriptor: guard.sd.as_mut_ptr().cast::<c_void>(),
             bInheritHandle: windows::Win32::Foundation::BOOL(0),
-        };
-
-        let guard = SecurityAttributesGuard {
-            sd: sd_buf,
-            acl: acl_buf,
-            token,
         };
 
         Ok((sa, guard))

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -373,17 +373,31 @@ fn create_user_only_security_attributes()
 // ---------------------------------------------------------------------------
 
 pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error> {
-    let (mut sa, _sec_guard) = create_user_only_security_attributes()?;
-
-    // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
-    // the duration of this call.  The kernel copies the security descriptor, so
-    // `_sec_guard` may be dropped after the pipe is created.
-    let server = unsafe {
-        ServerOptions::new()
-            .first_pipe_instance(true)
-            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-            .create_with_security_attributes_raw(pipe_path, (&raw mut sa).cast::<c_void>())?
-    };
+    let server = match create_user_only_security_attributes() {
+        Ok((mut sa, _sec_guard)) => {
+            // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
+            // the duration of this call.  The kernel copies the security descriptor, so
+            // `_sec_guard` may be dropped after the pipe is created.
+            unsafe {
+                ServerOptions::new()
+                    .first_pipe_instance(true)
+                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                    .create_with_security_attributes_raw(pipe_path, (&raw mut sa).cast::<c_void>())
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %pipe_path.display(),
+                error = %e,
+                "failed to create secure pipe, falling back to default security"
+            );
+            ServerOptions::new()
+                .first_pipe_instance(true)
+                .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                .create(pipe_path)
+        }
+    }
+    .map_err(Error::from)?;
 
     tracing::info!(path = %pipe_path.display(), "tauri-pilot named pipe listening");
 
@@ -441,12 +455,20 @@ async fn accept_loop(
     loop {
         server.connect().await?;
 
-        let (sa, _sec_guard) = create_user_only_security_attributes()?;
-        let next_server = unsafe {
-            ServerOptions::new()
-                .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-                .create_with_security_attributes_raw(&pipe_path, (&raw mut sa).cast::<c_void>())?
-        };
+        let next_server = match create_user_only_security_attributes() {
+            Ok((mut sa, _sec_guard)) => unsafe {
+                ServerOptions::new()
+                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                    .create_with_security_attributes_raw(&pipe_path, (&raw mut sa).cast::<c_void>())
+            },
+            Err(e) => {
+                tracing::warn!("failed to create secure pipe: {e}, falling back to default security");
+                ServerOptions::new()
+                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                    .create(&pipe_path)
+            }
+        }
+        .map_err(Error::from)?;
 
         let current = server;
         server = next_server;

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -520,7 +520,7 @@ mod tests {
         reader.read_line(&mut line).await.unwrap();
         let resp: Response = serde_json::from_str(&line).unwrap();
 
-        assert_eq!(resp.id, 1);
+        assert_eq!(resp.id, serde_json::json!(1));
         assert!(resp.error.is_none());
         assert_eq!(resp.result, Some(serde_json::json!({"status": "ok"})));
 
@@ -545,7 +545,7 @@ mod tests {
         reader.read_line(&mut line).await.unwrap();
         let resp: Response = serde_json::from_str(&line).unwrap();
 
-        assert_eq!(resp.id, 0);
+        assert_eq!(resp.id, serde_json::Value::Null);
         let err = resp.error.unwrap();
         assert_eq!(err.code, -32700);
 
@@ -571,7 +571,7 @@ mod tests {
             let mut line = String::new();
             reader.read_line(&mut line).await.unwrap();
             let resp: Response = serde_json::from_str(&line).unwrap();
-            assert_eq!(resp.id, i);
+            assert_eq!(resp.id, serde_json::json!(i));
         }
 
         handle.abort();

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -16,11 +16,12 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
 use windows::Win32::Security::{
-    ACL, ACL_REVISION, AddAccessAllowedAce, GetLengthSid, GetTokenInformation, InitializeAcl,
-    InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetLengthSid, GetTokenInformation,
+    ImpersonateNamedPipeClient, InitializeAcl, InitializeSecurityDescriptor,
+    PSECURITY_DESCRIPTOR, RevertToSelf, SECURITY_ATTRIBUTES,
     SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
 };
-use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken};
 
 pub fn socket_path(identifier: &str) -> PathBuf {
     PathBuf::from(format!(r"\\.\pipe\tauri-pilot-{identifier}"))
@@ -207,6 +208,85 @@ fn get_current_user_sid(
     Ok((token_user.User.Sid, token))
 }
 
+fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
+    // Impersonate the client to get its token.
+    if ImpersonateNamedPipeClient(pipe.as_raw_handle() as _).is_err() {
+        tracing::warn!("failed to impersonate named pipe client");
+        return true; // Allow connection if impersonation fails (DACL is primary)
+    }
+
+    // Get the impersonation token from the current thread.
+    let thread = unsafe { GetCurrentThread() };
+    let mut impersonation_token = HANDLE(0);
+    if unsafe { OpenProcessToken(thread, TOKEN_QUERY, &raw mut impersonation_token) }.is_err() {
+        tracing::warn!("failed to open thread token for impersonation");
+        let _ = RevertToSelf();
+        return true;
+    }
+
+    // Get the client's SID.
+    let client_sid = unsafe {
+        let mut return_length = 0u32;
+        let _ = GetTokenInformation(impersonation_token, TokenUser, None, 0, &raw mut return_length);
+        if return_length == 0 {
+            let _ = CloseHandle(impersonation_token);
+            let _ = RevertToSelf();
+            return true;
+        }
+        let mut token_user_buf = vec![0u8; return_length as usize];
+        if GetTokenInformation(
+            impersonation_token,
+            TokenUser,
+            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
+            return_length,
+            &raw mut return_length,
+        ).is_err() {
+            let _ = CloseHandle(impersonation_token);
+            let _ = RevertToSelf();
+            return true;
+        }
+        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
+        token_user.User.Sid
+    };
+
+    // Revert to self before getting our own SID.
+    let _ = RevertToSelf();
+    let _ = CloseHandle(impersonation_token);
+
+    // Get current process token and compare SIDs.
+    let matches = unsafe {
+        let process = GetCurrentProcess();
+        let mut token = HANDLE(0);
+        if OpenProcessToken(process, TOKEN_QUERY, &raw mut token).is_err() {
+            return true;
+        }
+        let mut return_length = 0u32;
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
+        if return_length == 0 {
+            let _ = CloseHandle(token);
+            return true;
+        }
+        let mut token_user_buf = vec![0u8; return_length as usize];
+        let result = GetTokenInformation(
+            token,
+            TokenUser,
+            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
+            return_length,
+            &raw mut return_length,
+        );
+        if result.is_err() {
+            let _ = CloseHandle(token);
+            return true;
+        }
+        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
+        let our_sid = token_user.User.Sid;
+        let _ = CloseHandle(token);
+        EqualSid(client_sid, our_sid).as_bool()
+    };
+
+    matches
+}
+
 fn create_security_descriptor_dacl(
     user_sid: *mut windows::Win32::Security::SID,
 ) -> std::io::Result<(
@@ -370,6 +450,11 @@ async fn accept_loop(
 
         let current = server;
         server = next_server;
+
+        if !client_sid_matches_current_user(&current) {
+            tracing::warn!("client SID does not match current user, closing connection");
+            continue;
+        }
 
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -312,6 +312,7 @@ async fn accept_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
     use tokio::net::windows::named_pipe::ClientOptions;
@@ -335,6 +336,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_server_responds_ping_ok() {
         let pipe = unique_pipe_path();
         let handle = start_test_server(&pipe).await;
@@ -358,9 +360,11 @@ mod tests {
         assert_eq!(resp.result, Some(serde_json::json!({"status": "ok"})));
 
         handle.abort();
+        let _ = handle.await;
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_server_handles_invalid_json() {
         let pipe = unique_pipe_path();
         let handle = start_test_server(&pipe).await;
@@ -381,9 +385,11 @@ mod tests {
         assert_eq!(err.code, -32700);
 
         handle.abort();
+        let _ = handle.await;
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_server_handles_multiple_requests() {
         let pipe = unique_pipe_path();
         let handle = start_test_server(&pipe).await;
@@ -404,5 +410,6 @@ mod tests {
         }
 
         handle.abort();
+        let _ = handle.await;
     }
 }

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -17,29 +17,26 @@ use std::time::Duration;
 #[allow(unused_imports)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
-use windows::Win32::Foundation::{
-    CloseHandle, ERROR_SUCCESS, GENERIC_READ, GENERIC_WRITE, HANDLE, HLOCAL,
-};
-use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, PSID};
 use windows::Win32::Security::{
-    ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AclSizeInformation, AddAccessAllowedAce, EqualSid,
-    GetAclInformation, GetLengthSid, GetTokenInformation, ImpersonateNamedPipeClient,
-    InitializeAcl, InitializeSecurityDescriptor, OpenThreadToken, PACL, PSECURITY_DESCRIPTOR,
-    RevertToSelf, SE_DACL_SECURITY_INFORMATION, SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl,
-    TOKEN_QUERY, TOKEN_USER, TokenUser,
+    ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetLengthSid, GetTokenInformation,
+    InitializeAcl, InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, RevertToSelf,
+    SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
 };
-use windows::Win32::System::Memory::LocalFree;
-use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken};
+use windows::Win32::System::Pipes::ImpersonateNamedPipeClient;
+use windows::Win32::System::Threading::{
+    GetCurrentProcess, GetCurrentThread, OpenProcessToken, OpenThreadToken,
+};
 
 pub fn socket_path(identifier: &str) -> PathBuf {
     PathBuf::from(format!(r"\\.\pipe\tauri-pilot-{identifier}"))
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-struct InstanceEntry {
-    pipe: String,
-    pid: u32,
-    created_at: u64,
+pub(crate) struct InstanceEntry {
+    pub pipe: String,
+    pub pid: u32,
+    pub created_at: u64,
 }
 
 fn instances_dir() -> std::io::Result<PathBuf> {
@@ -96,6 +93,7 @@ fn unregister_instance(identifier: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)] // used by `discover_instances`, kept for symmetry with the CLI resolver
 fn is_pid_alive(pid: u32) -> bool {
     use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
     use windows::Win32::System::Threading::{
@@ -108,7 +106,8 @@ fn is_pid_alive(pid: u32) -> bool {
             // SAFETY: `h` is a valid handle returned by OpenProcess.
             let alive = unsafe {
                 let mut exit_code: u32 = 0;
-                GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
+                GetExitCodeProcess(h, &raw mut exit_code).is_ok()
+                    && exit_code == STILL_ACTIVE.0 as u32
             };
             // SAFETY: closing the handle we just opened.
             unsafe {
@@ -120,6 +119,7 @@ fn is_pid_alive(pid: u32) -> bool {
     }
 }
 
+#[allow(dead_code)] // public helper for future CLI integration; not currently called
 pub(crate) fn discover_instances() -> std::io::Result<Vec<InstanceEntry>> {
     let dir = instances_dir()?;
     let mut instances = Vec::new();
@@ -155,6 +155,7 @@ pub(crate) fn discover_instances() -> std::io::Result<Vec<InstanceEntry>> {
     Ok(instances)
 }
 
+#[allow(dead_code)] // public helper for future CLI integration; not currently called
 pub(crate) fn find_newest_instance() -> std::io::Result<Option<InstanceEntry>> {
     let instances = discover_instances()?;
     Ok(instances.into_iter().max_by_key(|i| i.created_at))
@@ -263,9 +264,7 @@ fn open_thread_impersonation_token() -> std::io::Result<OwnedHandle> {
 /// Returns the SID owned by `token`, along with the backing buffer that the SID
 /// pointer references. The caller MUST keep the returned `Vec<u8>` alive for as
 /// long as the pointer is dereferenced (fix for the prior use-after-free).
-fn get_user_sid(
-    token: &OwnedHandle,
-) -> std::io::Result<(Vec<u8>, *mut windows::Win32::Security::SID)> {
+fn get_user_sid(token: &OwnedHandle) -> std::io::Result<(Vec<u8>, PSID)> {
     let mut return_length = 0u32;
     // First call is expected to fail with ERROR_INSUFFICIENT_BUFFER — it just
     // writes the required size into `return_length`.
@@ -293,9 +292,11 @@ fn get_user_sid(
     }
     .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-    // SAFETY: `buf` holds a valid `TOKEN_USER` laid out by the kernel. The `Sid`
-    // pointer it contains references memory inside `buf`, which we keep alive by
-    // returning it to the caller.
+    // SAFETY: `buf` holds a valid `TOKEN_USER` laid out by the kernel with the
+    // correct alignment for `TOKEN_USER` (padded by `GetTokenInformation`). The
+    // `Sid` pointer it contains references memory inside `buf`, which we keep
+    // alive by returning the buffer to the caller.
+    #[allow(clippy::cast_ptr_alignment)]
     let sid = unsafe { (*buf.as_ptr().cast::<TOKEN_USER>()).User.Sid };
     Ok((buf, sid))
 }
@@ -306,7 +307,7 @@ fn get_user_sid(
 /// remains the source of truth and this serves purely as a defence-in-depth check.
 fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
     // SAFETY: `pipe.as_raw_handle()` returns the kernel handle for the pipe server.
-    if unsafe { ImpersonateNamedPipeClient(pipe.as_raw_handle() as _) }.is_err() {
+    if unsafe { ImpersonateNamedPipeClient(HANDLE(pipe.as_raw_handle() as isize)) }.is_err() {
         tracing::warn!("failed to impersonate named pipe client");
         return true;
     }
@@ -358,13 +359,13 @@ fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
 
     // SAFETY: both SID pointers are backed by `_client_buf` and `_our_buf`, which
     // stay alive for the duration of this call.
-    unsafe { EqualSid(client_sid, our_sid) }.as_bool()
+    unsafe { EqualSid(client_sid, our_sid) }.is_ok()
 }
 
 /// Allocates and initializes the ACL granting the given SID access.
 /// Fixes the prior heap overflow: the layout now matches the `acl_size` we pass
 /// to `InitializeAcl`, not `sizeof::<ACL>()`.
-fn build_acl(user_sid: *mut windows::Win32::Security::SID) -> std::io::Result<AclBuffer> {
+fn build_acl(user_sid: PSID) -> std::io::Result<AclBuffer> {
     // SAFETY: `user_sid` points to a valid SID owned by the caller's buffer.
     let sid_length = unsafe { GetLengthSid(user_sid) } as usize;
 
@@ -375,7 +376,9 @@ fn build_acl(user_sid: *mut windows::Win32::Security::SID) -> std::io::Result<Ac
     let layout = Layout::from_size_align(acl_size, mem::align_of::<ACL>())
         .map_err(|e| std::io::Error::other(format!("invalid ACL layout: {e}")))?;
 
-    // SAFETY: `layout` has a non-zero size and an alignment that is a power of two.
+    // SAFETY: `layout` has a non-zero size and an alignment that matches `ACL`'s
+    // alignment requirement (enforced by `from_size_align` above).
+    #[allow(clippy::cast_ptr_alignment)]
     let ptr = unsafe { alloc_zeroed(layout) }.cast::<ACL>();
     if ptr.is_null() {
         // Do NOT dealloc a null pointer — it is UB. Just return.
@@ -386,8 +389,16 @@ fn build_acl(user_sid: *mut windows::Win32::Security::SID) -> std::io::Result<Ac
     let buffer = AclBuffer { ptr, layout };
 
     // SAFETY: `ptr` is valid, aligned, zeroed memory of exactly `acl_size` bytes.
-    unsafe { InitializeAcl(buffer.as_ptr(), acl_size as u32, ACL_REVISION) }
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    // `acl_size` fits in u32: ACL header (8) + ACE header (4) + access mask (4)
+    // + SID (max ~68 bytes) rounded up to DWORD is well under 64 KB.
+    unsafe {
+        InitializeAcl(
+            buffer.as_ptr(),
+            u32::try_from(acl_size).expect("ACL size fits in u32"),
+            ACL_REVISION,
+        )
+    }
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     // SAFETY: `buffer.as_ptr()` is a freshly-initialised ACL with room for this ACE
     // (our `acl_size` accounted for the SID length), and `user_sid` is valid.
@@ -530,27 +541,24 @@ async fn accept_loop(
         // retry after a short back-off. Silent downgrade to default DACL is
         // refused — we'd rather drop a connection than weaken security.
         let next_server = loop {
-            let sa_result = create_user_only_security_attributes();
-            let (mut sa, _sec_guard) = match sa_result {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "failed to build security attributes, retrying"
-                    );
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    continue;
+            // Build SA, create the pipe, and drop the guard buffers in one scope so
+            // no `*mut ACL` or `*mut c_void` crosses the retry `.await` below —
+            // `CreateNamedPipe` copies the security descriptor by the time it returns.
+            let create_result: std::io::Result<NamedPipeServer> = (|| {
+                let (mut sa, _sec_guard) = create_user_only_security_attributes()?;
+                // SAFETY: `sa` and its backing buffers are valid for this call.
+                unsafe {
+                    ServerOptions::new()
+                        .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                        .create_with_security_attributes_raw(
+                            &pipe_path,
+                            (&raw mut sa).cast::<c_void>(),
+                        )
                 }
-            };
+                .map_err(std::io::Error::other)
+            })();
 
-            // SAFETY: `sa` and its backing buffers are valid for this call.
-            let created = unsafe {
-                ServerOptions::new()
-                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-                    .create_with_security_attributes_raw(&pipe_path, (&raw mut sa).cast::<c_void>())
-            };
-
-            match created {
+            match create_result {
                 Ok(s) => break s,
                 Err(e) => {
                     tracing::warn!(
@@ -559,7 +567,6 @@ async fn accept_loop(
                         "transient failure creating next pipe instance, retrying"
                     );
                     tokio::time::sleep(Duration::from_millis(50)).await;
-                    continue;
                 }
             }
         };
@@ -697,66 +704,13 @@ mod tests {
     #[tokio::test]
     #[serial]
     #[cfg(windows)]
-    async fn test_dacl_regression_every_pipe_instance_has_dacl_with_one_ace() {
-        let pipe = unique_pipe_path();
-        let (server, guard) = bind(&pipe).expect("bind test pipe");
-
-        let raw_handle = server.as_raw_handle();
-        let handle = HANDLE(raw_handle as isize);
-
-        let mut dacl_ptr: PACL = PACL::default();
-        let mut sd_ptr = PSECURITY_DESCRIPTOR::default();
-        let sd_result = unsafe {
-            GetSecurityInfo(
-                handle,
-                SE_KERNEL_OBJECT,
-                SE_DACL_SECURITY_INFORMATION,
-                None,
-                None,
-                Some(&mut dacl_ptr),
-                None,
-                Some(&mut sd_ptr),
-            )
-        };
-        assert_eq!(sd_result, ERROR_SUCCESS, "GetSecurityInfo should succeed");
-        assert!(
-            !dacl_ptr.is_null(),
-            "DACL pointer must not be NULL — every pipe instance must have a DACL"
-        );
-
-        let mut acl_size = ACL_SIZE_INFORMATION::default();
-        let size_result = unsafe {
-            GetAclInformation(
-                dacl_ptr,
-                &mut acl_size as *mut _ as *mut c_void,
-                std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
-                AclSizeInformation,
-            )
-        };
-        size_result.expect("GetAclInformation should succeed");
-        assert_eq!(
-            acl_size.AceCount, 1,
-            "DACL must contain exactly 1 ACE (owner-only access)"
-        );
-
-        unsafe {
-            let _ = LocalFree(HLOCAL(sd_ptr.0));
-        }
-
-        // Trigger a new accept cycle and drop the server.
-        let _client = ClientOptions::new()
-            .open(&pipe)
-            .expect("client should connect");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        drop(server);
-        drop(guard);
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-
-    #[tokio::test]
-    #[serial]
-    #[cfg(windows)]
     async fn test_bound_pipe_carries_user_only_dacl() {
+        use windows::Win32::Foundation::LocalFree;
+        use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+        use windows::Win32::Security::{
+            ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION, GetAclInformation,
+        };
+
         let pipe = unique_pipe_path();
         let (server, guard) = bind(&pipe).expect("bind test pipe");
 
@@ -766,43 +720,43 @@ mod tests {
         // Retrieve the DACL from the freshly-bound pipe and assert:
         //   - the DACL pointer is non-NULL (the pipe is not running with a NULL DACL),
         //   - the DACL contains exactly one ACE (our owner-only ACE).
-        let mut dacl_ptr: PACL = PACL::default();
+        let mut dacl_ptr: *mut ACL = std::ptr::null_mut();
         let mut sd_ptr = PSECURITY_DESCRIPTOR::default();
-        let rc = unsafe {
+        unsafe {
             GetSecurityInfo(
                 handle,
                 SE_KERNEL_OBJECT,
-                SE_DACL_SECURITY_INFORMATION,
+                DACL_SECURITY_INFORMATION,
                 None,
                 None,
-                Some(&mut dacl_ptr),
+                Some(&raw mut dacl_ptr),
                 None,
-                Some(&mut sd_ptr),
+                Some(&raw mut sd_ptr),
             )
-        };
-        assert_eq!(
-            rc, ERROR_SUCCESS,
-            "GetSecurityInfo must succeed on a bound pipe"
-        );
+        }
+        .expect("GetSecurityInfo must succeed on a bound pipe");
         assert!(!dacl_ptr.is_null(), "bound pipe must carry a non-NULL DACL");
 
         let mut info = ACL_SIZE_INFORMATION::default();
-        let rc = unsafe {
+        unsafe {
             GetAclInformation(
                 dacl_ptr,
-                &mut info as *mut _ as *mut c_void,
+                (&raw mut info).cast::<c_void>(),
                 std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
                 AclSizeInformation,
             )
-        };
-        rc.expect("GetAclInformation must succeed");
+        }
+        .expect("GetAclInformation must succeed");
         assert_eq!(
             info.AceCount, 1,
             "bound pipe DACL must contain exactly one ACE (owner-only)"
         );
 
+        // SAFETY: `sd_ptr` was allocated by `GetSecurityInfo`; documented contract
+        // requires the caller to release it with `LocalFree`. `dacl_ptr` points
+        // into the same allocation and must not be freed separately.
         unsafe {
-            let _ = LocalFree(HLOCAL(sd_ptr.0));
+            let _ = LocalFree(windows::Win32::Foundation::HLOCAL(sd_ptr.0));
         }
 
         drop(server);

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -170,8 +170,14 @@ fn create_user_only_security_attributes()
         let mut acl_buf = vec![0u8; acl_size];
         let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
 
-        InitializeAcl(acl_ptr, acl_size.try_into().map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large"))?, ACL_REVISION)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        InitializeAcl(
+            acl_ptr,
+            acl_size.try_into().map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large")
+            })?,
+            ACL_REVISION,
+        )
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
         AddAccessAllowedAce(
             acl_ptr,
             ACL_REVISION,
@@ -191,7 +197,8 @@ fn create_user_only_security_attributes()
 
         // 5. Build SECURITY_ATTRIBUTES pointing into our buffers.
         let sa = SECURITY_ATTRIBUTES {
-            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>()).unwrap(),
+            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
+                .expect("SECURITY_ATTRIBUTES size must fit in u32"),
             lpSecurityDescriptor: sd_buf.as_mut_ptr().cast::<c_void>(),
             bInheritHandle: windows::Win32::Foundation::BOOL(0),
         };
@@ -218,7 +225,7 @@ pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error>
         ServerOptions::new()
             .first_pipe_instance(true)
             .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-            .create_with_security_attributes_raw(pipe_path, &raw mut sa as *mut c_void)?
+            .create_with_security_attributes_raw(pipe_path, (&raw mut sa).cast::<c_void>())?
     };
 
     tracing::info!(path = %pipe_path.display(), "tauri-pilot named pipe listening");

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -110,6 +110,7 @@ impl Drop for RegistryGuard {
 
 /// Owns the buffers backing a [`SECURITY_ATTRIBUTES`] and closes the token handle.
 /// Must outlive the `SECURITY_ATTRIBUTES` pointer passed to Windows APIs.
+#[allow(dead_code)]
 struct SecurityAttributesGuard {
     sd: Vec<u8>,
     acl: Vec<u8>,
@@ -138,8 +139,8 @@ fn create_user_only_security_attributes()
         // 1. Open the current process token (TOKEN_QUERY only).
         let process = GetCurrentProcess();
         let mut token = HANDLE(0);
-        OpenProcessToken(process, TOKEN_QUERY, &mut token)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        OpenProcessToken(process, TOKEN_QUERY, &raw mut token)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // 2. Retrieve TokenUser information.
         //    First call: discover required buffer size.
@@ -153,7 +154,7 @@ fn create_user_only_security_attributes()
             return_length,
             &mut return_length,
         )
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         let token_user = &*(token_user_buf.as_ptr() as *const TOKEN_USER);
         let user_sid = token_user.User.Sid;
@@ -169,23 +170,23 @@ fn create_user_only_security_attributes()
         let acl_ptr = acl_buf.as_mut_ptr() as *mut _;
 
         InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         AddAccessAllowedAce(
             acl_ptr,
             ACL_REVISION,
             (GENERIC_READ | GENERIC_WRITE).0 as u32,
             user_sid,
         )
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // 4. Initialise an absolute security descriptor and attach the DACL.
         let mut sd_buf = vec![0u8; 40];
         let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr() as *mut c_void);
 
         InitializeSecurityDescriptor(sd_ptr, 1)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // 5. Build SECURITY_ATTRIBUTES pointing into our buffers.
         let sa = SECURITY_ATTRIBUTES {
@@ -216,7 +217,7 @@ pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error>
         ServerOptions::new()
             .first_pipe_instance(true)
             .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-            .create_with_security_attributes_raw(pipe_path, &mut sa as *mut _ as *mut c_void)?
+            .create_with_security_attributes_raw(pipe_path, &raw mut sa as *mut c_void)?
     };
 
     tracing::info!(path = %pipe_path.display(), "tauri-pilot named pipe listening");

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -1,0 +1,399 @@
+use super::{EvalFn, FocusFn, ListWindowsFn, handle_connection};
+
+use crate::error::Error;
+use crate::eval::EvalEngine;
+#[allow(unused_imports)]
+use crate::protocol::Response;
+use crate::recorder::Recorder;
+
+use std::ffi::c_void;
+use std::mem;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+#[allow(unused_imports)]
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
+use windows::Win32::Security::{
+    ACL_REVISION, AddAccessAllowedAce, GetLengthSid, GetTokenInformation, InitializeAcl,
+    InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+pub(crate) fn socket_path(identifier: &str) -> PathBuf {
+    PathBuf::from(format!(r"\\.\pipe\tauri-pilot-{identifier}"))
+}
+
+fn registry_dir() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .map(|p| p.join("tauri-pilot"))
+}
+
+fn registry_path() -> Option<PathBuf> {
+    registry_dir().map(|d| d.join("instances.json"))
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct Registry {
+    instances: std::collections::BTreeMap<String, InstanceEntry>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct InstanceEntry {
+    pipe: String,
+    pid: u32,
+    created_at: u64,
+}
+
+fn read_registry(path: &Path) -> Registry {
+    match std::fs::read_to_string(path) {
+        Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
+        Err(_) => Registry::default(),
+    }
+}
+
+fn write_registry(path: &Path, reg: &Registry) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let data = serde_json::to_string_pretty(reg)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &data)?;
+    std::fs::rename(&tmp, path)
+}
+
+fn register_instance(identifier: &str, pipe_path: &Path) -> std::io::Result<()> {
+    let Some(reg_path) = registry_path() else {
+        return Ok(());
+    };
+    let mut reg = read_registry(&reg_path);
+    reg.instances.insert(
+        identifier.to_string(),
+        InstanceEntry {
+            pipe: pipe_path.to_string_lossy().into_owned(),
+            pid: std::process::id(),
+            created_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        },
+    );
+    write_registry(&reg_path, &reg)
+}
+
+fn unregister_instance(identifier: &str) {
+    let Some(reg_path) = registry_path() else {
+        return;
+    };
+    let mut reg = read_registry(&reg_path);
+    reg.instances.remove(identifier);
+    let _ = write_registry(&reg_path, &reg);
+}
+
+pub(crate) struct RegistryGuard {
+    identifier: String,
+}
+
+impl Drop for RegistryGuard {
+    fn drop(&mut self) {
+        unregister_instance(&self.identifier);
+        tracing::info!(identifier = %self.identifier, "registry entry removed");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Security: restrict the named pipe to the creating user only (DACL-only)
+// ---------------------------------------------------------------------------
+
+/// Owns the buffers backing a [`SECURITY_ATTRIBUTES`] and closes the token handle.
+/// Must outlive the `SECURITY_ATTRIBUTES` pointer passed to Windows APIs.
+struct SecurityAttributesGuard {
+    sd: Vec<u8>,
+    acl: Vec<u8>,
+    token: HANDLE,
+}
+
+impl Drop for SecurityAttributesGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if self.token.0 != 0 {
+                let _ = CloseHandle(self.token);
+            }
+        }
+    }
+}
+
+/// Build a [`SECURITY_ATTRIBUTES`] whose DACL grants `GENERIC_READ | GENERIC_WRITE`
+/// **only** to the current user.  No other principals receive access.
+///
+/// The returned guard must stay alive for as long as the `SECURITY_ATTRIBUTES` is
+/// passed to Windows APIs (the kernel copies the security descriptor, so the guard
+/// can be dropped immediately after the pipe is created).
+fn create_user_only_security_attributes()
+-> std::io::Result<(SECURITY_ATTRIBUTES, SecurityAttributesGuard)> {
+    unsafe {
+        // 1. Open the current process token (TOKEN_QUERY only).
+        let process = GetCurrentProcess();
+        let mut token = HANDLE(0);
+        OpenProcessToken(process, TOKEN_QUERY, &mut token)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        // 2. Retrieve TokenUser information.
+        //    First call: discover required buffer size.
+        let mut return_length = 0u32;
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &mut return_length);
+        let mut token_user_buf = vec![0u8; return_length as usize];
+        GetTokenInformation(
+            token,
+            TokenUser,
+            Some(token_user_buf.as_mut_ptr() as *mut c_void),
+            return_length,
+            &mut return_length,
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        let token_user = &*(token_user_buf.as_ptr() as *const TOKEN_USER);
+        let user_sid = token_user.User.Sid;
+
+        // 3. Allocate and initialise an ACL with a single ACE for the user.
+        let sid_length = GetLengthSid(user_sid) as usize;
+        // ACL header (8) + ACE header (4) + access-mask (4) + SID
+        let acl_size = 8 + 4 + 4 + sid_length;
+        // Align to DWORD boundary.
+        let acl_size = (acl_size + 3) & !3;
+
+        let mut acl_buf = vec![0u8; acl_size];
+        let acl_ptr = acl_buf.as_mut_ptr() as *mut _;
+
+        InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        AddAccessAllowedAce(
+            acl_ptr,
+            ACL_REVISION,
+            (GENERIC_READ | GENERIC_WRITE).0 as u32,
+            user_sid,
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        // 4. Initialise an absolute security descriptor and attach the DACL.
+        let mut sd_buf = vec![0u8; 40];
+        let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr() as *mut c_void);
+
+        InitializeSecurityDescriptor(sd_ptr, 1)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        // 5. Build SECURITY_ATTRIBUTES pointing into our buffers.
+        let sa = SECURITY_ATTRIBUTES {
+            nLength: mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: sd_buf.as_mut_ptr() as *mut c_void,
+            bInheritHandle: windows::Win32::Foundation::BOOL(0),
+        };
+
+        let guard = SecurityAttributesGuard {
+            sd: sd_buf,
+            acl: acl_buf,
+            token,
+        };
+
+        Ok((sa, guard))
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+pub(crate) fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error> {
+    let (mut sa, _sec_guard) = create_user_only_security_attributes()?;
+
+    // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
+    // the duration of this call.  The kernel copies the security descriptor, so
+    // `_sec_guard` may be dropped after the pipe is created.
+    let server = unsafe {
+        ServerOptions::new()
+            .first_pipe_instance(true)
+            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+            .create_with_security_attributes_raw(pipe_path, &mut sa as *mut _ as *mut c_void)?
+    };
+
+    tracing::info!(path = %pipe_path.display(), "tauri-pilot named pipe listening");
+
+    let identifier = pipe_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.strip_prefix("tauri-pilot-"))
+        .unwrap_or("unknown")
+        .to_string();
+
+    register_instance(&identifier, pipe_path)?;
+    let guard = RegistryGuard { identifier };
+
+    Ok((server, guard))
+}
+
+pub(crate) async fn run(
+    first_server: NamedPipeServer,
+    guard: RegistryGuard,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+    list_fn: Option<ListWindowsFn>,
+    focus_fn: Option<FocusFn>,
+    recorder: Recorder,
+) {
+    let identifier = guard.identifier.clone();
+    if let Err(e) = accept_loop(
+        first_server,
+        &identifier,
+        engine,
+        eval_fn,
+        list_fn,
+        focus_fn,
+        recorder,
+    )
+    .await
+    {
+        tracing::error!("named pipe server error: {e}");
+    }
+}
+
+async fn accept_loop(
+    first_server: NamedPipeServer,
+    identifier: &str,
+    engine: EvalEngine,
+    eval_fn: Option<EvalFn>,
+    list_fn: Option<ListWindowsFn>,
+    focus_fn: Option<FocusFn>,
+    recorder: Recorder,
+) -> Result<(), Error> {
+    let ctx = Arc::new((engine, eval_fn, list_fn, focus_fn, recorder));
+    let mut server = first_server;
+    let pipe_path = socket_path(identifier);
+
+    loop {
+        server.connect().await?;
+
+        let next_server = ServerOptions::new()
+            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+            .create(&pipe_path)?;
+
+        let current = server;
+        server = next_server;
+
+        let ctx = Arc::clone(&ctx);
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(
+                current,
+                &ctx.0,
+                ctx.1.as_ref(),
+                ctx.2.as_ref(),
+                ctx.3.as_ref(),
+                &ctx.4,
+            )
+            .await
+            {
+                tracing::warn!("connection error: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_pipe_path() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = format!("tauri-pilot-test-{}-{n}", std::process::id());
+        PathBuf::from(format!(r"\\.\pipe\{name}"))
+    }
+
+    async fn start_test_server(path: &PathBuf) -> tokio::task::JoinHandle<()> {
+        let (listener, guard) = bind(path).expect("bind test pipe");
+        let engine = EvalEngine::new();
+        let handle = tokio::spawn(async move {
+            run(listener, guard, engine, None, None, None, Recorder::new()).await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle
+    }
+
+    #[tokio::test]
+    async fn test_server_responds_ping_ok() {
+        let pipe = unique_pipe_path();
+        let handle = start_test_server(&pipe).await;
+
+        let client = ClientOptions::new().open(&pipe).unwrap();
+        let (reader, mut writer) = tokio::io::split(client);
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        let resp: Response = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(resp.id, 1);
+        assert!(resp.error.is_none());
+        assert_eq!(resp.result, Some(serde_json::json!({"status": "ok"})));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_server_handles_invalid_json() {
+        let pipe = unique_pipe_path();
+        let handle = start_test_server(&pipe).await;
+
+        let client = ClientOptions::new().open(&pipe).unwrap();
+        let (reader, mut writer) = tokio::io::split(client);
+        let mut reader = BufReader::new(reader);
+
+        writer.write_all(b"not json\n").await.unwrap();
+        writer.flush().await.unwrap();
+
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        let resp: Response = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(resp.id, 0);
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -32700);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_server_handles_multiple_requests() {
+        let pipe = unique_pipe_path();
+        let handle = start_test_server(&pipe).await;
+
+        let client = ClientOptions::new().open(&pipe).unwrap();
+        let (reader, mut writer) = tokio::io::split(client);
+        let mut reader = BufReader::new(reader);
+
+        for i in 1..=3 {
+            let req = format!("{{\"jsonrpc\":\"2.0\",\"id\":{i},\"method\":\"test\"}}\n");
+            writer.write_all(req.as_bytes()).await.unwrap();
+            writer.flush().await.unwrap();
+
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let resp: Response = serde_json::from_str(&line).unwrap();
+            assert_eq!(resp.id, i);
+        }
+
+        handle.abort();
+    }
+}

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -21,7 +21,7 @@ use windows::Win32::Security::{
 };
 use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
-pub(crate) fn socket_path(identifier: &str) -> PathBuf {
+pub fn socket_path(identifier: &str) -> PathBuf {
     PathBuf::from(format!(r"\\.\pipe\tauri-pilot-{identifier}"))
 }
 
@@ -93,7 +93,7 @@ fn unregister_instance(identifier: &str) {
     let _ = write_registry(&reg_path, &reg);
 }
 
-pub(crate) struct RegistryGuard {
+pub struct RegistryGuard {
     identifier: String,
 }
 
@@ -206,7 +206,7 @@ fn create_user_only_security_attributes()
 
 // ---------------------------------------------------------------------------
 
-pub(crate) fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error> {
+pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error> {
     let (mut sa, _sec_guard) = create_user_only_security_attributes()?;
 
     // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
@@ -234,7 +234,7 @@ pub(crate) fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard),
     Ok((server, guard))
 }
 
-pub(crate) async fn run(
+pub async fn run(
     first_server: NamedPipeServer,
     guard: RegistryGuard,
     engine: EvalEngine,

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -145,14 +145,14 @@ fn create_user_only_security_attributes()
         // 2. Retrieve TokenUser information.
         //    First call: discover required buffer size.
         let mut return_length = 0u32;
-        let _ = GetTokenInformation(token, TokenUser, None, 0, &mut return_length);
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
         let mut token_user_buf = vec![0u8; return_length as usize];
         GetTokenInformation(
             token,
             TokenUser,
-            Some(token_user_buf.as_mut_ptr() as *mut c_void),
+            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
             return_length,
-            &mut return_length,
+            &raw mut return_length,
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -170,19 +170,19 @@ fn create_user_only_security_attributes()
         let mut acl_buf = vec![0u8; acl_size];
         let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
 
-        InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
+        InitializeAcl(acl_ptr, acl_size.try_into().map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large"))?, ACL_REVISION)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
         AddAccessAllowedAce(
             acl_ptr,
             ACL_REVISION,
-            (GENERIC_READ | GENERIC_WRITE).0 as u32,
+            (GENERIC_READ | GENERIC_WRITE).0,
             user_sid,
         )
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // 4. Initialise an absolute security descriptor and attach the DACL.
         let mut sd_buf = vec![0u8; 40];
-        let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr() as *mut c_void);
+        let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr().cast::<c_void>());
 
         InitializeSecurityDescriptor(sd_ptr, 1)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -191,8 +191,8 @@ fn create_user_only_security_attributes()
 
         // 5. Build SECURITY_ATTRIBUTES pointing into our buffers.
         let sa = SECURITY_ATTRIBUTES {
-            nLength: mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
-            lpSecurityDescriptor: sd_buf.as_mut_ptr() as *mut c_void,
+            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>()).unwrap(),
+            lpSecurityDescriptor: sd_buf.as_mut_ptr().cast::<c_void>(),
             bInheritHandle: windows::Win32::Foundation::BOOL(0),
         };
 

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -6,21 +6,24 @@ use crate::eval::EvalEngine;
 use crate::protocol::Response;
 use crate::recorder::Recorder;
 
-use std::alloc::{alloc_zeroed, Layout};
+use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::ffi::c_void;
 use std::mem;
+use std::mem::MaybeUninit;
+use std::os::windows::io::AsRawHandle;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 #[allow(unused_imports)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
 use windows::Win32::Security::{
-    ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetAclInformation, GetLengthSid,
-    GetSecurityInfo, GetTokenInformation, ImpersonateNamedPipeClient, InitializeAcl,
-    InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, RevertToSelf, SECURITY_ATTRIBUTES,
-    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser, AclSizeInformation,
-    SE_DACL_SECURITY_INFORMATION,
+    ACL, ACL_REVISION, AclSizeInformation, AddAccessAllowedAce, EqualSid, GetAclInformation,
+    GetLengthSid, GetSecurityInfo, GetTokenInformation, ImpersonateNamedPipeClient, InitializeAcl,
+    InitializeSecurityDescriptor, OpenThreadToken, PSECURITY_DESCRIPTOR, RevertToSelf,
+    SE_DACL_SECURITY_INFORMATION, SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl, TOKEN_QUERY,
+    TOKEN_USER, TokenUser,
 };
 use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken};
 
@@ -36,36 +39,26 @@ struct InstanceEntry {
 }
 
 fn instances_dir() -> std::io::Result<PathBuf> {
-    let local_app_data =
-        std::env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()).ok_or_else(|| {
+    let local_app_data = std::env::var_os("LOCALAPPDATA")
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "LOCALAPPDATA environment variable is not set or empty",
             )
         })?;
-    Ok(PathBuf::from(local_app_data).join("tauri-pilot").join("instances"))
+    Ok(PathBuf::from(local_app_data)
+        .join("tauri-pilot")
+        .join("instances"))
 }
 
 fn instance_file_path(identifier: &str) -> std::io::Result<PathBuf> {
     let dir = instances_dir()?;
-    if !dir.exists() {
-        let wide_path: Vec<u16> = dir.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
-        let mut sa = SECURITY_ATTRIBUTES {
-            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
-                .expect("SECURITY_ATTRIBUTES size must fit in u32"),
-            lpSecurityDescriptor: std::ptr::null_mut(),
-            bInheritHandle: windows::Win32::Foundation::BOOL(0),
-        };
-        let sd = windows::Win32::Security::SECURITY_DESCRIPTOR {};
-        sa.lpSecurityDescriptor = &sd as *const _ as *mut _;
-        unsafe {
-            windows::Win32::FileSystem::CreateDirectoryW(
-                windows::core::PCWSTR::from_raw(wide_path.as_ptr()),
-                Some(&sa),
-            )
-        }
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::PermissionDenied, e))?;
-    }
+    // The instances directory sits under %LOCALAPPDATA%, which already inherits
+    // user-only ACLs from the user profile, so no extra DACL is needed here.
+    // `create_dir_all` is recursive (unlike `CreateDirectoryW`) and is a no-op
+    // when the directory already exists.
+    std::fs::create_dir_all(&dir)?;
     Ok(dir.join(format!("{identifier}.json")))
 }
 
@@ -100,16 +93,23 @@ fn unregister_instance(identifier: &str) -> std::io::Result<()> {
 }
 
 fn is_pid_alive(pid: u32) -> bool {
-    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
     use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    // SAFETY: OpenProcess is a Win32 call that returns a HANDLE or an error.
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) };
     match handle {
         Ok(h) => {
+            // SAFETY: `h` is a valid handle returned by OpenProcess.
             let alive = unsafe {
                 let mut exit_code: u32 = 0;
                 GetExitCodeProcess(h, &mut exit_code).is_ok() && exit_code == STILL_ACTIVE.0
             };
-            unsafe { let _ = CloseHandle(h) };
+            // SAFETY: closing the handle we just opened.
+            unsafe {
+                let _ = CloseHandle(h);
+            };
             alive
         }
         Err(_) => false,
@@ -174,229 +174,292 @@ impl Drop for RegistryGuard {
 // Security: restrict the named pipe to the creating user only (DACL-only)
 // ---------------------------------------------------------------------------
 
-/// Owns the buffers backing a [`SECURITY_ATTRIBUTES`] and closes the token handle.
-struct SecurityAttributesGuard {
-    sd: Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>,
-    acl: Box<MaybeUninit<ACL>>,
-    token: HANDLE,
+/// Owns a raw allocation backing an ACL with the correct layout.
+struct AclBuffer {
+    ptr: *mut ACL,
+    layout: Layout,
 }
 
-impl Drop for SecurityAttributesGuard {
+impl AclBuffer {
+    fn as_ptr(&self) -> *mut ACL {
+        self.ptr
+    }
+}
+
+impl Drop for AclBuffer {
     fn drop(&mut self) {
-        unsafe {
-            if self.token.0 != 0 {
-                let _ = CloseHandle(self.token);
+        if !self.ptr.is_null() {
+            // SAFETY: `ptr` was allocated by `alloc_zeroed` with the same `layout`
+            // and has not been freed yet.
+            unsafe {
+                dealloc(self.ptr.cast::<u8>(), self.layout);
             }
         }
     }
 }
 
-fn get_current_user_sid(
-    token: HANDLE,
-) -> std::io::Result<(*mut windows::Win32::Security::SID, HANDLE)> {
-    let mut return_length = 0u32;
-    let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
-    let mut token_user_buf = vec![0u8; return_length as usize];
-    GetTokenInformation(
-        token,
-        TokenUser,
-        Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
-        return_length,
-        &raw mut return_length,
-    )
-    .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
-    Ok((token_user.User.Sid, token))
+/// RAII wrapper for a Win32 `HANDLE` that closes it on drop.
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
 }
 
-fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
-    // Impersonate the client to get its token.
-    if ImpersonateNamedPipeClient(pipe.as_raw_handle() as _).is_err() {
-        tracing::warn!("failed to impersonate named pipe client");
-        return true; // Allow connection if impersonation fails (DACL is primary)
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if self.0.0 != 0 {
+            // SAFETY: `self.0` was returned by a successful `Open*Token` call
+            // and has not been closed yet.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+/// Owns the buffers backing a [`SECURITY_ATTRIBUTES`].
+struct SecurityAttributesGuard {
+    /// Backing storage for the `SECURITY_DESCRIPTOR`; must outlive the pipe creation.
+    _sd: Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>,
+    /// Backing storage for the ACL; must outlive the pipe creation.
+    _acl: AclBuffer,
+    /// Backing storage for the SID (referenced by the ACE we add to the ACL).
+    _sid_buf: Vec<u8>,
+    /// The token handle used to obtain the SID.
+    _token: OwnedHandle,
+}
+
+/// Opens the current process token for reading the creator's SID.
+fn open_process_token() -> std::io::Result<OwnedHandle> {
+    // SAFETY: `GetCurrentProcess` returns a pseudo-handle that does not need closing.
+    let process = unsafe { GetCurrentProcess() };
+    let mut token = HANDLE(0);
+    // SAFETY: `process` is a valid pseudo-handle; `token` points to stack-local storage.
+    unsafe { OpenProcessToken(process, TOKEN_QUERY, &raw mut token) }
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    Ok(OwnedHandle(token))
+}
+
+/// Opens the current thread's impersonation token. Must be called after
+/// [`ImpersonateNamedPipeClient`] so the thread is impersonating the peer.
+fn open_thread_impersonation_token() -> std::io::Result<OwnedHandle> {
+    // SAFETY: `GetCurrentThread` returns a pseudo-handle that does not need closing.
+    let thread = unsafe { GetCurrentThread() };
+    let mut token = HANDLE(0);
+    // SAFETY: `thread` is a valid pseudo-handle; `token` points to stack-local storage.
+    // `OpenThreadToken` reads the impersonation token from the thread, which is the
+    // client's token after `ImpersonateNamedPipeClient`.
+    unsafe { OpenThreadToken(thread, TOKEN_QUERY, true, &raw mut token) }
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    Ok(OwnedHandle(token))
+}
+
+/// Returns the SID owned by `token`, along with the backing buffer that the SID
+/// pointer references. The caller MUST keep the returned `Vec<u8>` alive for as
+/// long as the pointer is dereferenced (fix for the prior use-after-free).
+fn get_user_sid(
+    token: &OwnedHandle,
+) -> std::io::Result<(Vec<u8>, *mut windows::Win32::Security::SID)> {
+    let mut return_length = 0u32;
+    // First call is expected to fail with ERROR_INSUFFICIENT_BUFFER — it just
+    // writes the required size into `return_length`.
+    // SAFETY: `token` is a valid handle; `return_length` points to stack storage.
+    unsafe {
+        let _ = GetTokenInformation(token.raw(), TokenUser, None, 0, &raw mut return_length);
     }
 
-    // Get the impersonation token from the current thread.
-    let thread = unsafe { GetCurrentThread() };
-    let mut impersonation_token = HANDLE(0);
-    if unsafe { OpenProcessToken(thread, TOKEN_QUERY, &raw mut impersonation_token) }.is_err() {
-        tracing::warn!("failed to open thread token for impersonation");
-        let _ = RevertToSelf();
+    if return_length == 0 {
+        return Err(std::io::Error::other(
+            "GetTokenInformation returned zero size",
+        ));
+    }
+
+    let mut buf = vec![0u8; return_length as usize];
+    // SAFETY: `buf` is a valid, sized byte buffer; `token` is a valid handle.
+    unsafe {
+        GetTokenInformation(
+            token.raw(),
+            TokenUser,
+            Some(buf.as_mut_ptr().cast::<c_void>()),
+            return_length,
+            &raw mut return_length,
+        )
+    }
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // SAFETY: `buf` holds a valid `TOKEN_USER` laid out by the kernel. The `Sid`
+    // pointer it contains references memory inside `buf`, which we keep alive by
+    // returning it to the caller.
+    let sid = unsafe { (*buf.as_ptr().cast::<TOKEN_USER>()).User.Sid };
+    Ok((buf, sid))
+}
+
+/// Checks whether the connected client's SID matches the current user's SID.
+/// Returns `false` only if we proved they are different. Any failure along the
+/// way is treated as "matches" so that DACL (which is the primary defence)
+/// remains the source of truth and this serves purely as a defence-in-depth check.
+fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
+    // SAFETY: `pipe.as_raw_handle()` returns the kernel handle for the pipe server.
+    if unsafe { ImpersonateNamedPipeClient(pipe.as_raw_handle() as _) }.is_err() {
+        tracing::warn!("failed to impersonate named pipe client");
         return true;
     }
 
-    // Get the client's SID.
-    let client_sid = unsafe {
-        let mut return_length = 0u32;
-        let _ = GetTokenInformation(impersonation_token, TokenUser, None, 0, &raw mut return_length);
-        if return_length == 0 {
-            let _ = CloseHandle(impersonation_token);
-            let _ = RevertToSelf();
+    // Open the client's token from the thread (NOT the process).
+    let client_token = match open_thread_impersonation_token() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open thread impersonation token");
+            // SAFETY: we are still impersonating; revert before returning.
+            unsafe {
+                let _ = RevertToSelf();
+            }
             return true;
         }
-        let mut token_user_buf = vec![0u8; return_length as usize];
-        if GetTokenInformation(
-            impersonation_token,
-            TokenUser,
-            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
-            return_length,
-            &raw mut return_length,
-        ).is_err() {
-            let _ = CloseHandle(impersonation_token);
-            let _ = RevertToSelf();
-            return true;
-        }
-        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
-        token_user.User.Sid
     };
 
-    // Revert to self before getting our own SID.
-    let _ = RevertToSelf();
-    let _ = CloseHandle(impersonation_token);
+    let client_sid_result = get_user_sid(&client_token);
 
-    // Get current process token and compare SIDs.
-    let matches = unsafe {
-        let process = GetCurrentProcess();
-        let mut token = HANDLE(0);
-        if OpenProcessToken(process, TOKEN_QUERY, &raw mut token).is_err() {
+    // Revert impersonation as soon as we have read the client SID (or failed to).
+    // SAFETY: we called `ImpersonateNamedPipeClient` above; this undoes it.
+    unsafe {
+        let _ = RevertToSelf();
+    }
+
+    let (_client_buf, client_sid) = match client_sid_result {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to read client SID");
             return true;
         }
-        let mut return_length = 0u32;
-        let _ = GetTokenInformation(token, TokenUser, None, 0, &raw mut return_length);
-        if return_length == 0 {
-            let _ = CloseHandle(token);
-            return true;
-        }
-        let mut token_user_buf = vec![0u8; return_length as usize];
-        let result = GetTokenInformation(
-            token,
-            TokenUser,
-            Some(token_user_buf.as_mut_ptr().cast::<c_void>()),
-            return_length,
-            &raw mut return_length,
-        );
-        if result.is_err() {
-            let _ = CloseHandle(token);
-            return true;
-        }
-        let token_user = &*token_user_buf.as_ptr().cast::<TOKEN_USER>();
-        let our_sid = token_user.User.Sid;
-        let _ = CloseHandle(token);
-        EqualSid(client_sid, our_sid).as_bool()
     };
 
-    matches
+    let our_token = match open_process_token() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open process token");
+            return true;
+        }
+    };
+
+    let (_our_buf, our_sid) = match get_user_sid(&our_token) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to read own SID");
+            return true;
+        }
+    };
+
+    // SAFETY: both SID pointers are backed by `_client_buf` and `_our_buf`, which
+    // stay alive for the duration of this call.
+    unsafe { EqualSid(client_sid, our_sid) }.as_bool()
 }
 
-fn create_security_descriptor_dacl(
-    user_sid: *mut windows::Win32::Security::SID,
-) -> std::io::Result<(
-    Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>,
-    Box<MaybeUninit<ACL>>,
-)> {
-    // Allocate ACL with proper alignment for ACL structure.
-    // SAFETY: Layout::new::<ACL>() guarantees alignment required by ACL.
-    // alloc_zeroed initializes memory to zero, which is valid for ACL.
-    let acl_layout = Layout::new::<ACL>();
-    let sid_length = GetLengthSid(user_sid) as usize;
-    let acl_size = (8 + 4 + 4 + sid_length + 3) & !3; // DWORD-aligned
-    let acl_ptr = unsafe { alloc_zeroed(acl_layout) as *mut ACL };
+/// Allocates and initializes the ACL granting the given SID access.
+/// Fixes the prior heap overflow: the layout now matches the `acl_size` we pass
+/// to `InitializeAcl`, not `sizeof::<ACL>()`.
+fn build_acl(user_sid: *mut windows::Win32::Security::SID) -> std::io::Result<AclBuffer> {
+    // SAFETY: `user_sid` points to a valid SID owned by the caller's buffer.
+    let sid_length = unsafe { GetLengthSid(user_sid) } as usize;
 
-    // Initialize ACL or abort if allocation failed.
-    if acl_ptr.is_null() {
-        std::alloc::dealloc(acl_ptr as *mut u8, acl_layout);
+    // ACL header (8) + ACE header (4) + ACE access mask (4) + SID, rounded up
+    // to a DWORD boundary. This is exactly what `InitializeAcl` will expect.
+    let acl_size = (8 + 4 + 4 + sid_length + 3) & !3;
+
+    let layout = Layout::from_size_align(acl_size, mem::align_of::<ACL>())
+        .map_err(|e| std::io::Error::other(format!("invalid ACL layout: {e}")))?;
+
+    // SAFETY: `layout` has a non-zero size and an alignment that is a power of two.
+    let ptr = unsafe { alloc_zeroed(layout) }.cast::<ACL>();
+    if ptr.is_null() {
+        // Do NOT dealloc a null pointer — it is UB. Just return.
         return Err(std::io::Error::other("failed to allocate ACL"));
     }
 
-    // SAFETY: acl_ptr is valid, non-null, and properly aligned for ACL.
-    // The size calculation ensures DWORD alignment (4-byte boundary).
-    unsafe {
-        InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-        AddAccessAllowedAce(acl_ptr, ACL_REVISION, (GENERIC_READ | GENERIC_WRITE).0, user_sid)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-    }
+    // Wrap immediately so any ? below runs the destructor.
+    let buffer = AclBuffer { ptr, layout };
 
-    // Allocate security descriptor with proper alignment.
-    // SAFETY: Box::new(MaybeUninit::uninit()) provides properly aligned,
-    // uninitialized memory for SECURITY_DESCRIPTOR.
+    // SAFETY: `ptr` is valid, aligned, zeroed memory of exactly `acl_size` bytes.
+    unsafe { InitializeAcl(buffer.as_ptr(), acl_size as u32, ACL_REVISION) }
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // SAFETY: `buffer.as_ptr()` is a freshly-initialised ACL with room for this ACE
+    // (our `acl_size` accounted for the SID length), and `user_sid` is valid.
+    unsafe {
+        AddAccessAllowedAce(
+            buffer.as_ptr(),
+            ACL_REVISION,
+            (GENERIC_READ | GENERIC_WRITE).0,
+            user_sid,
+        )
+    }
+    .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    Ok(buffer)
+}
+
+/// Allocates a `SECURITY_DESCRIPTOR` and attaches the given ACL as its DACL.
+fn build_security_descriptor(
+    acl: &AclBuffer,
+) -> std::io::Result<Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>> {
     let sd_box = Box::new(MaybeUninit::<windows::Win32::Security::SECURITY_DESCRIPTOR>::uninit());
     let sd_ptr = PSECURITY_DESCRIPTOR(sd_box.as_ptr() as *mut c_void);
 
-    // SAFETY: sd_ptr points to properly aligned, valid memory for SECURITY_DESCRIPTOR.
-    unsafe {
-        InitializeSecurityDescriptor(sd_ptr, 1)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-        SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-    }
+    // SAFETY: `sd_ptr` points to properly aligned, writable storage for a
+    // `SECURITY_DESCRIPTOR`; `InitializeSecurityDescriptor` will initialise it.
+    unsafe { InitializeSecurityDescriptor(sd_ptr, 1) }
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
-    // Wrap ACL pointer in Box for RAII cleanup.
-    let acl_box = unsafe { Box::from_raw(acl_ptr) };
-    Ok((sd_box, acl_box))
+    // SAFETY: `sd_ptr` has just been initialised; `acl.as_ptr()` is a valid ACL.
+    unsafe { SetSecurityDescriptorDacl(sd_ptr, true, Some(acl.as_ptr()), false) }
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    Ok(sd_box)
 }
 
 fn create_user_only_security_attributes()
 -> std::io::Result<(SECURITY_ATTRIBUTES, SecurityAttributesGuard)> {
-    unsafe {
-        let process = GetCurrentProcess();
-        let mut token = HANDLE(0);
-        OpenProcessToken(process, TOKEN_QUERY, &raw mut token)
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
+    let token = open_process_token()?;
+    let (sid_buf, user_sid) = get_user_sid(&token)?;
+    let acl = build_acl(user_sid)?;
+    let sd = build_security_descriptor(&acl)?;
 
-        // Guard created immediately so CloseHandle is called on any early return.
-        let mut guard = SecurityAttributesGuard {
-            sd: Box::new(MaybeUninit::uninit()),
-            acl: Box::new(MaybeUninit::uninit()),
-            token,
-        };
+    let sd_ptr = PSECURITY_DESCRIPTOR(sd.as_ptr() as *mut c_void);
 
-        let (user_sid, _token) = get_current_user_sid(guard.token)?;
-        let (sd, acl) = create_security_descriptor_dacl(user_sid)?;
-        guard.sd = sd;
-        guard.acl = acl;
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
+            .expect("SECURITY_ATTRIBUTES size must fit in u32"),
+        lpSecurityDescriptor: sd_ptr.0,
+        bInheritHandle: windows::Win32::Foundation::BOOL(0),
+    };
 
-        // SAFETY: sd box is valid, uninitialized memory that InitializeSecurityDescriptor
-        // will write to. PSECURITY_DESCRIPTOR is *mut SECURITY_DESCRIPTOR.
-        let sd_ptr = PSECURITY_DESCRIPTOR(guard.sd.as_ptr() as *mut c_void);
+    let guard = SecurityAttributesGuard {
+        _sd: sd,
+        _acl: acl,
+        _sid_buf: sid_buf,
+        _token: token,
+    };
 
-        let sa = SECURITY_ATTRIBUTES {
-            nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
-                .expect("SECURITY_ATTRIBUTES size must fit in u32"),
-            lpSecurityDescriptor: sd_ptr.0,
-            bInheritHandle: windows::Win32::Foundation::BOOL(0),
-        };
-
-        Ok((sa, guard))
-    }
+    Ok((sa, guard))
 }
 
 // ---------------------------------------------------------------------------
 
 pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error> {
-    let server = match create_user_only_security_attributes() {
-        Ok((mut sa, _sec_guard)) => {
-            // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
-            // the duration of this call.  The kernel copies the security descriptor, so
-            // `_sec_guard` may be dropped after the pipe is created.
-            unsafe {
-                ServerOptions::new()
-                    .first_pipe_instance(true)
-                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-                    .create_with_security_attributes_raw(pipe_path, (&raw mut sa).cast::<c_void>())
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                path = %pipe_path.display(),
-                error = %e,
-                "failed to create secure pipe, falling back to default security"
-            );
-            ServerOptions::new()
-                .first_pipe_instance(true)
-                .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-                .create(pipe_path)
-        }
+    // Refuse to downgrade security. If the DACL setup fails we fail hard rather
+    // than creating a pipe with the default (broader) DACL.
+    let (mut sa, _sec_guard) = create_user_only_security_attributes().map_err(Error::from)?;
+
+    // SAFETY: `sa` and its backing buffers (owned by `_sec_guard`) are valid for
+    // the duration of this call. The kernel copies the security descriptor, so
+    // `_sec_guard` may be dropped after the pipe is created.
+    let server = unsafe {
+        ServerOptions::new()
+            .first_pipe_instance(true)
+            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+            .create_with_security_attributes_raw(pipe_path, (&raw mut sa).cast::<c_void>())
     }
     .map_err(Error::from)?;
 
@@ -454,22 +517,48 @@ async fn accept_loop(
     let pipe_path = socket_path(identifier);
 
     loop {
+        // A failure here means the current pipe is genuinely dead (handle closed,
+        // etc.) — propagate it so the supervising task can react.
         server.connect().await?;
 
-        let next_server = match create_user_only_security_attributes() {
-            Ok((mut sa, _sec_guard)) => unsafe {
+        // Build the next pipe instance. Transient failures (e.g. `ERROR_PIPE_BUSY`
+        // or handle exhaustion) must NOT take the whole server down: log and
+        // retry after a short back-off. Silent downgrade to default DACL is
+        // refused — we'd rather drop a connection than weaken security.
+        let next_server = loop {
+            let sa_result = create_user_only_security_attributes();
+            let (mut sa, _sec_guard) = match sa_result {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "failed to build security attributes, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    continue;
+                }
+            };
+
+            // SAFETY: `sa` and its backing buffers are valid for this call.
+            let created = unsafe {
                 ServerOptions::new()
                     .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
                     .create_with_security_attributes_raw(&pipe_path, (&raw mut sa).cast::<c_void>())
-            },
-            Err(e) => {
-                tracing::warn!("failed to create secure pipe: {e}, falling back to default security");
-                ServerOptions::new()
-                    .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-                    .create(&pipe_path)
+            };
+
+            match created {
+                Ok(s) => break s,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %pipe_path.display(),
+                        error = %e,
+                        "transient failure creating next pipe instance, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    continue;
+                }
             }
-        }
-        .map_err(Error::from)?;
+        };
 
         let current = server;
         server = next_server;
@@ -605,17 +694,14 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     async fn test_dacl_regression_every_pipe_instance_has_dacl_with_one_ace() {
-        use windows::Win32::Foundation::PHANDLE;
         use windows::Win32::Storage::FileSystem::PACL;
 
         let pipe = unique_pipe_path();
         let (server, guard) = bind(&pipe).expect("bind test pipe");
 
-        // Get the raw handle from the NamedPipeServer.
         let raw_handle = server.as_raw_handle();
         let handle = HANDLE(raw_handle as *mut c_void);
 
-        // Retrieve the DACL via GetSecurityInfo.
         let mut dacl_ptr: PACL = PACL::default();
         let sd_result = unsafe {
             GetSecurityInfo(
@@ -636,7 +722,6 @@ mod tests {
             "DACL pointer must not be NULL — every pipe instance must have a DACL"
         );
 
-        // Query the ACL size to get the ACE count.
         let mut acl_size = AclSizeInformation::default();
         let size_result = unsafe {
             GetAclInformation(
@@ -652,26 +737,76 @@ mod tests {
             "DACL must contain exactly 1 ACE (owner-only access)"
         );
 
-        // Clean up the security descriptor allocated by GetSecurityInfo.
         unsafe {
-            let _ = windows::Win32::Security::LocalFree(
-                windows::Win32::Foundation::HLOCAL(dacl_ptr.0 as *mut c_void),
-            );
+            let _ = windows::Win32::Security::LocalFree(windows::Win32::Foundation::HLOCAL(
+                dacl_ptr.0 as *mut c_void,
+            ));
         }
 
-        // Now connect a client to trigger the accept_loop and create a new server instance.
-        // We need to poll the accept futures so the accept_loop can run.
-        let client = ClientOptions::new().open(&pipe).expect("client should connect");
-
-        // Give the accept_loop time to spawn the connection handler.
+        // Trigger a new accept cycle and drop the server.
+        let _client = ClientOptions::new()
+            .open(&pipe)
+            .expect("client should connect");
         tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Close our server handle — this allows the accept_loop to exit its current
-        // connect() call and create a new instance with its own DACL.
         drop(server);
         drop(guard);
-
-        // Brief pause to let the accept_loop cycle.
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[cfg(windows)]
+    async fn test_bound_pipe_carries_user_only_dacl() {
+        use windows::Win32::Storage::FileSystem::PACL;
+
+        let pipe = unique_pipe_path();
+        let (server, guard) = bind(&pipe).expect("bind test pipe");
+
+        let raw_handle = server.as_raw_handle();
+        let handle = HANDLE(raw_handle as *mut c_void);
+
+        // Retrieve the DACL from the freshly-bound pipe and assert:
+        //   - the DACL pointer is non-NULL (the pipe is not running with a NULL DACL),
+        //   - the DACL contains exactly one ACE (our owner-only ACE).
+        let mut dacl_ptr: PACL = PACL::default();
+        let rc = unsafe {
+            GetSecurityInfo(
+                handle,
+                windows::Win32::Security::SE_KERNEL_OBJECT,
+                SE_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                Some(&mut dacl_ptr),
+                None,
+                None,
+                None,
+            )
+        };
+        assert_eq!(rc, Ok(()), "GetSecurityInfo must succeed on a bound pipe");
+        assert!(!dacl_ptr.is_null(), "bound pipe must carry a non-NULL DACL");
+
+        let mut info = AclSizeInformation::default();
+        let rc = unsafe {
+            GetAclInformation(
+                dacl_ptr,
+                &mut info as *mut _ as *mut c_void,
+                std::mem::size_of::<AclSizeInformation>() as u32,
+                AclSizeInformation,
+            )
+        };
+        assert_eq!(rc, Ok(()), "GetAclInformation must succeed");
+        assert_eq!(
+            info.AceCount, 1,
+            "bound pipe DACL must contain exactly one ACE (owner-only)"
+        );
+
+        unsafe {
+            let _ = windows::Win32::Security::LocalFree(windows::Win32::Foundation::HLOCAL(
+                dacl_ptr.0 as *mut c_void,
+            ));
+        }
+
+        drop(server);
+        drop(guard);
     }
 }

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -17,14 +17,18 @@ use std::time::Duration;
 #[allow(unused_imports)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
-use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
-use windows::Win32::Security::{
-    ACL, ACL_REVISION, AclSizeInformation, AddAccessAllowedAce, EqualSid, GetAclInformation,
-    GetLengthSid, GetSecurityInfo, GetTokenInformation, ImpersonateNamedPipeClient, InitializeAcl,
-    InitializeSecurityDescriptor, OpenThreadToken, PSECURITY_DESCRIPTOR, RevertToSelf,
-    SE_DACL_SECURITY_INFORMATION, SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl, TOKEN_QUERY,
-    TOKEN_USER, TokenUser,
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_SUCCESS, GENERIC_READ, GENERIC_WRITE, HANDLE, HLOCAL,
 };
+use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+use windows::Win32::Security::{
+    ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AclSizeInformation, AddAccessAllowedAce, EqualSid,
+    GetAclInformation, GetLengthSid, GetTokenInformation, ImpersonateNamedPipeClient,
+    InitializeAcl, InitializeSecurityDescriptor, OpenThreadToken, PACL, PSECURITY_DESCRIPTOR,
+    RevertToSelf, SE_DACL_SECURITY_INFORMATION, SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl,
+    TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+use windows::Win32::System::Memory::LocalFree;
 use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken};
 
 pub fn socket_path(identifier: &str) -> PathBuf {
@@ -694,53 +698,49 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     async fn test_dacl_regression_every_pipe_instance_has_dacl_with_one_ace() {
-        use windows::Win32::Storage::FileSystem::PACL;
-
         let pipe = unique_pipe_path();
         let (server, guard) = bind(&pipe).expect("bind test pipe");
 
         let raw_handle = server.as_raw_handle();
-        let handle = HANDLE(raw_handle as *mut c_void);
+        let handle = HANDLE(raw_handle as isize);
 
         let mut dacl_ptr: PACL = PACL::default();
+        let mut sd_ptr = PSECURITY_DESCRIPTOR::default();
         let sd_result = unsafe {
             GetSecurityInfo(
                 handle,
-                windows::Win32::Security::SE_KERNEL_OBJECT,
+                SE_KERNEL_OBJECT,
                 SE_DACL_SECURITY_INFORMATION,
                 None,
                 None,
                 Some(&mut dacl_ptr),
                 None,
-                None,
-                None,
+                Some(&mut sd_ptr),
             )
         };
-        assert_eq!(sd_result, Ok(()), "GetSecurityInfo should succeed");
+        assert_eq!(sd_result, ERROR_SUCCESS, "GetSecurityInfo should succeed");
         assert!(
             !dacl_ptr.is_null(),
             "DACL pointer must not be NULL — every pipe instance must have a DACL"
         );
 
-        let mut acl_size = AclSizeInformation::default();
+        let mut acl_size = ACL_SIZE_INFORMATION::default();
         let size_result = unsafe {
             GetAclInformation(
                 dacl_ptr,
                 &mut acl_size as *mut _ as *mut c_void,
-                std::mem::size_of::<AclSizeInformation>() as u32,
+                std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
                 AclSizeInformation,
             )
         };
-        assert_eq!(size_result, Ok(()), "GetAclInformation should succeed");
+        size_result.expect("GetAclInformation should succeed");
         assert_eq!(
             acl_size.AceCount, 1,
             "DACL must contain exactly 1 ACE (owner-only access)"
         );
 
         unsafe {
-            let _ = windows::Win32::Security::LocalFree(windows::Win32::Foundation::HLOCAL(
-                dacl_ptr.0 as *mut c_void,
-            ));
+            let _ = LocalFree(HLOCAL(sd_ptr.0));
         }
 
         // Trigger a new accept cycle and drop the server.
@@ -757,53 +757,52 @@ mod tests {
     #[serial]
     #[cfg(windows)]
     async fn test_bound_pipe_carries_user_only_dacl() {
-        use windows::Win32::Storage::FileSystem::PACL;
-
         let pipe = unique_pipe_path();
         let (server, guard) = bind(&pipe).expect("bind test pipe");
 
         let raw_handle = server.as_raw_handle();
-        let handle = HANDLE(raw_handle as *mut c_void);
+        let handle = HANDLE(raw_handle as isize);
 
         // Retrieve the DACL from the freshly-bound pipe and assert:
         //   - the DACL pointer is non-NULL (the pipe is not running with a NULL DACL),
         //   - the DACL contains exactly one ACE (our owner-only ACE).
         let mut dacl_ptr: PACL = PACL::default();
+        let mut sd_ptr = PSECURITY_DESCRIPTOR::default();
         let rc = unsafe {
             GetSecurityInfo(
                 handle,
-                windows::Win32::Security::SE_KERNEL_OBJECT,
+                SE_KERNEL_OBJECT,
                 SE_DACL_SECURITY_INFORMATION,
                 None,
                 None,
                 Some(&mut dacl_ptr),
                 None,
-                None,
-                None,
+                Some(&mut sd_ptr),
             )
         };
-        assert_eq!(rc, Ok(()), "GetSecurityInfo must succeed on a bound pipe");
+        assert_eq!(
+            rc, ERROR_SUCCESS,
+            "GetSecurityInfo must succeed on a bound pipe"
+        );
         assert!(!dacl_ptr.is_null(), "bound pipe must carry a non-NULL DACL");
 
-        let mut info = AclSizeInformation::default();
+        let mut info = ACL_SIZE_INFORMATION::default();
         let rc = unsafe {
             GetAclInformation(
                 dacl_ptr,
                 &mut info as *mut _ as *mut c_void,
-                std::mem::size_of::<AclSizeInformation>() as u32,
+                std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
                 AclSizeInformation,
             )
         };
-        assert_eq!(rc, Ok(()), "GetAclInformation must succeed");
+        rc.expect("GetAclInformation must succeed");
         assert_eq!(
             info.AceCount, 1,
             "bound pipe DACL must contain exactly one ACE (owner-only)"
         );
 
         unsafe {
-            let _ = windows::Win32::Security::LocalFree(windows::Win32::Foundation::HLOCAL(
-                dacl_ptr.0 as *mut c_void,
-            ));
+            let _ = LocalFree(HLOCAL(sd_ptr.0));
         }
 
         drop(server);

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -16,10 +16,11 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
 use windows::Win32::Security::{
-    ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetLengthSid, GetTokenInformation,
-    ImpersonateNamedPipeClient, InitializeAcl, InitializeSecurityDescriptor,
-    PSECURITY_DESCRIPTOR, RevertToSelf, SECURITY_ATTRIBUTES,
-    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetAclInformation, GetLengthSid,
+    GetSecurityInfo, GetTokenInformation, ImpersonateNamedPipeClient, InitializeAcl,
+    InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, RevertToSelf, SECURITY_ATTRIBUTES,
+    SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser, AclSizeInformation,
+    SE_DACL_SECURITY_INFORMATION,
 };
 use windows::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken};
 
@@ -598,5 +599,79 @@ mod tests {
 
         handle.abort();
         let _ = handle.await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[cfg(windows)]
+    async fn test_dacl_regression_every_pipe_instance_has_dacl_with_one_ace() {
+        use windows::Win32::Foundation::PHANDLE;
+        use windows::Win32::Storage::FileSystem::PACL;
+
+        let pipe = unique_pipe_path();
+        let (server, guard) = bind(&pipe).expect("bind test pipe");
+
+        // Get the raw handle from the NamedPipeServer.
+        let raw_handle = server.as_raw_handle();
+        let handle = HANDLE(raw_handle as *mut c_void);
+
+        // Retrieve the DACL via GetSecurityInfo.
+        let mut dacl_ptr: PACL = PACL::default();
+        let sd_result = unsafe {
+            GetSecurityInfo(
+                handle,
+                windows::Win32::Security::SE_KERNEL_OBJECT,
+                SE_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                Some(&mut dacl_ptr),
+                None,
+                None,
+                None,
+            )
+        };
+        assert_eq!(sd_result, Ok(()), "GetSecurityInfo should succeed");
+        assert!(
+            !dacl_ptr.is_null(),
+            "DACL pointer must not be NULL — every pipe instance must have a DACL"
+        );
+
+        // Query the ACL size to get the ACE count.
+        let mut acl_size = AclSizeInformation::default();
+        let size_result = unsafe {
+            GetAclInformation(
+                dacl_ptr,
+                &mut acl_size as *mut _ as *mut c_void,
+                std::mem::size_of::<AclSizeInformation>() as u32,
+                AclSizeInformation,
+            )
+        };
+        assert_eq!(size_result, Ok(()), "GetAclInformation should succeed");
+        assert_eq!(
+            acl_size.AceCount, 1,
+            "DACL must contain exactly 1 ACE (owner-only access)"
+        );
+
+        // Clean up the security descriptor allocated by GetSecurityInfo.
+        unsafe {
+            let _ = windows::Win32::Security::LocalFree(
+                windows::Win32::Foundation::HLOCAL(dacl_ptr.0 as *mut c_void),
+            );
+        }
+
+        // Now connect a client to trigger the accept_loop and create a new server instance.
+        // We need to poll the accept futures so the accept_loop can run.
+        let client = ClientOptions::new().open(&pipe).expect("client should connect");
+
+        // Give the accept_loop time to spawn the connection handler.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Close our server handle — this allows the accept_loop to exit its current
+        // connect() call and create a new instance with its own DACL.
+        drop(server);
+        drop(guard);
+
+        // Brief pause to let the accept_loop cycle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -6,6 +6,7 @@ use crate::eval::EvalEngine;
 use crate::protocol::Response;
 use crate::recorder::Recorder;
 
+use std::alloc::{alloc_zeroed, Layout};
 use std::ffi::c_void;
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -172,11 +173,9 @@ impl Drop for RegistryGuard {
 // ---------------------------------------------------------------------------
 
 /// Owns the buffers backing a [`SECURITY_ATTRIBUTES`] and closes the token handle.
-/// Must outlive the `SECURITY_ATTRIBUTES` pointer passed to Windows APIs.
-#[allow(dead_code)]
 struct SecurityAttributesGuard {
-    sd: Vec<u8>,
-    acl: Vec<u8>,
+    sd: Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>,
+    acl: Box<MaybeUninit<ACL>>,
     token: HANDLE,
 }
 
@@ -208,39 +207,54 @@ fn get_current_user_sid(
     Ok((token_user.User.Sid, token))
 }
 
-#[allow(clippy::cast_ptr_alignment)]
 fn create_security_descriptor_dacl(
     user_sid: *mut windows::Win32::Security::SID,
-) -> std::io::Result<(Vec<u8>, Vec<u8>, *mut ACL)> {
+) -> std::io::Result<(
+    Box<MaybeUninit<windows::Win32::Security::SECURITY_DESCRIPTOR>>,
+    Box<MaybeUninit<ACL>>,
+)> {
+    // Allocate ACL with proper alignment for ACL structure.
+    // SAFETY: Layout::new::<ACL>() guarantees alignment required by ACL.
+    // alloc_zeroed initializes memory to zero, which is valid for ACL.
+    let acl_layout = Layout::new::<ACL>();
     let sid_length = GetLengthSid(user_sid) as usize;
-    let acl_size = (8 + 4 + 4 + sid_length + 3) & !3;
-    let mut acl_buf = vec![0u8; acl_size];
-    let acl_ptr = acl_buf.as_mut_ptr().cast::<ACL>();
-    InitializeAcl(
-        acl_ptr,
-        acl_size.try_into().map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "ACL size too large")
-        })?,
-        ACL_REVISION,
-    )
-    .map_err(|e| std::io::Error::other(e.to_string()))?;
-    AddAccessAllowedAce(
-        acl_ptr,
-        ACL_REVISION,
-        (GENERIC_READ | GENERIC_WRITE).0,
-        user_sid,
-    )
-    .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut sd_buf = vec![0u8; 40];
-    let sd_ptr = PSECURITY_DESCRIPTOR(sd_buf.as_mut_ptr().cast::<c_void>());
-    InitializeSecurityDescriptor(sd_ptr, 1)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    Ok((sd_buf, acl_buf, acl_ptr))
+    let acl_size = (8 + 4 + 4 + sid_length + 3) & !3; // DWORD-aligned
+    let acl_ptr = unsafe { alloc_zeroed(acl_layout) as *mut ACL };
+
+    // Initialize ACL or abort if allocation failed.
+    if acl_ptr.is_null() {
+        std::alloc::dealloc(acl_ptr as *mut u8, acl_layout);
+        return Err(std::io::Error::other("failed to allocate ACL"));
+    }
+
+    // SAFETY: acl_ptr is valid, non-null, and properly aligned for ACL.
+    // The size calculation ensures DWORD alignment (4-byte boundary).
+    unsafe {
+        InitializeAcl(acl_ptr, acl_size as u32, ACL_REVISION)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        AddAccessAllowedAce(acl_ptr, ACL_REVISION, (GENERIC_READ | GENERIC_WRITE).0, user_sid)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+    }
+
+    // Allocate security descriptor with proper alignment.
+    // SAFETY: Box::new(MaybeUninit::uninit()) provides properly aligned,
+    // uninitialized memory for SECURITY_DESCRIPTOR.
+    let sd_box = Box::new(MaybeUninit::<windows::Win32::Security::SECURITY_DESCRIPTOR>::uninit());
+    let sd_ptr = PSECURITY_DESCRIPTOR(sd_box.as_ptr() as *mut c_void);
+
+    // SAFETY: sd_ptr points to properly aligned, valid memory for SECURITY_DESCRIPTOR.
+    unsafe {
+        InitializeSecurityDescriptor(sd_ptr, 1)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        SetSecurityDescriptorDacl(sd_ptr, true, Some(acl_ptr), false)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+    }
+
+    // Wrap ACL pointer in Box for RAII cleanup.
+    let acl_box = unsafe { Box::from_raw(acl_ptr) };
+    Ok((sd_box, acl_box))
 }
 
-#[allow(clippy::cast_ptr_alignment)]
 fn create_user_only_security_attributes()
 -> std::io::Result<(SECURITY_ATTRIBUTES, SecurityAttributesGuard)> {
     unsafe {
@@ -251,20 +265,24 @@ fn create_user_only_security_attributes()
 
         // Guard created immediately so CloseHandle is called on any early return.
         let mut guard = SecurityAttributesGuard {
-            sd: Vec::new(),
-            acl: Vec::new(),
+            sd: Box::new(MaybeUninit::uninit()),
+            acl: Box::new(MaybeUninit::uninit()),
             token,
         };
 
         let (user_sid, _token) = get_current_user_sid(guard.token)?;
-        let (sd, acl, _acl_ptr) = create_security_descriptor_dacl(user_sid)?;
+        let (sd, acl) = create_security_descriptor_dacl(user_sid)?;
         guard.sd = sd;
         guard.acl = acl;
+
+        // SAFETY: sd box is valid, uninitialized memory that InitializeSecurityDescriptor
+        // will write to. PSECURITY_DESCRIPTOR is *mut SECURITY_DESCRIPTOR.
+        let sd_ptr = PSECURITY_DESCRIPTOR(guard.sd.as_ptr() as *mut c_void);
 
         let sa = SECURITY_ATTRIBUTES {
             nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
                 .expect("SECURITY_ATTRIBUTES size must fit in u32"),
-            lpSecurityDescriptor: guard.sd.as_mut_ptr().cast::<c_void>(),
+            lpSecurityDescriptor: sd_ptr.0,
             bInheritHandle: windows::Win32::Foundation::BOOL(0),
         };
 
@@ -343,9 +361,12 @@ async fn accept_loop(
     loop {
         server.connect().await?;
 
-        let next_server = ServerOptions::new()
-            .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
-            .create(&pipe_path)?;
+        let (sa, _sec_guard) = create_user_only_security_attributes()?;
+        let next_server = unsafe {
+            ServerOptions::new()
+                .pipe_mode(tokio::net::windows::named_pipe::PipeMode::Byte)
+                .create_with_security_attributes_raw(&pipe_path, (&raw mut sa).cast::<c_void>())?
+        };
 
         let current = server;
         server = next_server;


### PR DESCRIPTION
## Summary

Add Windows support for tauri-pilot using Named Pipe IPC transport, replacing Unix domain sockets on Windows while keeping full Linux/macOS compatibility.

## What changed

| Platform | Transport | Discovery | Security |
|----------|-----------|-----------|----------|
| Linux/macOS | Unix domain socket (unchanged) | XDG_RUNTIME_DIR → /tmp, mtime+uid | 0o600 + peer_cred |
| Windows | Named Pipe (`\\\\.\\pipe\\tauri-pilot-{id}`) | %LOCALAPPDATA%\\tauri-pilot\\instances.json | User-only DACL |

### Files changed
- `crates/tauri-plugin-pilot/src/server/` — extracted to `mod.rs` + `unix.rs` + `windows.rs` (+DACL)
- `crates/tauri-pilot-cli/src/client/` — extracted to `mod.rs` + `unix.rs` + `windows.rs`
- `crates/tauri-pilot-cli/src/main.rs` — `resolve_socket()` with Windows registry branch
- `crates/tauri-plugin-pilot/src/lib.rs` — `#[cfg(any(unix, windows))]` gates
- `crates/*/Cargo.toml` — platform-gated `libc`, `windows` crate with features
- `.github/workflows/ci.yml` — `windows-latest` added
- `README.md` — Windows badge + WebView2 mention

### Key implementation details

**User-only DACL** (`server/windows.rs`):
- `create_user_only_security_attributes()` opens process token, gets user SID, creates ACL with single ACE granting `GENERIC_READ | GENERIC_WRITE`, attaches to security descriptor
- Passed to `ServerOptions::create_with_security_attributes_raw()`

**Registry-based discovery** (`server/windows.rs` + `main.rs`):
- Server writes `{pipe, pid, created_at}` to `%LOCALAPPDATA%\\tauri-pilot\\instances.json` on bind
- Server removes entry on drop via `RegistryGuard`
- CLI reads registry to find correct pipe for multi-instance support

**Named Pipe accept loop** (`server/windows.rs`):
- Uses `connect() → create next → spawn` pattern (different from Unix `accept()`)
- Each connection spawns a tokio task with shared `Arc<Ctx>`

## Testing

- `cargo check --workspace` passes on rustc 1.95.0
- `cargo fmt --all -- --check` passes
- Platform-specific tests in `server/windows.rs` and `client/windows.rs`
- CI matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`

## Known items for review

1. **Commit scopes**: Use `feat(windows)` instead of `feat(plugin)`/`feat(cli)` — can amend if strict CONTRIBUTING.md compliance needed
2. **Module sizes**: `server/windows.rs` (399 lines) and `server/unix.rs` (339 lines) exceed 150-line guideline — inherited from original `server.rs` (455 lines)
3. **Function size**: `create_user_only_security_attributes()` is ~65 lines (limit: 50)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows support: named‑pipe IPC added so plugin and CLI work on Windows and Unix.

* **CI/Testing**
  * CI check matrix now runs on Windows; platform‑gated and more reliable tests for parallel runs.

* **Documentation**
  * README, badges, and architecture docs updated to include Windows/WebView2 and IPC changes.

* **Bug Fixes / Security**
  * Windows IPC security hardening (access controls/SID checks) and various platform correctness fixes.

* **Other**
  * Protocol ID widened to accept JSON values; manifests/dependencies adjusted for multi‑platform builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows IPC via Named Pipes with strict per‑user security and per‑instance discovery, keeping Unix sockets on Linux/macOS. The server core is now shared across platforms; CLI, tests, CI, and docs updated.

- New Features
  - Windows transport: Named Pipes at \\.\pipe\tauri-pilot-{id} with a user‑only DACL, per‑connection client SID validation, and a 1MB request line cap.
  - Discovery: per‑instance files at %LOCALAPPDATA%\tauri-pilot\instances\*.json; the CLI picks the newest alive instance.
  - Shared server core in server/mod.rs; platform servers/clients in unix.rs and windows.rs (Windows accept loop: connect → create next → spawn with retry/backoff).

- Bug Fixes
  - Protocol/server: JSON‑RPC id is now a JSON value; parse errors return id:null; per‑line reads are hard‑capped to prevent OOM on newline‑less floods.
  - Windows security: fixed ACL allocation overflow and SID lifetime/use‑after‑free; peer SID check uses the thread token; user‑only DACL applied to every pipe instance with no default‑DACL fallback; accept loop handles transient creation errors with retry/backoff; added DACL regression test.
  - Windows API: corrected `windows` 0.52 API paths and feature flags, free security descriptors via LocalFree, compare to ERROR_SUCCESS, handle CloseHandle properly, and fix STILL_ACTIVE cast in PID checks.
  - Tests/CI/build/docs: stabilized Windows tests (`serial_test`, unique pipe/socket names, CRLF‑safe assertions); cfg‑gated deps (`libc` on Unix, `windows` on Windows); Linux `enigo` marked `optional = true`; CI adds windows‑latest; README mentions Windows/WebView2 and updates the architecture diagram; plugin description now “IPC JSON‑RPC”; `init()` docs cover Windows Named Pipe behavior.

<sup>Written for commit 2de6e6b99141ba31db8c7972d5237705cc725fe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

