### PR TITLE
fix(bridge): auto-wrap top-level await in eval (fixes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge `waitFor` reads `options.ref` (was `options.target`) so its protocol matches `resolveTarget`, the field name used by every other element-targeting handler ([#74])
 - The MCP `wait` tool now routes through the same `build_wait_params` helper so MCP clients get the auto-detection fix without their own code change ([#74])
 - Scoped the `press` + global-shortcut claim from PR #45 / `[0.4.0]`. On X11, `enigo`'s `XTestFakeKeyEvent` backend does not reliably satisfy the `XGrabKey` passive grabs used by `tauri-plugin-global-shortcut`'s Linux backend, so registered global shortcuts may not fire. DOM listeners and Tauri accelerators are unaffected. See [#75], the README's "Known limitations" section, and the `press` reference docs for the mechanism and the documented workaround.
+- `tauri-pilot eval` now auto-wraps top-level `await` in an async IIFE so the natural shape works (`await Promise.resolve("hi")`, `await fetch("/api").then(r => r.json())`). Previously the bridge fell through to indirect eval — a script context where top-level `await` is forbidden — and surfaced an opaque `Unexpected identifier 'Promise'` error instead of pointing at the real cause. The bridge now compiles in three stages (expression → async-expression → async-statement-IIFE-when-await-is-detected → indirect-eval) and emits a clear error pointing back at `docs/reference/cli.md` when none of them parse. Multi-statement scripts that want to surface a value still need an explicit `return`. ([#79])
 
 ### Changed
 
@@ -244,3 +245,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/mpiton/tauri-pilot/issues/73
 [#74]: https://github.com/mpiton/tauri-pilot/issues/74
 [#75]: https://github.com/mpiton/tauri-pilot/issues/75
+[#79]: https://github.com/mpiton/tauri-pilot/issues/79

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -774,18 +774,29 @@
     return expr();
   }
 
-  // Heuristic top-level `await` detector. Strips comments, single/double
-  // quoted strings, and regex literals so text like `"await"`, `/* await */`
-  // or `/await/` does not trigger a false positive, then masks property
-  // accesses (`obj.await`) so the bareword test does not fire on member
-  // expressions. Template literals are deliberately NOT stripped so a real
-  // `` `${await x}` `` is detected; the cost is that a template containing
-  // the literal text `` `await` `` is a false positive — this is harmless
-  // because the async-IIFE wrap still executes the script correctly, only
-  // the completion-value contract changes (the user must use an explicit
-  // `return` to surface a value, which is documented in cli.md). For scripts
-  // larger than 100 KB the strip pass is skipped to bound worst-case scan
-  // time; the raw `await` test is used instead.
+  // Heuristic top-level `await` detector. Strips comments and single/double
+  // quoted strings so text like `"await"` or `/* await */` does not trigger
+  // a false positive, then masks property accesses (`obj.await`) so the
+  // bareword test does not fire on member expressions.
+  //
+  // Two intentional choices, each documented because the alternative is
+  // worse:
+  //
+  //   * Template literals are NOT stripped. Stripping them with a single-pass
+  //     regex cannot balance nested `${...}` braces, and it also drops a real
+  //     `` `${await x}` ``. Leaving them in only causes false positives on a
+  //     literal like `` `await` ``, which is harmless: the script still runs
+  //     wrapped in an async IIFE, only the completion-value contract changes
+  //     (the user must use an explicit `return` to surface a value, which is
+  //     documented in cli.md).
+  //   * Regex literals (`/await/`) are NOT stripped either. A naive
+  //     `\/.../[flags]*` match also swallows division expressions like
+  //     `a / await foo / c`, which would silently hide a real top-level
+  //     `await` and break the auto-wrap fallback. False positives from a
+  //     literal `/await/` regex are again harmless wraps.
+  //
+  // For scripts larger than 100 KB the strip pass is skipped to bound
+  // worst-case scan time; the raw `await` test is used instead.
   // `await` inside a nested `async function` is also flagged, but wrapping
   // such scripts in an outer async IIFE is harmless: the inner `await` still
   // binds to the inner function.
@@ -796,7 +807,6 @@
       .replace(/\/\/[^\n]*/g, "")
       .replace(/'(?:[^'\\]|\\.)*'/g, "''")
       .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-      .replace(/\/(?:[^\/\\\n]|\\.)+\/[gimsuy]*/g, "//")
       .replace(/\.\s*await\b/g, ".__prop");
     return /\bawait\b/.test(stripped);
   }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -732,31 +732,34 @@
     // propagate, not trigger a fallback — otherwise the script would run twice.
     var expr;
     try {
-      expr = new Function("return (" + script + ")");
+      expr = new Function("return (\n" + script + "\n)");
     } catch (e1) {
       if (!(e1 instanceof SyntaxError)) throw e1;
-      // Stage 2 — async-expression compile (#79).
-      // Handles top-level `await` in expression position, e.g.
-      // `await Promise.resolve("hi")` or `await fetch(...).then(r => r.json())`.
-      // The async IIFE returns a Promise; the Rust wrapper already awaits it.
-      try {
-        var asyncExpr = new Function(
-          "return (async () => (" + script + "))()"
-        );
-        return asyncExpr();
-      } catch (e2) {
-        if (!(e2 instanceof SyntaxError)) throw e2;
-      }
-      // Stage 3 — statement fallback. Indirect eval runs in global script
-      // context and returns the completion value of the last expression (#46).
-      // Top-level `await` is not allowed in script context, so when the script
-      // contains `await` outside a function we wrap it in an async statement
-      // IIFE first (#79). Inside that IIFE the user must use `return` to surface
-      // a value; otherwise the result is `null`.
+      // The newlines around `script` in every wrapper below isolate user
+      // tokens from generated closing punctuation. Without them, a trailing
+      // `// comment` on the last line of the user script swallows `))()` or
+      // `})()` and the wrapper fails to compile.
       if (hasTopLevelAwait(script)) {
+        // Stage 2 — async-expression compile (#79).
+        // Handles top-level `await` in expression position, e.g.
+        // `await Promise.resolve("hi")` or `await fetch(...).then(r => r.json())`.
+        // Returns a Promise; the Rust wrapper already awaits it.
+        try {
+          var asyncExpr = new Function(
+            "return (async () => (\n" + script + "\n))()"
+          );
+          return asyncExpr();
+        } catch (e2) {
+          if (!(e2 instanceof SyntaxError)) throw e2;
+        }
+        // Stage 3 — async-statement IIFE (#79).
+        // Top-level `await` is not allowed in plain script context, so when
+        // the user script does not fit an expression but does contain
+        // `await`, we wrap it in an async statement IIFE. The user must use
+        // `return` to surface a value; otherwise the result is `null`.
         try {
           var asyncStmt = new Function(
-            "return (async () => { " + script + " })()"
+            "return (async () => {\n" + script + "\n})()"
           );
           return asyncStmt();
         } catch (e3) {
@@ -768,6 +771,8 @@
           );
         }
       }
+      // Stage 4 — statement fallback. Indirect eval runs in global script
+      // context and returns the completion value of the last expression (#46).
       var indirectEval = eval;
       return indirectEval(script);
     }
@@ -802,11 +807,16 @@
   // binds to the inner function.
   function hasTopLevelAwait(src) {
     if (src.length > 100000) return /\bawait\b/.test(src);
+    // Strip quoted strings BEFORE comments, otherwise a URL like
+    // `"http://example.com"` looks like a `//` line comment and the rest
+    // of the line — including any real `await` — gets deleted, producing a
+    // false negative. Same for `"/* not a comment */"` block markers
+    // embedded in a string.
     var stripped = src
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/\/\/[^\n]*/g, "")
       .replace(/'(?:[^'\\]|\\.)*'/g, "''")
       .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "")
       .replace(/\.\s*await\b/g, ".__prop");
     return /\bawait\b/.test(stripped);
   }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -725,24 +725,67 @@
   function evalScript(options) {
     var script = options && options.script;
     if (!script) throw new Error("No script provided");
-    // Compile as an expression first so `{a:1}` keeps its object-literal
-    // semantics (not a labeled block) and `class C {}` evaluates to the
-    // constructor. Keep compilation separate from execution: a runtime
-    // SyntaxError from e.g. `JSON.parse('x')` must propagate, not trigger
-    // the statement fallback — otherwise the script would run twice.
+    // Stage 1 — expression compile.
+    // `{a:1}` keeps its object-literal semantics (not a labeled block) and
+    // `class C {}` evaluates to the constructor. Keep compilation separate
+    // from execution: a runtime SyntaxError from e.g. `JSON.parse('x')` must
+    // propagate, not trigger a fallback — otherwise the script would run twice.
     var expr;
     try {
       expr = new Function("return (" + script + ")");
-    } catch (e) {
-      if (!(e instanceof SyntaxError)) throw e;
-      // Fallback for statements (`const x = 1; x`, function declarations,
-      // etc.) that the expression wrapper can't parse. Indirect eval runs
-      // in global scope and returns the completion value of the last
-      // expression (#46).
+    } catch (e1) {
+      if (!(e1 instanceof SyntaxError)) throw e1;
+      // Stage 2 — async-expression compile (#79).
+      // Handles top-level `await` in expression position, e.g.
+      // `await Promise.resolve("hi")` or `await fetch(...).then(r => r.json())`.
+      // The async IIFE returns a Promise; the Rust wrapper already awaits it.
+      try {
+        var asyncExpr = new Function(
+          "return (async () => (" + script + "))()"
+        );
+        return asyncExpr();
+      } catch (e2) {
+        if (!(e2 instanceof SyntaxError)) throw e2;
+      }
+      // Stage 3 — statement fallback. Indirect eval runs in global script
+      // context and returns the completion value of the last expression (#46).
+      // Top-level `await` is not allowed in script context, so when the script
+      // contains `await` outside a function we wrap it in an async statement
+      // IIFE first (#79). Inside that IIFE the user must use `return` to surface
+      // a value; otherwise the result is `null`.
+      if (hasTopLevelAwait(script)) {
+        try {
+          var asyncStmt = new Function(
+            "return (async () => { " + script + " })()"
+          );
+          return asyncStmt();
+        } catch (e3) {
+          if (!(e3 instanceof SyntaxError)) throw e3;
+          throw new SyntaxError(
+            "top-level await detected but the script could not be auto-wrapped. " +
+              "Wrap explicitly: (async () => { /* ...; */ return value; })() — " +
+              "see docs/reference/cli.md"
+          );
+        }
+      }
       var indirectEval = eval;
       return indirectEval(script);
     }
     return expr();
+  }
+
+  // Heuristic top-level `await` detector. Strips strings and comments first to
+  // avoid false positives from text like `"await"` or `/* await */`. Nested
+  // `await` inside an inner `async function` is still flagged, but wrapping
+  // such scripts in an outer async IIFE is harmless.
+  function hasTopLevelAwait(src) {
+    var stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "")
+      .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+      .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+      .replace(/`(?:[^`\\$]|\\.|\$\{[^}]*\})*`/g, "``");
+    return /\bawait\b/.test(stripped);
   }
 
   function waitFor(options) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -780,12 +780,15 @@
   }
 
   // Heuristic top-level `await` detector. Strips comments and single/double
-  // quoted strings so text like `"await"` or `/* await */` does not trigger
-  // a false positive, then masks property accesses (`obj.await`) so the
-  // bareword test does not fire on member expressions.
+  // quoted strings, masks property accesses (`obj.await`), then peels
+  // nested `function`/arrow-with-block bodies so an `await` buried in a
+  // nested function does not trigger top-level detection — otherwise a
+  // statement script like `async function f(){ await 1; } f(); 1+1`
+  // would be mis-routed to the async-statement wrapper and lose its
+  // completion value.
   //
-  // Two intentional choices, each documented because the alternative is
-  // worse:
+  // Three deliberate non-strips, each documented because the alternative
+  // is worse:
   //
   //   * Template literals are NOT stripped. Stripping them with a single-pass
   //     regex cannot balance nested `${...}` braces, and it also drops a real
@@ -799,12 +802,13 @@
   //     `a / await foo / c`, which would silently hide a real top-level
   //     `await` and break the auto-wrap fallback. False positives from a
   //     literal `/await/` regex are again harmless wraps.
+  //   * Methods inside `class` bodies are NOT recognised — the function-body
+  //     strip only matches `function`/arrow blocks. A class with an `await`
+  //     inside an `async` method would be flagged. Niche enough that
+  //     dragging in keyword-aware parsing isn't worth it.
   //
   // For scripts larger than 100 KB the strip pass is skipped to bound
   // worst-case scan time; the raw `await` test is used instead.
-  // `await` inside a nested `async function` is also flagged, but wrapping
-  // such scripts in an outer async IIFE is harmless: the inner `await` still
-  // binds to the inner function.
   function hasTopLevelAwait(src) {
     if (src.length > 100000) return /\bawait\b/.test(src);
     // Strip quoted strings BEFORE comments, otherwise a URL like
@@ -818,6 +822,17 @@
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/\/\/[^\n]*/g, "")
       .replace(/\.\s*await\b/g, ".__prop");
+    // Peel innermost `function`/arrow bodies. Each iteration matches blocks
+    // with no nested braces, so doubly-nested functions take two passes.
+    // Cap the iteration count so a pathological input cannot loop forever.
+    for (var k = 0; k < 6; k++) {
+      var prev = stripped;
+      stripped = stripped
+        .replace(/\bfunction\s*\*?\s*[\w$]*\s*\([^()]*\)\s*\{[^{}]*\}/g, "fn()")
+        .replace(/\([^()]*\)\s*=>\s*\{[^{}]*\}/g, "fn()")
+        .replace(/\b[\w$]+\s*=>\s*\{[^{}]*\}/g, "fn()");
+      if (stripped === prev) break;
+    }
     return /\bawait\b/.test(stripped);
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -774,17 +774,30 @@
     return expr();
   }
 
-  // Heuristic top-level `await` detector. Strips strings and comments first to
-  // avoid false positives from text like `"await"` or `/* await */`. Nested
-  // `await` inside an inner `async function` is still flagged, but wrapping
-  // such scripts in an outer async IIFE is harmless.
+  // Heuristic top-level `await` detector. Strips comments, single/double
+  // quoted strings, and regex literals so text like `"await"`, `/* await */`
+  // or `/await/` does not trigger a false positive, then masks property
+  // accesses (`obj.await`) so the bareword test does not fire on member
+  // expressions. Template literals are deliberately NOT stripped so a real
+  // `` `${await x}` `` is detected; the cost is that a template containing
+  // the literal text `` `await` `` is a false positive — this is harmless
+  // because the async-IIFE wrap still executes the script correctly, only
+  // the completion-value contract changes (the user must use an explicit
+  // `return` to surface a value, which is documented in cli.md). For scripts
+  // larger than 100 KB the strip pass is skipped to bound worst-case scan
+  // time; the raw `await` test is used instead.
+  // `await` inside a nested `async function` is also flagged, but wrapping
+  // such scripts in an outer async IIFE is harmless: the inner `await` still
+  // binds to the inner function.
   function hasTopLevelAwait(src) {
+    if (src.length > 100000) return /\bawait\b/.test(src);
     var stripped = src
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/\/\/[^\n]*/g, "")
       .replace(/'(?:[^'\\]|\\.)*'/g, "''")
       .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-      .replace(/`(?:[^`\\$]|\\.|\$\{[^}]*\})*`/g, "``");
+      .replace(/\/(?:[^\/\\\n]|\\.)+\/[gimsuy]*/g, "//")
+      .replace(/\.\s*await\b/g, ".__prop");
     return /\bawait\b/.test(stripped);
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -822,15 +822,20 @@
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/\/\/[^\n]*/g, "")
       .replace(/\.\s*await\b/g, ".__prop");
-    // Peel innermost `function`/arrow bodies. Each iteration matches blocks
-    // with no nested braces, so doubly-nested functions take two passes.
-    // Cap the iteration count so a pathological input cannot loop forever.
+    // Peel innermost `function`/arrow bodies, both block-bodied
+    // (`() => { ... }`) and concise (`() => expr`). Each iteration matches
+    // bodies with no nested braces, so doubly-nested functions take two
+    // passes. Cap the iteration count so a pathological input cannot loop
+    // forever. Concise arrow bodies stop at any of `;,){}\n` to avoid
+    // chewing through the rest of the script.
     for (var k = 0; k < 6; k++) {
       var prev = stripped;
       stripped = stripped
         .replace(/\bfunction\s*\*?\s*[\w$]*\s*\([^()]*\)\s*\{[^{}]*\}/g, "fn()")
         .replace(/\([^()]*\)\s*=>\s*\{[^{}]*\}/g, "fn()")
-        .replace(/\b[\w$]+\s*=>\s*\{[^{}]*\}/g, "fn()");
+        .replace(/\b[\w$]+\s*=>\s*\{[^{}]*\}/g, "fn()")
+        .replace(/\([^()]*\)\s*=>\s*[^{};,)\n]+/g, "fn()")
+        .replace(/\b[\w$]+\s*=>\s*[^{};,)\n]+/g, "fn()");
       if (stripped === prev) break;
     }
     return /\bawait\b/.test(stripped);

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -312,15 +312,15 @@ mod tests {
             "BRIDGE_JS must define evalScript"
         );
         assert!(
-            js.contains("(async () => (\" + script + \"))()"),
+            js.contains("(async () => (\\n\" + script + \"\\n))()"),
             "evalScript must include the async-expression compile stage (#79)"
         );
         assert!(
             js.contains("hasTopLevelAwait(script)"),
-            "evalScript must guard the async-statement fallback with hasTopLevelAwait (#79)"
+            "evalScript must guard the async fallbacks with hasTopLevelAwait (#79)"
         );
         assert!(
-            js.contains("(async () => { \" + script + \" })()"),
+            js.contains("(async () => {\\n\" + script + \"\\n})()"),
             "evalScript must include the async-statement IIFE fallback (#79)"
         );
         assert!(
@@ -341,13 +341,13 @@ mod tests {
         // SAFETY: the needle is ASCII, so `find()` returns a UTF-8 char boundary.
         let body = &js[evalscript_idx..];
         let expr_idx = body
-            .find("\"return (\" + script + \")\"")
+            .find("\"return (\\n\" + script + \"\\n)\"")
             .expect("stage 1 expression compile missing");
         let async_expr_idx = body
-            .find("\"return (async () => (\" + script + \"))()\"")
+            .find("\"return (async () => (\\n\" + script + \"\\n))()\"")
             .expect("stage 2 async-expression compile missing");
         let async_stmt_idx = body
-            .find("\"return (async () => { \" + script + \" })()\"")
+            .find("\"return (async () => {\\n\" + script + \"\\n})()\"")
             .expect("stage 3 async-statement IIFE missing");
         let indirect_idx = body
             .find("var indirectEval = eval;")

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -299,4 +299,67 @@ mod tests {
             "scroll must throw on unknown direction instead of silently no-op"
         );
     }
+
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
+    fn bridge_eval_auto_wraps_top_level_await() {
+        // #79: top-level `await` in user scripts must compile via the
+        // async-IIFE fallback stages instead of crashing with an opaque
+        // SyntaxError from indirect eval.
+        let js = super::BRIDGE_JS;
+        assert!(
+            js.contains("function evalScript("),
+            "BRIDGE_JS must define evalScript"
+        );
+        assert!(
+            js.contains("(async () => (\" + script + \"))()"),
+            "evalScript must include the async-expression compile stage (#79)"
+        );
+        assert!(
+            js.contains("hasTopLevelAwait(script)"),
+            "evalScript must guard the async-statement fallback with hasTopLevelAwait (#79)"
+        );
+        assert!(
+            js.contains("(async () => { \" + script + \" })()"),
+            "evalScript must include the async-statement IIFE fallback (#79)"
+        );
+        assert!(
+            js.contains("function hasTopLevelAwait("),
+            "BRIDGE_JS must define the hasTopLevelAwait helper (#79)"
+        );
+        assert!(
+            js.contains("top-level await detected but the script could not be auto-wrapped"),
+            "evalScript must surface a clear error when auto-wrap fails (#79)"
+        );
+
+        // Stage ordering: expression compile must precede the async fallbacks,
+        // and the async-expression stage must precede the indirect-eval path.
+        let evalscript_idx = js.find("function evalScript(").expect("evalScript missing");
+        let body = &js[evalscript_idx..];
+        let expr_idx = body
+            .find("new Function(\"return (\" + script + \")\")")
+            .expect("stage 1 expression compile missing");
+        let async_expr_idx = body
+            .find("new Function(\n          \"return (async () => (\" + script + \"))()\"\n        )")
+            .or_else(|| body.find("(async () => (\" + script + \"))()"))
+            .expect("stage 2 async-expression compile missing");
+        let async_stmt_idx = body
+            .find("(async () => { \" + script + \" })()")
+            .expect("stage 3 async-statement IIFE missing");
+        let indirect_idx = body
+            .find("var indirectEval = eval;")
+            .expect("indirect eval fallback missing");
+        assert!(
+            expr_idx < async_expr_idx,
+            "expression compile must precede async-expression fallback"
+        );
+        assert!(
+            async_expr_idx < async_stmt_idx,
+            "async-expression must precede async-statement fallback"
+        );
+        assert!(
+            async_stmt_idx < indirect_idx,
+            "async-statement IIFE must precede plain indirect eval (await guard runs first)"
+        );
+    }
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -334,17 +334,20 @@ mod tests {
 
         // Stage ordering: expression compile must precede the async fallbacks,
         // and the async-expression stage must precede the indirect-eval path.
+        // Needles are formatting-stable substrings of the JS source, so a
+        // future `prettier`/`rustfmt` reflow of `bridge.js` does not silently
+        // break the ordering check.
         let evalscript_idx = js.find("function evalScript(").expect("evalScript missing");
+        // SAFETY: the needle is ASCII, so `find()` returns a UTF-8 char boundary.
         let body = &js[evalscript_idx..];
         let expr_idx = body
-            .find("new Function(\"return (\" + script + \")\")")
+            .find("\"return (\" + script + \")\"")
             .expect("stage 1 expression compile missing");
         let async_expr_idx = body
-            .find("new Function(\n          \"return (async () => (\" + script + \"))()\"\n        )")
-            .or_else(|| body.find("(async () => (\" + script + \"))()"))
+            .find("\"return (async () => (\" + script + \"))()\"")
             .expect("stage 2 async-expression compile missing");
         let async_stmt_idx = body
-            .find("(async () => { \" + script + \" })()")
+            .find("\"return (async () => { \" + script + \" })()\"")
             .expect("stage 3 async-statement IIFE missing");
         let indirect_idx = body
             .find("var indirectEval = eval;")

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -770,8 +770,26 @@ $ tauri-pilot eval "document.querySelector('a')?.click()" && tauri-pilot state
 # click fires, then state prints — exit 0
 ```
 
-Top-level `await` is not supported; wrap async work in an IIFE:
-`(async () => await fetch('/api').then(r => r.json()))()`.
+Top-level `await` is auto-wrapped in an async IIFE, so the natural shape works:
+
+```bash
+$ tauri-pilot eval 'await Promise.resolve("hello")'
+hello
+
+$ tauri-pilot eval 'await fetch("/api/items").then(r => r.json())'
+[…]
+```
+
+For multi-statement scripts (e.g. `const` followed by a value to surface), use
+an explicit `return` since the wrapper has no completion-value semantics:
+
+```bash
+$ tauri-pilot eval 'const r = await fetch("/api"); return r.status'
+200
+```
+
+Without `return`, the result is `null`. If the auto-wrap can't compile the
+script (rare; usually a syntax error), the error message points back here.
 
 ---
 


### PR DESCRIPTION
## Summary

- `tauri-pilot eval` now auto-wraps top-level `await` in an async IIFE so the natural shape works (`await Promise.resolve("hi")`, `await fetch("/api").then(r => r.json())`).
- The bridge previously fell through to indirect eval — a script context where top-level `await` is forbidden — and surfaced an opaque `Unexpected identifier 'Promise'` error pointing at the wrong cause.
- When the auto-wrap can't compile the script, the error message points back at `docs/reference/cli.md` instead of the raw SyntaxError.

Closes #79.

## What changed

`evalScript` now compiles in three stages:

1. **Expression compile** (unchanged): `{a:1}` keeps object-literal semantics, `class C {}` evaluates to the constructor.
2. **Async-expression compile** *(new)*: wraps the script in `(async () => (script))()` so `await foo()` and `await foo().then(...)` resolve via the existing Rust `wrap_script` await chain.
3. **Async-statement IIFE** *(new, await-guarded)*: if top-level `await` is detected via the `hasTopLevelAwait` helper (string- and comment-stripping regex), wraps in `(async () => { script })()`. Otherwise falls through to indirect eval (unchanged path for `const x = 1; x`).

Compile is kept separate from execution at stage 1 so a runtime SyntaxError from e.g. `JSON.parse('x')` still propagates without re-running side effects.

## Behavior validation

Standalone replica run via `node`:

```
[OK]   plain expression       → 2
[OK]   object literal         → {"a":1,"b":2}
[OK]   statement (const+expr) → 42
[OK]   top-level await expr   → "hello"
[OK]   top-level await chain  → 84
[OK]   multi-stmt with return → 15
[OK]   multi-stmt no return   → undefined
[OK]   await in string        → "await me"
[OK]   await in comment       → 3
[OK]   class body             → undefined  (expected: function value, not JSON-serializable)
[FAIL] syntax error           → Unexpected token '='   (expected, propagates)
```

Existing repro from #79 now both work:

```bash
$ tauri-pilot eval 'await Promise.resolve("hello")'
hello

$ tauri-pilot eval 'await fetch("/api/items").then(r => r.json())'
[…]
```

## Caveats

- Multi-statement scripts that want to surface a value still need an explicit `return` (`const r = await fetch(...); return r.status`). Without it, the result is `null`. Documented in `docs/reference/cli.md`.
- `hasTopLevelAwait` is a heuristic: `await` inside an inner `async function` is also flagged, but wrapping such scripts in an outer async IIFE is harmless — the inner `await` still binds to the inner function.

## Test plan

- [x] `cargo test --workspace` — 253 passed, 0 failed.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] New regression test `bridge_eval_auto_wraps_top_level_await` asserts:
  - `evalScript` defines the async-expression stage
  - `hasTopLevelAwait` is defined and gates the async-statement stage
  - Stage ordering: expression → async-expression → async-statement (await-guarded) → indirect eval
  - Auto-wrap-failure error mentions `docs/reference/cli.md`
- [x] Standalone JS behavior matrix above (run via `node /tmp/test-eval-79.js`).
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed` with `#79` link.
- [x] `docs/reference/cli.md` rewritten — old "Top-level await is not supported" warning replaced with the new auto-wrap behavior + the explicit-`return` caveat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-wraps top-level `await` in `tauri-pilot eval` so natural async snippets run, and replaces the opaque “Unexpected identifier 'Promise'” error with a clear message. Fixes #79.

- **Bug Fixes**
  - `evalScript` now compiles in stages: expression → await-guard → async-expression `(async () => (\nscript\n))()` → async-statement IIFE `(async () => {\nscript\n})()` → else indirect eval. Wrappers fence `script` with newlines to avoid trailing `//` swallowing, and the await guard runs before async stages so non-`await` scripts don’t return a Promise.
  - Hardened `hasTopLevelAwait`: strip strings before comments; mask `.await` property access; peel nested `function`, arrow-with-block, and concise-arrow bodies so inner `await` doesn’t trigger a top-level wrap (class methods still not recognized); keep template literals so `${await x}` is detected; do not strip regex literals to avoid missing `a / await x / c`; skip the strip pass for scripts >100 KB. On wrap failure, show a clear error pointing to `docs/reference/cli.md`. The ordering test now matches stable inner-string needles (including `\n`) to prevent silent regressions.

<sup>Written for commit 103b783d4295e4cb385c5d0c8b045bad91fba675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-wraps top-level await in eval so direct `await` works without manual IIFEs.

* **Bug Fixes**
  * Staged evaluation improves expression vs. statement handling and shows clearer errors that point to the CLI docs when compilation fails.

* **Documentation**
  * Updated eval command guidance with examples and clarified that multi-statement scripts must explicitly `return` values; failure behavior documented.

* **Tests**
  * Added a debug-only test to validate top-level-await handling and fallback ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->