### PR TITLE
fix(bridge): pick native value setter from element prototype (fixes #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fill` and `type` actions now work on `<textarea>`. The bridge previously grabbed the `value` setter via `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") || Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")` — but the first descriptor is always truthy, so the textarea fallback was unreachable and the input setter was applied to a textarea, throwing `The HTMLInputElement.value setter can only be used on instances of HTMLInputElement` (WebIDL `[LegacyUnforgeable]` brand check). The bridge now resolves the setter via `Object.getPrototypeOf(el)`, which works uniformly across `<input>`, `<textarea>`, and `<select>` (and also fixes a latent variant of the same bug for inputs sourced from another realm/iframe). The React controlled-input bypass that already existed for plain `<input>` is preserved unchanged. `select` was refactored to share the same helper for consistency, with no behavior change ([#85]).
+
 ## [0.5.0] - 2026-04-25
 
 ### Added
@@ -251,3 +255,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#75]: https://github.com/mpiton/tauri-pilot/issues/75
 [#79]: https://github.com/mpiton/tauri-pilot/issues/79
 [#80]: https://github.com/mpiton/tauri-pilot/issues/80
+[#85]: https://github.com/mpiton/tauri-pilot/issues/85

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -544,6 +544,17 @@
 
   function select(params) {
     const el = resolveTarget(params);
+    // The CLI/tool contract is "select acts on <select>". Before the
+    // nativeValueSetter refactor, this guarantee fell out of the WebIDL brand
+    // check on `HTMLSelectElement.prototype.value` (calling that setter on an
+    // <input>/<textarea> threw). The new helper picks the setter from the
+    // element's own prototype, so a misrouted selector would now silently
+    // succeed against a non-<select> and report ok while no option was
+    // actually selected. Re-introduce the type guard explicitly.
+    if (!(el instanceof HTMLSelectElement)) {
+      const tag = (el && el.tagName ? String(el.tagName) : String(el)).slice(0, 64);
+      throw new Error("select requires a <select> element, got: " + tag);
+    }
     const setter = nativeValueSetter(el);
     if (setter) {
       setter.call(el, params.value);

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -550,10 +550,15 @@
     // <input>/<textarea> threw). The new helper picks the setter from the
     // element's own prototype, so a misrouted selector would now silently
     // succeed against a non-<select> and report ok while no option was
-    // actually selected. Re-introduce the type guard explicitly.
-    if (!(el instanceof HTMLSelectElement)) {
-      const tag = (el && el.tagName ? String(el.tagName) : String(el)).slice(0, 64);
-      throw new Error("select requires a <select> element, got: " + tag);
+    // actually selected. Re-introduce the type guard with a tag-based check
+    // (realm-safe): an `instanceof` constructor check would be tied to the
+    // host realm and would reject valid <select> elements coming from another
+    // window/iframe realm, which is exactly the case nativeValueSetter was
+    // built to support.
+    const tag = el && el.tagName ? String(el.tagName).toLowerCase() : "";
+    if (tag !== "select") {
+      const reported = (tag || String(el)).slice(0, 64);
+      throw new Error("select requires a <select> element, got: " + reported);
     }
     const setter = nativeValueSetter(el);
     if (setter) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -500,14 +500,23 @@
     return { ok: true };
   }
 
+  // Resolve the native `value` setter for the element's actual prototype.
+  // Frameworks (React, Preact-signals, Vue) sometimes install an instance-level
+  // setter that swallows programmatic writes; preferring the prototype setter
+  // bypasses that override and keeps WebIDL [LegacyUnforgeable] brand checks
+  // happy on <input>, <textarea>, and <select> alike (#85).
+  function nativeValueSetter(el) {
+    const proto = Object.getPrototypeOf(el);
+    const desc = proto && Object.getOwnPropertyDescriptor(proto, "value");
+    return desc && typeof desc.set === "function" ? desc.set : null;
+  }
+
   function fill(params) {
     const el = resolveTarget(params);
     el.focus();
-    const setter =
-      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
-      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
-    if (setter && setter.set) {
-      setter.set.call(el, params.value);
+    const setter = nativeValueSetter(el);
+    if (setter) {
+      setter.call(el, params.value);
     } else {
       el.value = params.value;
     }
@@ -519,13 +528,11 @@
   function typeText(params) {
     const el = resolveTarget(params);
     el.focus();
-    const setter =
-      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
-      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
+    const setter = nativeValueSetter(el);
     for (const ch of params.text) {
       el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
-      if (setter && setter.set) {
-        setter.set.call(el, el.value + ch);
+      if (setter) {
+        setter.call(el, el.value + ch);
       } else {
         el.value += ch;
       }
@@ -537,9 +544,9 @@
 
   function select(params) {
     const el = resolveTarget(params);
-    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
-    if (setter && setter.set) {
-      setter.set.call(el, params.value);
+    const setter = nativeValueSetter(el);
+    if (setter) {
+      setter.call(el, params.value);
     } else {
       el.value = params.value;
     }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -430,6 +430,16 @@ mod tests {
             "select must call nativeValueSetter (#85) so a future textarea-style brand-check bug cannot reappear in any setter handler"
         );
 
+        // The pre-refactor `select` relied on the WebIDL brand check to reject
+        // non-<select> targets implicitly. The helper drops that guarantee, so
+        // `select` must keep an explicit `instanceof HTMLSelectElement` guard
+        // to fail fast on misrouted selectors instead of silently writing
+        // `value` on an unrelated element.
+        assert!(
+            select_body.contains("instanceof HTMLSelectElement"),
+            "select must explicitly reject non-<select> targets after the nativeValueSetter refactor (#85)"
+        );
+
         // Helper must be defined before its callers (hoisting works for `function`
         // declarations, but ordering keeps the source readable for reviewers).
         let fill_idx = js

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -432,12 +432,18 @@ mod tests {
 
         // The pre-refactor `select` relied on the WebIDL brand check to reject
         // non-<select> targets implicitly. The helper drops that guarantee, so
-        // `select` must keep an explicit `instanceof HTMLSelectElement` guard
-        // to fail fast on misrouted selectors instead of silently writing
-        // `value` on an unrelated element.
+        // `select` must keep an explicit guard to fail fast on misrouted
+        // selectors instead of silently writing `value` on an unrelated
+        // element. The guard must be realm-safe (tag-based, not `instanceof`),
+        // because `nativeValueSetter` was added specifically to support
+        // elements coming from another window/iframe realm.
         assert!(
-            select_body.contains("instanceof HTMLSelectElement"),
+            select_body.contains("select requires a <select> element"),
             "select must explicitly reject non-<select> targets after the nativeValueSetter refactor (#85)"
+        );
+        assert!(
+            !select_body.contains("instanceof HTMLSelectElement"),
+            "select guard must be realm-safe — `instanceof HTMLSelectElement` rejects valid <select> elements from another realm, which contradicts the cross-realm support that motivated nativeValueSetter (#85)"
         );
 
         // Helper must be defined before its callers (hoisting works for `function`

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -365,4 +365,82 @@ mod tests {
             "async-statement IIFE must precede plain indirect eval (await guard runs first)"
         );
     }
+
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
+    fn bridge_native_value_setter_picks_prototype_per_element() {
+        // #85: `fill` and `type` on a <textarea> threw
+        // "The HTMLInputElement.value setter can only be used on instances of HTMLInputElement"
+        // because the old code used
+        //   Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+        //   || Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
+        // The first descriptor is always truthy, so the textarea branch was unreachable
+        // and the input setter was applied to a textarea, violating the WebIDL brand check.
+        let js = super::BRIDGE_JS;
+
+        assert!(
+            js.contains("function nativeValueSetter("),
+            "BRIDGE_JS must define a nativeValueSetter helper that picks the prototype based on the element (#85)"
+        );
+
+        // The helper must use the element's actual prototype to support input,
+        // textarea, and select uniformly without violating the brand check.
+        assert!(
+            js.contains("Object.getPrototypeOf(el)"),
+            "nativeValueSetter must derive the prototype from the element instance (#85)"
+        );
+
+        // Buggy short-circuit must be gone from fill/typeText.
+        let buggy_pattern =
+            "Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, \"value\") ||";
+        assert!(
+            !js.contains(buggy_pattern),
+            "fill/typeText must not use the `HTMLInputElement.prototype || HTMLTextAreaElement.prototype` short-circuit (#85)"
+        );
+
+        // Bound each function body by the start of the next `function ` declaration
+        // (or end-of-string), so the slice is immune to brace indentation changes
+        // and to nested blocks closing with the same brace pattern.
+        // ASCII needles → `find()` returns offsets that are valid UTF-8 char boundaries.
+        let body_of = |fn_decl: &str| -> &str {
+            let start = js
+                .find(fn_decl)
+                .unwrap_or_else(|| panic!("{fn_decl} missing"));
+            let after = start + fn_decl.len();
+            let end = js[after..]
+                .find("\n  function ")
+                .map_or(js.len(), |off| after + off);
+            &js[start..end]
+        };
+
+        let fill_body = body_of("function fill(params)");
+        let type_body = body_of("function typeText(params)");
+        let select_body = body_of("function select(params)");
+
+        assert!(
+            fill_body.contains("nativeValueSetter("),
+            "fill must call nativeValueSetter (#85)"
+        );
+        assert!(
+            type_body.contains("nativeValueSetter("),
+            "typeText must call nativeValueSetter (#85)"
+        );
+        assert!(
+            select_body.contains("nativeValueSetter("),
+            "select must call nativeValueSetter (#85) so a future textarea-style brand-check bug cannot reappear in any setter handler"
+        );
+
+        // Helper must be defined before its callers (hoisting works for `function`
+        // declarations, but ordering keeps the source readable for reviewers).
+        let fill_idx = js
+            .find("function fill(params)")
+            .expect("fill function missing");
+        let helper_idx = js
+            .find("function nativeValueSetter(")
+            .expect("nativeValueSetter helper missing");
+        assert!(
+            helper_idx < fill_idx,
+            "nativeValueSetter must be declared before fill (#85)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `fill`/`type` actions throwing `The HTMLInputElement.value setter can only be used on instances of HTMLInputElement` on `<textarea>` (#85).
- Replace the buggy `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") || HTMLTextAreaElement.prototype …` short-circuit with a `nativeValueSetter(el)` helper that derives the prototype from the element via `Object.getPrototypeOf(el)`. Works for `<input>`, `<textarea>`, and `<select>`, plus elements sourced from another realm/iframe. The existing React controlled-input bypass is preserved (prototype setter still wins over any framework-installed instance setter).
- Refactor `select` to share the same helper for consistency (no behavior change).
- Add a regression test in `tauri-plugin-pilot` asserting the buggy pattern is gone, the helper is defined, and `fill`, `typeText`, `select` all call it.

## Root cause

```javascript
// bridge.js (before)
const setter =
  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ||
  Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value");
setter.set.call(el, params.value); // throws on a <textarea>
```

`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")` always returns a truthy descriptor in any browser, so the textarea branch was unreachable and the input setter was always applied — failing the WebIDL `[LegacyUnforgeable]` brand check on a textarea host object.

## Fix

```javascript
function nativeValueSetter(el) {
  const proto = Object.getPrototypeOf(el);
  const desc = proto && Object.getOwnPropertyDescriptor(proto, "value");
  return desc && typeof desc.set === "function" ? desc.set : null;
}
```

`fill`, `typeText`, and `select` all use it; same primitive as before for inputs (so React controlled-input bypass is unchanged), correct setter for textareas and selects, and the iframe/cross-realm case picks the element's own realm's prototype so the brand check passes there too.

## Verification

- `cargo test --workspace` → 256 passed.
- `cargo clippy --workspace -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- Manual repro against `pilot-test-app` (`<textarea name="bio">`):
  - Before: `tauri-pilot fill 'textarea[name="bio"]' "x"` → `RPC error (-32603): Eval error: JavaScript error: The HTMLInputElement.value setter can only be used on instances of HTMLInputElement`.
  - After: `✓ ok` for `fill`, `type`, plus `select` and `<input>` paths still work.

## Test plan

- [x] Regression test asserts the buggy `||` short-circuit is gone and that `fill`, `typeText`, `select` call the new helper
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual repro against `pilot-test-app` confirms `fill`/`type` succeed on `<textarea>`
- [x] `<input>` and `<select>` paths still work

Closes #85.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `fill`/`type` on `<textarea>` by using the element’s own native `value` setter. Also updates `select` to use the same helper and adds a realm-safe guard so it only targets `<select>`. Fixes #85.

- **Bug Fixes**
  - Introduce `nativeValueSetter(el)` to resolve the setter via `Object.getPrototypeOf(el)`. Works for `<input>`, `<textarea>`, and `<select>`, including cross-realm; preserves the React controlled-input bypass.
  - Use the helper in `fill`, `typeText`, and `select`.
  - Keep `select` strict with a tag-based guard (`el.tagName.toLowerCase() === "select"`) and a clear error for non-`<select>`; extend tests to enforce the guard and the removal of the old short-circuit.

<sup>Written for commit d56787ad6ef80b16b8f8bf74c7c34fcb8890aa75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `fill` and `type` on `<textarea>` by using the element’s native value setter.
  * `select` now validates target elements and consistently applies the same value helper.

* **Tests**
  * Added a debug-only verification test for form input operations.

* **Documentation**
  * Updated changelog and appended an issue reference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/86)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->