### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-25
+
 ### Added
 
 - **Windows support** — named pipe server and client for Windows, with security hardening (DACL, SID validation), registry-based instance discovery, and platform-specific tests ([#64])
@@ -225,7 +227,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mpiton/tauri-pilot/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/mpiton/tauri-pilot/compare/v0.2.0...v0.2.1

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Bump `tauri-plugin-pilot` and `tauri-pilot-cli` to `0.5.0`. Finalize CHANGELOG.md — date `[0.5.0]` section (2026-04-25), add fresh `[Unreleased]` header, update compare links.

## Highlights since 0.4.0

- **Windows support** via Named Pipes with security hardening — DACL, SID validation, registry-based instance discovery (#64)
- **Batch scenario runner** — declarative TOML scenarios, 18 action types, JUnit XML output, fail_fast, auto failure screenshots, multi-level timeouts (#62, #63)
- **Bridge fixes**:
  - `scroll top` / `scroll bottom` actually scroll, unknown directions reject (#73)
  - `wait` positional auto-detects CSS selector vs `@ref`, empty target rejected up-front (#74)
  - `eval` auto-wraps top-level `await` in async IIFE (#79)
- **CLI fix**: `--json snapshot --save` emits self-describing `{path, elements}`; `RUST_LOG` routed to stderr in CLI mode — pipelines safe (#80)
- **Press limitation scoped** — Linux X11 enigo can't satisfy XGrabKey passive grabs, documented (#75)
- **Security**: 4 Dependabot alerts resolved (vite + astro CVEs), `windows` crate dedup 0.52 → 0.61

## QA performed (Linux)

- All 36 CLI commands + 18 scenario action types exercised against `pilot-test-app`
- Multi-window (`--window settings`), MCP server (45 tools), record/replay, drag/drop, watch + `--require-mutation`
- All [Unreleased] features pass; no regressions
- `cargo test --workspace`: 255 passed
- `cargo clippy --workspace -- -D warnings`: clean

## Post-merge

After squash-merge to main, tag from the merged commit:

```bash
git checkout main && git pull origin main
git tag -a v0.5.0 -m "Release v0.5.0"
git push --tags
```

CI then verifies tag/version match, publishes crates.io (plugin → CLI), creates GitHub Release.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (255 passed)
- [x] `cargo fmt --all`
- [x] Live QA against `pilot-test-app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v0.5.0 release. Bumps `tauri-plugin-pilot` and `tauri-pilot-cli` to 0.5.0 and finalizes the CHANGELOG with a dated 0.5.0 section, a fresh Unreleased header, and updated compare links.

<sup>Written for commit 751fa184cdfbf505d8e0e13030f82349b66873a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.0 of Tauri Pilot CLI and Tauri Plugin Pilot.
  * Updated changelog with release notes for this version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->