### PR TITLE
chore(deps): windows 0.52 → 0.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `tauri-plugin-pilot` `init()` doc comment clarifies the no-op fallback now excludes Windows too and mentions the Named Pipe server path ([#64])
+- Bumped `windows` crate `0.52` → `0.61` on both `tauri-plugin-pilot` and `tauri-pilot-cli`, aligning with the version already pulled transitively by `tauri`/`tao`/`wry`/`webview2-com`/`enigo`. Deduplicates the Windows dependency graph (removes the parallel `windows-targets` tree shipped with 0.52) and picks up the `HANDLE(*mut c_void)` layout matching `std::os::windows::raw::HANDLE`. Mechanical breaking changes: `HANDLE(0)` → `HANDLE(std::ptr::null_mut())`, `HANDLE(raw as isize)` → `HANDLE(raw)`, `self.0.0 != 0` → `!self.0.0.is_null()`, `PSID` import relocated from `Win32::Foundation` to `Win32::Security`, `BOOL` now lives in `windows::core`, `SetSecurityDescriptorDacl` takes `Option<*const ACL>` (cast via `.cast_const()`), `GetSecurityInfo` returns `WIN32_ERROR` (use `.ok()`), `LocalFree` takes `Option<HLOCAL>` ([#68])
 - Bumped `indicatif` from `0.17` to `0.18` (brings the transitive `console` update to `0.16`; only `ProgressBar::new_spinner()` is used — API stable)
 - Bumped docs dependencies: `astro` `6.1.3` → `6.1.9`, `@astrojs/starlight` `0.38.2` → `0.38.4`, transitively `vite` `7.3.1` → `7.3.2`
 - Refreshed `Cargo.lock` patch-level updates: `libc` `0.2.184` → `0.2.186`, `clap` / `clap_derive` `4.6.0` → `4.6.1`, `assert_cmd` `2.2.0` → `2.2.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,3 +232,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#17]: https://github.com/mpiton/tauri-pilot/pull/17
 [#31]: https://github.com/mpiton/tauri-pilot/issues/31
 [#64]: https://github.com/mpiton/tauri-pilot/pull/64
+[#68]: https://github.com/mpiton/tauri-pilot/issues/68

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -38,7 +38,7 @@ quick-xml = "0.36"
 libc = "0.2.184"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.52", features = [
+windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
 ] }

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -37,7 +37,7 @@ enigo = { version = "0.6.1", optional = true }
 libc = "0.2.184"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.52", features = [
+windows = { version = "0.61", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_System_Pipes",

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -17,10 +17,10 @@ use std::time::Duration;
 #[allow(unused_imports)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
-use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, PSID};
+use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE};
 use windows::Win32::Security::{
     ACL, ACL_REVISION, AddAccessAllowedAce, EqualSid, GetLengthSid, GetTokenInformation,
-    InitializeAcl, InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, RevertToSelf,
+    InitializeAcl, InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, PSID, RevertToSelf,
     SECURITY_ATTRIBUTES, SetSecurityDescriptorDacl, TOKEN_QUERY, TOKEN_USER, TokenUser,
 };
 use windows::Win32::System::Pipes::ImpersonateNamedPipeClient;
@@ -214,7 +214,7 @@ impl OwnedHandle {
 
 impl Drop for OwnedHandle {
     fn drop(&mut self) {
-        if self.0.0 != 0 {
+        if !self.0.0.is_null() {
             // SAFETY: `self.0` was returned by a successful `Open*Token` call
             // and has not been closed yet.
             unsafe {
@@ -240,7 +240,7 @@ struct SecurityAttributesGuard {
 fn open_process_token() -> std::io::Result<OwnedHandle> {
     // SAFETY: `GetCurrentProcess` returns a pseudo-handle that does not need closing.
     let process = unsafe { GetCurrentProcess() };
-    let mut token = HANDLE(0);
+    let mut token = HANDLE(std::ptr::null_mut());
     // SAFETY: `process` is a valid pseudo-handle; `token` points to stack-local storage.
     unsafe { OpenProcessToken(process, TOKEN_QUERY, &raw mut token) }
         .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -252,7 +252,7 @@ fn open_process_token() -> std::io::Result<OwnedHandle> {
 fn open_thread_impersonation_token() -> std::io::Result<OwnedHandle> {
     // SAFETY: `GetCurrentThread` returns a pseudo-handle that does not need closing.
     let thread = unsafe { GetCurrentThread() };
-    let mut token = HANDLE(0);
+    let mut token = HANDLE(std::ptr::null_mut());
     // SAFETY: `thread` is a valid pseudo-handle; `token` points to stack-local storage.
     // `OpenThreadToken` reads the impersonation token from the thread, which is the
     // client's token after `ImpersonateNamedPipeClient`.
@@ -307,7 +307,7 @@ fn get_user_sid(token: &OwnedHandle) -> std::io::Result<(Vec<u8>, PSID)> {
 /// remains the source of truth and this serves purely as a defence-in-depth check.
 fn client_sid_matches_current_user(pipe: &NamedPipeServer) -> bool {
     // SAFETY: `pipe.as_raw_handle()` returns the kernel handle for the pipe server.
-    if unsafe { ImpersonateNamedPipeClient(HANDLE(pipe.as_raw_handle() as isize)) }.is_err() {
+    if unsafe { ImpersonateNamedPipeClient(HANDLE(pipe.as_raw_handle())) }.is_err() {
         tracing::warn!("failed to impersonate named pipe client");
         return true;
     }
@@ -428,7 +428,7 @@ fn build_security_descriptor(
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     // SAFETY: `sd_ptr` has just been initialised; `acl.as_ptr()` is a valid ACL.
-    unsafe { SetSecurityDescriptorDacl(sd_ptr, true, Some(acl.as_ptr()), false) }
+    unsafe { SetSecurityDescriptorDacl(sd_ptr, true, Some(acl.as_ptr().cast_const()), false) }
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     Ok(sd_box)
@@ -447,7 +447,7 @@ fn create_user_only_security_attributes()
         nLength: u32::try_from(mem::size_of::<SECURITY_ATTRIBUTES>())
             .expect("SECURITY_ATTRIBUTES size must fit in u32"),
         lpSecurityDescriptor: sd_ptr.0,
-        bInheritHandle: windows::Win32::Foundation::BOOL(0),
+        bInheritHandle: windows::core::BOOL(0),
     };
 
     let guard = SecurityAttributesGuard {
@@ -715,7 +715,7 @@ mod tests {
         let (server, guard) = bind(&pipe).expect("bind test pipe");
 
         let raw_handle = server.as_raw_handle();
-        let handle = HANDLE(raw_handle as isize);
+        let handle = HANDLE(raw_handle);
 
         // Retrieve the DACL from the freshly-bound pipe and assert:
         //   - the DACL pointer is non-NULL (the pipe is not running with a NULL DACL),
@@ -734,6 +734,7 @@ mod tests {
                 Some(&raw mut sd_ptr),
             )
         }
+        .ok()
         .expect("GetSecurityInfo must succeed on a bound pipe");
         assert!(!dacl_ptr.is_null(), "bound pipe must carry a non-NULL DACL");
 
@@ -756,7 +757,7 @@ mod tests {
         // requires the caller to release it with `LocalFree`. `dacl_ptr` points
         // into the same allocation and must not be freed separately.
         unsafe {
-            let _ = LocalFree(windows::Win32::Foundation::HLOCAL(sd_ptr.0));
+            let _ = LocalFree(Some(windows::Win32::Foundation::HLOCAL(sd_ptr.0)));
         }
 
         drop(server);


### PR DESCRIPTION
## Summary

Bump `windows` crate 0.52 → 0.61 on both `tauri-plugin-pilot` and `tauri-pilot-cli`.

• Aligns direct dependency with transitive version already pulled by `tauri`/`tao`/`wry`/`webview2-com`/`enigo`
• Deduplicates graph, removes parallel `windows-targets` tree
• Picks up `HANDLE(*mut c_void)` layout matching `std::os::windows::raw::HANDLE`
• Fixes all breaking changes in Win32 FFI (HANDLE, BOOL, PSID, SetSecurityDescriptorDacl, GetSecurityInfo, LocalFree)
• Test suite validates DACL correctness via `test_bound_pipe_carries_user_only_dacl`

## Type

chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Windows platform dependency to a newer release to align versions across the project and reduce duplicated Windows-target trees, improving compatibility and maintainability.
* **Known Impact**
  * Windows-specific interoperability changes may alter behavior or require verification on Windows systems; please test relevant functionality.
* **Documentation**
  * Added a changelog entry with a reference link for this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `windows` to `0.61` in `tauri-plugin-pilot` and `tauri-pilot-cli` to align with the `tauri` stack and dedupe the graph; also linked #68 in the CHANGELOG. Updated Win32 FFI to the new API; tests confirm the pipe DACL stays user-only.

- **Dependencies**
  - `windows` `0.52` → `0.61` in both crates; aligns with `tauri`/`tao`/`wry`/`webview2-com`/`enigo` and removes the parallel `windows-targets` tree.

- **Refactors**
  - Adjusted for API/layout changes: `HANDLE(*mut c_void)`, `HANDLE(0)` → `HANDLE(std::ptr::null_mut())`, `HANDLE(raw as isize)` → `HANDLE(raw)`, `self.0.0 != 0` → `!self.0.0.is_null()`, `PSID` moved to `Win32::Security`, `BOOL` now in `windows::core`, `SetSecurityDescriptorDacl` takes `Option<*const ACL>` (use `.cast_const()`), `GetSecurityInfo` returns `WIN32_ERROR` (use `.ok()`), `LocalFree` takes `Option<HLOCAL>`.

<sup>Written for commit 753cd65ffed6fde4665a2e35218f8a5af59ecde0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

