### PR TITLE
docs: fix cross-file inconsistencies and dead links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Batch scenario runner** — `tauri-pilot run <scenario.toml>` executes declarative TOML scenarios with 18 action types (click, fill, type, press, select, check, scroll, navigate, wait, watch, eval, screenshot, assert-text, assert-exists, assert-visible, assert-hidden, assert-value, assert-url). Supports `fail_fast` (default true), `--no-fail-fast` override, `--junit <file>` for JUnit XML output, and auto-captures failure screenshots to `./tauri-pilot-failures/`. Exit code 0 = all pass, 1 = any failure. Example: `docs/examples/login-flow.toml` ([#62])
+- `connect.timeout_ms` in TOML scenarios — wraps `Client::connect` in `tokio::time::timeout` ([#63])
+- `global_timeout_ms` in TOML scenarios — hard deadline around `run_scenario` ([#63])
+- Per-step `timeout_ms` applied to all non-`wait`/`watch` actions via `tokio::time::timeout` ([#63])
+- `<testsuites>` JUnit XML root now carries `tests`, `failures`, `errors`, `skipped`, `time` aggregate attributes for CI reporters (Jenkins, GitHub Actions, Allure) ([#63])
+
+### Fixed
+
+- `assert-exists` now verifies the `visible` key is present in the RPC response to catch missing DOM elements ([#63])
+
 ## [0.4.0] - 2026-04-17
 
 ### Added
@@ -173,6 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#52]: https://github.com/mpiton/tauri-pilot/pull/52
 [#53]: https://github.com/mpiton/tauri-pilot/pull/53
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
+[#62]: https://github.com/mpiton/tauri-pilot/pull/62
+[#63]: https://github.com/mpiton/tauri-pilot/pull/63
 [Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This document covers the development w
 
 - Rust 1.95.0+ with edition 2024
 - A Tauri v2 app for testing (or use the examples)
-- Linux (WebKitGTK) — macOS/Windows not yet supported
+- Linux (WebKitGTK) or macOS (WebKit) — Windows planned
 
 ## Development Setup
 
@@ -39,7 +39,7 @@ cargo test --workspace
 
 ## Architecture
 
-See [ARCHI.md](ARCHI.md) for architecture decisions and module structure.
+See the [Architecture guide](https://mpiton.github.io/tauri-pilot/guides/architecture/) for design decisions and module structure.
 
 ## `run` vs `record`/`replay`
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ the JavaScript do not need escaping.
 | Command | Description |
 |---------|-------------|
 | `ping` | Health check |
+| `windows` | List all open windows (multi-window apps) |
 | `snapshot` | Accessibility tree with refs (`--save` to persist) |
 | `diff` | Compare snapshots, show only changes |
 | `click` | Click an element |
@@ -163,7 +164,10 @@ the JavaScript do not need escaping.
 | `screenshot` | Capture as PNG |
 | `wait` | Wait for element to appear/disappear |
 | `navigate` | Change the WebView URL |
+| `url` | Get current URL |
+| `title` | Get current page title |
 | `state` | Get URL, title, viewport, scroll |
+| `forms` | Dump all form fields on the page |
 | `assert` | One-step verification (text, visible, hidden, value, count, checked, contains, url) |
 | `watch` | Watch for DOM mutations |
 | `storage` | Read/write localStorage and sessionStorage (`--session`) |
@@ -171,6 +175,7 @@ the JavaScript do not need escaping.
 | `network` | Capture and display network requests |
 | `record` | Record interactions (`start`, `stop --output`, `status`) |
 | `replay` | Replay recorded session (`--export sh` for shell script) |
+| `run` | Execute a declarative TOML scenario (`--junit` for CI output) |
 | `mcp` | Start a Model Context Protocol server over stdio |
 
 ## For AI Agents

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ tauri-pilot is a **debug-only** tool. The plugin runs exclusively under `#[cfg(d
 If you discover a security vulnerability, please report it responsibly:
 
 1. **Do NOT open a public issue**
-2. Email: security@mpiton.dev (or use GitHub's private vulnerability reporting)
+2. Email: contact@mathieu-piton.com (or use GitHub's private vulnerability reporting)
 3. Include steps to reproduce and potential impact
 4. We will respond within 72 hours
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -158,6 +158,16 @@ variable and command expansion inside the script.
 | `replay <file>` | Replay recorded session with original timing |
 | `replay <file> --export sh` | Export recording as executable shell script |
 
+### Declarative Scenarios
+
+| Command | Description |
+|---------|-------------|
+| `run <scenario.toml>` | Execute declarative TOML scenario with assertions and timeouts |
+| `run <file> --no-fail-fast` | Continue running remaining steps after a failure |
+| `run <file> --junit <out.xml>` | Emit JUnit XML report for CI integration |
+
+Failure screenshots auto-saved to `./tauri-pilot-failures/`. Exit code 0 on success, 1 on any failure. Use `run` for structured CI tests; use `record`/`replay` for capture-replay of manual interactions.
+
 ## Global Flags
 
 | Flag | Description |

--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome. Bug reports, feature requests, and pull requests are 
 
 - Rust 1.95.0+ with edition 2024
 - A Tauri v2 app for testing (or use the examples)
-- Linux (WebKitGTK) — macOS/Windows not yet supported
+- Linux (WebKitGTK) or macOS (WebKit) — Windows planned
 
 ## Development Setup
 

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -7,7 +7,7 @@ description: How to use tauri-pilot to let AI agents interact with Tauri app UIs
 
 No existing tool lets AI agents interact with Tauri app UIs. The gap exists because:
 
-- **Playwright doesn't work** — Tauri uses system WebViews (WebKitGTK on Linux, WebKit on macOS), not Chromium. Playwright has no driver for either.
+- **Playwright doesn't work** — Playwright drives standalone browser processes (Chromium, Firefox, and its own bundled WebKit build). Tauri embeds the system WebView directly (WebKitGTK on Linux, WebKit on macOS), so there is no browser process for Playwright to attach to.
 - **tauri-pilot speaks a protocol optimized for LLM consumption** — the accessibility tree output is text-based, compact, and structured to be read directly by a language model.
 - **Refs map to UI elements unambiguously** — `@e3` is a stable handle within a snapshot, removing the need for CSS selectors or XPath expressions.
 

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -7,7 +7,7 @@ description: How to use tauri-pilot to let AI agents interact with Tauri app UIs
 
 No existing tool lets AI agents interact with Tauri app UIs. The gap exists because:
 
-- **Playwright doesn't work** — Tauri uses WebKitGTK, not Chromium. Playwright has no driver for WebKitGTK.
+- **Playwright doesn't work** — Tauri uses system WebViews (WebKitGTK on Linux, WebKit on macOS), not Chromium. Playwright has no driver for either.
 - **tauri-pilot speaks a protocol optimized for LLM consumption** — the accessibility tree output is text-based, compact, and structured to be read directly by a language model.
 - **Refs map to UI elements unambiguously** — `@e3` is a stable handle within a snapshot, removing the need for CSS selectors or XPath expressions.
 

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -121,12 +121,16 @@ tauri-pilot/
 ├── Cargo.toml                     # workspace
 ├── crates/
 │   ├── tauri-plugin-pilot/
+│   │   ├── build.rs               # Tauri plugin build hook (permissions)
 │   │   ├── src/
 │   │   │   ├── lib.rs             # Plugin init, js_init_script, setup
 │   │   │   ├── server.rs          # Unix socket server, accept loop
 │   │   │   ├── protocol.rs        # Request, Response, RpcError
 │   │   │   ├── handler.rs         # Dispatch method → handler
 │   │   │   ├── eval.rs            # EvalEngine (callback pattern)
+│   │   │   ├── diff.rs            # Snapshot diff (added/removed/changed)
+│   │   │   ├── key.rs             # press command key-combo parser
+│   │   │   ├── recorder.rs        # record/replay interaction capture
 │   │   │   └── error.rs           # thiserror types
 │   │   └── js/
 │   │       └── bridge.js          # JS bridge (included via include_str!)
@@ -137,5 +141,8 @@ tauri-pilot/
 │           ├── client.rs          # Unix socket client
 │           ├── protocol.rs        # Request, Response
 │           ├── output.rs          # Formatters text/JSON
+│           ├── style.rs           # owo-colors TTY-aware styling helpers
+│           ├── scenario.rs        # TOML scenario runner + JUnit XML output
+│           ├── mcp.rs             # Model Context Protocol stdio server
 │           └── error.rs           # anyhow wrappers
 ```


### PR DESCRIPTION
## Summary

Full documentation audit revealed several inconsistencies between public-facing files. This PR aligns them.

- **Security contact email** — `SECURITY.md` was pointing to `security@mpiton.dev` while `Cargo.toml` uses `contact@mathieu-piton.com`. Aligned on the Cargo.toml address.
- **Platform support** — `CONTRIBUTING.md`, `docs/contributing.md`, and `docs/guides/ai-agents.md` still claimed Linux-only, but macOS shipped in 0.3.0 (#37). README and getting-started were already correct; the rest now match.
- **Dead link** — `CONTRIBUTING.md` linked to `ARCHI.md`, which is gitignored and never shipped. Replaced with the public docs site architecture page.
- **Empty `[Unreleased]`** — CHANGELOG.md did not reflect the two PRs merged after 0.4.0. Added entries for #62 (batch scenario runner `run`) and #63 (scenario timeouts, `assert-exists` fix, JUnit `<testsuites>` aggregates).
- **Missing commands** — README.md reference table was missing `run`, `windows`, `url`, `title`, `forms`. SKILL.md was missing `run`. Both now complete.
- **Outdated module map** — `docs/guides/architecture.md` listed only the initial 6 plugin files and 6 CLI files. Updated to cover `build.rs`, `diff.rs`, `key.rs`, `recorder.rs` (plugin) and `mcp.rs`, `scenario.rs`, `style.rs` (CLI).

## Test plan

- [ ] `grep -rn "security@mpiton" docs/ *.md` returns nothing
- [ ] `grep -rn "ARCHI.md](ARCHI" *.md` returns nothing
- [ ] `grep -rn "macOS/Windows not yet" *.md docs/` returns nothing
- [ ] CHANGELOG `[Unreleased]` section renders with #62 / #63 link refs resolving at the bottom
- [ ] Astro docs build still succeeds (`cd docs && npm run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `run` command to execute TOML declarative scenarios with `--no-fail-fast`, `--junit`, per-step and global timeouts, and automatic failure screenshots saved to ./tauri-pilot-failures/.
  * Added CLI commands: `windows`, `url`, `title`, and `forms`.
  * Scenario exit codes: 0 on success, 1 on any failure.

* **Bug Fixes**
  * `assert-exists` now checks visibility in responses.

* **Documentation**
  * macOS (WebKit) added to supported platforms; JUnit XML now includes aggregate test metrics.

* **Chores**
  * Updated security contact email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-file doc inconsistencies and removes dead links. Updates platform support, security contact, command references, changelog, and architecture docs, and clarifies why Playwright cannot drive Tauri.

- **Documentation**
  - Align security contact email to contact@mathieu-piton.com in `SECURITY.md`.
  - Update platform support to Linux (WebKitGTK) and macOS (WebKit); Windows planned. Clarify in AI Agents guide that Playwright drives standalone browsers, while Tauri embeds the system WebView.
  - Replace dead `ARCHI.md` link with the public Architecture guide and refresh the module map (plugin: `build.rs`, `diff.rs`, `key.rs`, `recorder.rs`; CLI: `mcp.rs`, `scenario.rs`, `style.rs`).
  - Populate CHANGELOG [Unreleased] with `run` scenario runner, timeouts, `assert-exists` fix, and JUnit aggregates (from #62 and #63).
  - Complete command references: add `run`, `windows`, `url`, `title`, `forms` in README and a “Declarative Scenarios” section in `SKILL.md`.

<sup>Written for commit 1965b1f8b462c9cc973e625d9198c88951f91cf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

