### PR TITLE
fix(cli): keep --json snapshot --save stdout pipe-safe (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,8 +246,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/mpiton/tauri-pilot/issues/73
 [#74]: https://github.com/mpiton/tauri-pilot/issues/74
 [#75]: https://github.com/mpiton/tauri-pilot/issues/75
-<<<<<<< HEAD
 [#79]: https://github.com/mpiton/tauri-pilot/issues/79
-=======
 [#80]: https://github.com/mpiton/tauri-pilot/issues/80
->>>>>>> 18c1831 (fix(cli): keep --json snapshot --save stdout pipe-safe (#80))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The MCP `wait` tool now routes through the same `build_wait_params` helper so MCP clients get the auto-detection fix without their own code change ([#74])
 - Scoped the `press` + global-shortcut claim from PR #45 / `[0.4.0]`. On X11, `enigo`'s `XTestFakeKeyEvent` backend does not reliably satisfy the `XGrabKey` passive grabs used by `tauri-plugin-global-shortcut`'s Linux backend, so registered global shortcuts may not fire. DOM listeners and Tauri accelerators are unaffected. See [#75], the README's "Known limitations" section, and the `press` reference docs for the mechanism and the documented workaround.
 - `tauri-pilot eval` now auto-wraps top-level `await` in an async IIFE so the natural shape works (`await Promise.resolve("hi")`, `await fetch("/api").then(r => r.json())`). Previously the bridge fell through to indirect eval — a script context where top-level `await` is forbidden — and surfaced an opaque `Unexpected identifier 'Promise'` error instead of pointing at the real cause. The bridge now compiles in three stages (expression → async-expression → async-statement-IIFE-when-await-is-detected → indirect-eval) and emits a clear error pointing back at `docs/reference/cli.md` when none of them parse. Multi-statement scripts that want to surface a value still need an explicit `return`. ([#79])
+- `tauri-pilot --json snapshot --save <path>` now emits a self-describing JSON object on stdout: the saved file path is merged into the result as `"path"` (alongside `"elements"`), matching the `record stop --output` and `screenshot` conventions. Pipelines like `... | jq` or `... | python -c 'json.load(sys.stdin)'` are no longer at the mercy of stderr/stdout interleaving. Also routed `tracing` output to stderr in CLI mode so `RUST_LOG`-driven log lines can never corrupt a `--json` payload (it was already routed to stderr in `mcp` mode). The human-readable "Snapshot saved to <path>" line is still printed to stderr ([#80]).
 
 ### Changed
 
@@ -245,4 +246,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#73]: https://github.com/mpiton/tauri-pilot/issues/73
 [#74]: https://github.com/mpiton/tauri-pilot/issues/74
 [#75]: https://github.com/mpiton/tauri-pilot/issues/75
+<<<<<<< HEAD
 [#79]: https://github.com/mpiton/tauri-pilot/issues/79
+=======
+[#80]: https://github.com/mpiton/tauri-pilot/issues/80
+>>>>>>> 18c1831 (fix(cli): keep --json snapshot --save stdout pipe-safe (#80))

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -412,6 +412,13 @@ async fn run_snapshot_command(
     save: Option<std::path::PathBuf>,
     window: Option<&str>,
 ) -> Result<serde_json::Value> {
+    tracing::info!(
+        interactive,
+        selector = selector.as_deref(),
+        depth,
+        save = save.as_ref().map(|p| p.display().to_string()),
+        "running snapshot"
+    );
     let params = with_window(
         Some(json!({
             "interactive": interactive,
@@ -422,6 +429,10 @@ async fn run_snapshot_command(
     );
     let mut result = client.call("snapshot", params).await?;
     if let Some(ref path) = save {
+        // The on-disk file holds the unmodified RPC payload; the `"path"` key
+        // below is added to the in-memory result *after* the write so consumers
+        // who later re-load the file still see the original `{"elements": …}`
+        // shape that `diff --ref` and the plugin expect.
         let json = serde_json::to_string_pretty(&result)?;
         std::fs::write(path, &json)
             .with_context(|| format!("Failed to save snapshot to {}", path.display()))?;
@@ -430,6 +441,10 @@ async fn run_snapshot_command(
         // and `screenshot` conventions; see #80).
         if let serde_json::Value::Object(ref mut obj) = result {
             obj.insert("path".into(), json!(path.display().to_string()));
+        } else {
+            tracing::warn!(
+                "snapshot RPC returned a non-object result; skipping `path` injection"
+            );
         }
         eprintln!("Snapshot saved to {}", path.display());
     }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -31,14 +31,13 @@ async fn main() -> Result<()> {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
 
-    if is_mcp {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .with_writer(std::io::stderr)
-            .init();
-    } else {
-        tracing_subscriber::fmt().with_env_filter(env_filter).init();
-    }
+    // CLI tools must keep stdout reserved for data so callers can pipe into
+    // `jq`, `python -c 'json.load(...)'`, etc. without log noise corrupting the
+    // payload (see #80).
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .init();
 
     if is_mcp {
         return mcp::run_mcp_server(args.socket, args.window).await;
@@ -421,11 +420,17 @@ async fn run_snapshot_command(
         })),
         window,
     );
-    let result = client.call("snapshot", params).await?;
+    let mut result = client.call("snapshot", params).await?;
     if let Some(ref path) = save {
         let json = serde_json::to_string_pretty(&result)?;
         std::fs::write(path, &json)
             .with_context(|| format!("Failed to save snapshot to {}", path.display()))?;
+        // Embed the saved path in the JSON result so `--json` consumers can
+        // recover it without parsing stderr (matches `record stop --output`
+        // and `screenshot` conventions; see #80).
+        if let serde_json::Value::Object(ref mut obj) = result {
+            obj.insert("path".into(), json!(path.display().to_string()));
+        }
         eprintln!("Snapshot saved to {}", path.display());
     }
     Ok(result)

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -442,9 +442,7 @@ async fn run_snapshot_command(
         if let serde_json::Value::Object(ref mut obj) = result {
             obj.insert("path".into(), json!(path.display().to_string()));
         } else {
-            tracing::warn!(
-                "snapshot RPC returned a non-object result; skipping `path` injection"
-            );
+            tracing::warn!("snapshot RPC returned a non-object result; skipping `path` injection");
         }
         eprintln!("Snapshot saved to {}", path.display());
     }

--- a/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
+++ b/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
@@ -1,0 +1,113 @@
+//! Integration test for issue #80: `tauri-pilot --json snapshot --save <path>` must
+//! produce parseable JSON on stdout. Status messages must not pollute stdout.
+//!
+//! Pattern: spawn mock JSON-RPC unix socket server in a tokio runtime on a worker
+//! thread, then run the binary via `assert_cmd` against that socket and inspect
+//! stdout/stderr separately.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use assert_cmd::Command;
+
+static SOCK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let n = SOCK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!(
+        "/tmp/tauri-pilot-it-{}-{}-{}.sock",
+        tag,
+        std::process::id(),
+        n
+    ))
+}
+
+/// Spawn a one-shot mock server that answers one `snapshot` request with a fixed
+/// elements tree, then exits. Returns the join handle so the test can wait on it.
+fn spawn_mock_snapshot_server(socket: &PathBuf) -> thread::JoinHandle<()> {
+    let _ = std::fs::remove_file(socket);
+    let listener = UnixListener::bind(socket).expect("bind mock socket");
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = stream;
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read line");
+        let req: serde_json::Value = serde_json::from_str(line.trim()).expect("parse request");
+        let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let resp = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "elements": [
+                    {"depth": 0, "role": "root", "name": "Root"},
+                    {"depth": 1, "role": "button", "name": "Click"}
+                ]
+            }
+        });
+        let mut bytes = serde_json::to_vec(&resp).expect("serialize");
+        bytes.push(b'\n');
+        writer.write_all(&bytes).expect("write");
+        writer.flush().expect("flush");
+    })
+}
+
+#[test]
+fn snapshot_save_json_stdout_is_pure_parseable_json() {
+    let socket = unique_socket_path("snap-save");
+    let handle = spawn_mock_snapshot_server(&socket);
+
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let save_path = tmpdir.path().join("snap.json");
+
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .args([
+            "--socket",
+            socket.to_str().unwrap(),
+            "--json",
+            "snapshot",
+            "--save",
+            save_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run tauri-pilot");
+
+    handle.join().expect("mock server join");
+    let _ = std::fs::remove_file(&socket);
+
+    assert!(
+        output.status.success(),
+        "binary exited with non-zero status: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not parseable JSON (issue #80): {e}\n--- stdout ---\n{stdout}\n--- end ---"
+        )
+    });
+
+    let path_in_json = parsed
+        .get("path")
+        .and_then(|v| v.as_str())
+        .expect("JSON should expose saved file path");
+    assert_eq!(path_in_json, save_path.to_str().unwrap());
+
+    let elements = parsed
+        .get("elements")
+        .and_then(|v| v.as_array())
+        .expect("snapshot elements must remain in JSON");
+    assert_eq!(elements.len(), 2);
+
+    assert!(save_path.exists(), "save file should exist");
+    let written = std::fs::read_to_string(&save_path).expect("read written file");
+    let parsed_file: serde_json::Value = serde_json::from_str(&written).expect("file is JSON");
+    assert!(parsed_file.get("elements").is_some());
+}

--- a/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
+++ b/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
@@ -69,11 +69,11 @@ fn snapshot_save_json_stdout_is_pure_parseable_json() {
         .expect("cargo_bin")
         .args([
             "--socket",
-            socket.to_str().unwrap(),
+            socket.to_str().expect("socket path is UTF-8"),
             "--json",
             "snapshot",
             "--save",
-            save_path.to_str().unwrap(),
+            save_path.to_str().expect("save path is UTF-8"),
         ])
         .output()
         .expect("run tauri-pilot");
@@ -98,7 +98,10 @@ fn snapshot_save_json_stdout_is_pure_parseable_json() {
         .get("path")
         .and_then(|v| v.as_str())
         .expect("JSON should expose saved file path");
-    assert_eq!(path_in_json, save_path.to_str().unwrap());
+    assert_eq!(
+        path_in_json,
+        save_path.to_str().expect("save path is UTF-8")
+    );
 
     let elements = parsed
         .get("elements")
@@ -110,4 +113,51 @@ fn snapshot_save_json_stdout_is_pure_parseable_json() {
     let written = std::fs::read_to_string(&save_path).expect("read written file");
     let parsed_file: serde_json::Value = serde_json::from_str(&written).expect("file is JSON");
     assert!(parsed_file.get("elements").is_some());
+    assert!(
+        parsed_file.get("path").is_none(),
+        "saved file must not contain the injected `path` key"
+    );
+}
+
+/// Regression guard for the second half of #80: any `tracing` log line emitted
+/// by the CLI must land on stderr, never stdout. Previously
+/// `tracing_subscriber::fmt()` defaulted to stdout in non-MCP mode, so a
+/// `RUST_LOG=info` user would see log noise spliced into the `--json` payload.
+#[test]
+fn snapshot_save_json_stdout_clean_with_rust_log_info() {
+    let socket = unique_socket_path("snap-rustlog");
+    let handle = spawn_mock_snapshot_server(&socket);
+
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let save_path = tmpdir.path().join("snap.json");
+
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .env("RUST_LOG", "info")
+        .args([
+            "--socket",
+            socket.to_str().expect("socket path is UTF-8"),
+            "--json",
+            "snapshot",
+            "--save",
+            save_path.to_str().expect("save path is UTF-8"),
+        ])
+        .output()
+        .expect("run tauri-pilot");
+
+    handle.join().expect("mock server join");
+    let _ = std::fs::remove_file(&socket);
+
+    assert!(
+        output.status.success(),
+        "binary exited with non-zero status: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    serde_json::from_str::<serde_json::Value>(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout polluted by tracing logs (issue #80): {e}\n--- stdout ---\n{stdout}\n--- end ---"
+        )
+    });
 }

--- a/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
+++ b/crates/tauri-pilot-cli/tests/snapshot_save_json.rs
@@ -78,14 +78,18 @@ fn snapshot_save_json_stdout_is_pure_parseable_json() {
         .output()
         .expect("run tauri-pilot");
 
+    // Fail fast before join() so a binary that exits before connecting (e.g.
+    // arg-parse error) cannot leave the mock server blocked on accept() and
+    // hang the test indefinitely.
+    if !output.status.success() {
+        let _ = std::fs::remove_file(&socket);
+        panic!(
+            "binary exited with non-zero status: stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
     handle.join().expect("mock server join");
     let _ = std::fs::remove_file(&socket);
-
-    assert!(
-        output.status.success(),
-        "binary exited with non-zero status: stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
 
     let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
@@ -145,14 +149,17 @@ fn snapshot_save_json_stdout_clean_with_rust_log_info() {
         .output()
         .expect("run tauri-pilot");
 
+    // Fail fast before join() so a binary that exits before connecting cannot
+    // leave the mock server blocked on accept() and hang the test.
+    if !output.status.success() {
+        let _ = std::fs::remove_file(&socket);
+        panic!(
+            "binary exited with non-zero status: stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
     handle.join().expect("mock server join");
     let _ = std::fs::remove_file(&socket);
-
-    assert!(
-        output.status.success(),
-        "binary exited with non-zero status: stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
 
     let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
     serde_json::from_str::<serde_json::Value>(&stdout).unwrap_or_else(|e| {

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -166,6 +166,8 @@ tauri-pilot snapshot [OPTIONS]
 | `-d`, `--depth <n>` | Maximum tree depth to traverse |
 | `--save <file>` | Save the snapshot to a JSON file for later comparison with `diff --ref` |
 
+**Note on `--save` with `--json`:** the saved file holds the unmodified RPC payload (`{"elements":[…]}`) so it can be fed straight back into `diff --ref`. The `--json` payload printed to stdout additionally embeds a `"path"` field (`{"elements":[…],"path":"<file>"}`) so callers piping into `jq` / `python -c 'json.load(sys.stdin)'` can recover the saved location without parsing stderr. The two shapes are intentionally different.
+
 **Example:**
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #80. `tauri-pilot --json snapshot --save <path>` is no longer at the mercy of stderr/stdout interleaving when piped into `jq` / `python -c 'json.load(sys.stdin)'`.

Two coupled changes in `crates/tauri-pilot-cli/src/main.rs`:

1. **Tracing → stderr in CLI mode** *(actual root cause of the reported `JSONDecodeError`)*. `tracing_subscriber::fmt()` defaulted to **stdout** in the CLI branch, so any `RUST_LOG`-enabled log line landed between the `{` and `}` of a `--json` payload. MCP mode was already routed to stderr; the CLI branch now does the same. The pre-existing `eprintln!("Snapshot saved to …")` was already on stderr, so the pure-`eprintln` story did not explain the user's pipeline failure — `RUST_LOG`-driven tracing on stdout did.
2. **Self-describing JSON** — when `--save` is set, the saved file path is merged into the in-memory result as `"path"` alongside `"elements"`. Consumers can recover the path without parsing stderr. The on-disk file is written *before* the mutation, so a file saved by `--save` and later loaded into `diff --ref` keeps the original `{"elements": …}` shape that the plugin expects.

The human-readable `"Snapshot saved to <path>"` line still goes to stderr (unchanged behavior).

### Why the merge shape (vs. a synthetic envelope)

Issue #80 explicitly asks for `{ "saved_to": "<path>", "elements": [...] }` (a hybrid). `screenshot --json <path>` returns `{"path":"..."}` because the alternative would be a multi-MB base64 blob; `record stop --output` returns `{"status":"saved","path":"...","count":N}` because the entry list is offloaded to the file. A snapshot tree is small enough to keep in the response, and the user wants both. This PR adopts the user's requested shape and matches the precedent's `path` key name.

## Behavior

```bash
$ tauri-pilot --json snapshot --save /tmp/snap.json
{
  "elements": [...],
  "path": "/tmp/snap.json"
}

$ tauri-pilot --json snapshot --save /tmp/snap.json | jq '.path'
"/tmp/snap.json"

# RUST_LOG no longer corrupts the payload
$ RUST_LOG=info tauri-pilot --json snapshot --save /tmp/snap.json | jq '.elements | length'
3
```

The on-disk file does **not** contain the injected `"path"` key — a regression test asserts this.

## Convention table (verified against the source)

| Command | `--json` stdout | path embedded? |
|---|---|---|
| `screenshot --json <path>` (main.rs:122-130) | `{"path":"..."}` | ✅ |
| `record stop --output <path>` (main.rs:1009-1015) | `{"status":"saved","path":"...","count":N}` | ✅ |
| `snapshot --save <path>` (before) | `{"elements":[...]}` | ❌ |
| `snapshot --save <path>` (after) | `{"elements":[...],"path":"..."}` | ✅ |

## Adversarial review

Spawned `rust-reviewer`, `code-reviewer`, and `security-reviewer` agents against commit 18c1831. Triage:

- **rust-reviewer BLOCK** (silent no-op when result is not an object) → fixed in 903b9bd: `tracing::warn!` fallback so future protocol drift surfaces.
- **code-reviewer MAJOR** (test would pass with the tracing fix reverted) → fixed in 903b9bd: added a deterministic `tracing::info!("running snapshot", …)` at the start of `run_snapshot_command` and a second integration test that runs the binary under `RUST_LOG=info` and asserts stdout is still parseable JSON. Verified by reverting the tracing fix locally — new test fails as expected.
- **code-reviewer NIT** (file-vs-stdout asymmetry undocumented) → fixed in 903b9bd: inline doc comment in `run_snapshot_command` explains the asymmetry.
- **security-reviewer**: clean. `serde_json::json!` always escapes the path string, no injection vector. Tracing macros only emit filesystem paths from the XDG runtime instance directory; nothing sensitive is newly visible on stderr.
- **rust-reviewer MAJOR** (test race on `handle.join()` ordering): not addressed — invalid analysis. `UnixListener::bind` makes the socket listening immediately and the kernel queues connect attempts; `accept()` always drains them. The `handle.join()` call already happens before the assertions, so a panicking server thread surfaces before any other failure.
- **code-reviewer MAJOR** (API shape — synthetic envelope vs. merge): not addressed — issue #80 explicitly requested the merge shape, and the user is the source of truth on this. PR description now spells out the rationale.

## Test plan

- [x] `cargo test --workspace` — 254 pass, including:
  - `snapshot_save_json_stdout_is_pure_parseable_json` — asserts `--json` stdout is parseable JSON containing `"path"` and `"elements"`, and that the on-disk file does not contain the injected `"path"` key
  - `snapshot_save_json_stdout_clean_with_rust_log_info` — runs the binary with `RUST_LOG=info` and asserts stdout is still parseable JSON; verified locally to fail when the tracing-to-stderr fix is reverted
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Manual: `... --json snapshot --save /tmp/x | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'` prints `/tmp/x`
- [x] Manual: text-mode (no `--json`) snapshot still prints the tree + the "Snapshot saved to" status line
- [x] CHANGELOG.md `[Unreleased] / Fixed` updated with `[#80]` reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--json snapshot --save` now returns a self-describing JSON that includes the saved file location as a top-level "path" field.

* **Bug Fixes**
  * CLI logging/tracing is routed to stderr so environment-driven logs no longer contaminate JSON on stdout.

* **Documentation**
  * CLI snapshot docs and changelog updated to explain differences between saved JSON and stdout JSON.

* **Tests**
  * New integration tests validate stdout JSON shape, saved-file contents, and behavior when logging is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->