### PR TITLE
fix(plugin): unbound wait/watch Rust channel from DEFAULT_TIMEOUT (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `wait` no longer caps user-supplied `--timeout` at the internal Rust default
+  (10 s). The handler dispatched `wait` through the generic `handle_eval_method`
+  with `DEFAULT_TIMEOUT`, so any `--timeout` above 10 000 ms produced a cryptic
+  `Eval error: eval timed out after 10s` instead of the bridge's well-formed
+  `Timeout waiting for <selector>` rejection. The reporter on issue #91 surfaced
+  this as "`wait --selector` silently fails for UUID values" — the UUID was a
+  coincidence: their UUID-bearing kanban rows simply rendered after the 10 s
+  cap. `wait` now joins `watch` on a shared `bridge_eval_timeout` helper that
+  pads the JS-side timeout with a 2 s headroom buffer ([#91]).
+
 ### Security
 
 - `SKILL.md`: addressed skills.sh Snyk findings W007 (insecure credential
@@ -276,3 +288,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#79]: https://github.com/mpiton/tauri-pilot/issues/79
 [#80]: https://github.com/mpiton/tauri-pilot/issues/80
 [#85]: https://github.com/mpiton/tauri-pilot/issues/85
+[#91]: https://github.com/mpiton/tauri-pilot/issues/91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coincidence: their UUID-bearing kanban rows simply rendered after the 10 s
   cap. `wait` now joins `watch` on a shared `bridge_eval_timeout` helper that
   pads the JS-side timeout with a 2 s headroom buffer ([#91]).
+- `bridge.js` `waitFor`: explicit `timeout: 0` is honored as "resolve or reject
+  immediately" instead of being coerced to the 10 000 ms default via
+  `||`-fallback. The previous behavior desynchronised the JS timer from the
+  padded Rust channel and could surface the generic "eval timed out" error for
+  `wait --timeout 0`. Matches the `watch` semantics that already used a
+  `!= null` check ([#91]).
 
 ### Security
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -868,7 +868,12 @@
     var selector = options && options.selector;
     var ref = options && options.ref;
     var gone = (options && options.gone) || false;
-    var timeout = (options && options.timeout) || 10000;
+    // Use a `!= null` check (matching `watch` below) rather than `|| 10000` so
+    // an explicit `timeout: 0` resolves immediately instead of silently
+    // expanding to 10 s — the latter desynchronised the Rust channel padded
+    // via `BRIDGE_TIMEOUT_BUFFER_MS` and surfaced the generic "eval timed out"
+    // instead of the bridge's own rejection.
+    var timeout = (options && options.timeout != null) ? options.timeout : 10000;
 
     if (!selector && !ref) {
       return Promise.reject(

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -27,9 +27,34 @@ static PRESS_ORDER_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Extra headroom added to the JS-side watch timeout so the Rust oneshot channel
-/// doesn't expire before the JS `MutationObserver` can resolve/reject.
-const WATCH_BUFFER_MS: u64 = 2_000;
+/// Default JS-side timeout when params omit it. Mirrors the bridge default
+/// (`waitFor`/`watch` both fall back to `10_000` ms in `bridge.js`).
+const DEFAULT_BRIDGE_TIMEOUT_MS: u64 = 10_000;
+/// Extra headroom added to the JS-side timeout so the Rust oneshot channel
+/// doesn't expire before the JS callback can resolve/reject. Without this,
+/// a user-supplied `wait`/`watch` timeout above `DEFAULT_TIMEOUT` would be
+/// silently capped by the Rust channel (fixes #91 — the cryptic
+/// "eval timed out after 10s" that hid the bridge-side selector error).
+///
+/// This is a *ceiling*, not a per-call cost: when the bridge resolves or
+/// rejects normally, the channel returns within milliseconds and the buffer
+/// is never consumed. The buffer only kicks in when JS is stuck (frozen
+/// webview, blocked main thread). Matches the prior `WATCH_BUFFER_MS` value;
+/// covers the `__TAURI_INTERNALS__.invoke('plugin:pilot|__callback', …)`
+/// roundtrip plus a GC pause without slowing fast-path failures.
+const BRIDGE_TIMEOUT_BUFFER_MS: u64 = 2_000;
+
+/// Compute the Rust-side eval timeout for a method whose JS implementation
+/// honors `options.timeout` (currently `wait` and `watch`). Pads the user
+/// value with [`BRIDGE_TIMEOUT_BUFFER_MS`] so the bridge always gets to surface
+/// its own well-formed rejection before the channel goes silent.
+fn bridge_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
+    let timeout_ms = params
+        .and_then(|p| p.get("timeout"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_BRIDGE_TIMEOUT_MS);
+    Duration::from_millis(timeout_ms.saturating_add(BRIDGE_TIMEOUT_BUFFER_MS))
+}
 
 /// Extract and remove the optional `"window"` key from params.
 ///
@@ -110,16 +135,22 @@ pub(crate) async fn dispatch(
         }),
         "click" | "fill" | "type" | "select" | "check" | "scroll" | "drag" | "drop" | "text"
         | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "state"
-        | "wait" | "visible" | "count" | "checked" => {
+        | "visible" | "count" | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
-        "watch" => {
-            let timeout_ms = params
-                .and_then(|p| p.get("timeout"))
-                .and_then(serde_json::Value::as_u64)
-                .unwrap_or(10_000);
-            let timeout = Duration::from_millis(timeout_ms.saturating_add(WATCH_BUFFER_MS));
-            handle_eval_method(method, params, engine, eval_fn, win, timeout).await
+        // `wait` and `watch` both honor a JS-side `options.timeout`; the Rust
+        // channel timeout must outlive that so the bridge can surface its own
+        // rejection (issue #91).
+        "wait" | "watch" => {
+            handle_eval_method(
+                method,
+                params,
+                engine,
+                eval_fn,
+                win,
+                bridge_eval_timeout(params),
+            )
+            .await
         }
         "screenshot" => {
             handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
@@ -1161,5 +1192,199 @@ mod tests {
         let entries = recorder.stop();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].action, "navigate");
+    }
+
+    // ─── bridge_eval_timeout (issue #91) ─────────────────────────────────────
+
+    #[test]
+    fn test_bridge_eval_timeout_uses_param_plus_buffer() {
+        // The Rust channel must outlive the JS timer so the bridge gets to
+        // surface its own well-formed rejection (e.g.
+        // `Timeout waiting for [data-testid="..."]`) instead of the channel
+        // tripping first with the cryptic "eval timed out after 10s".
+        let params = json!({"selector": "#root", "timeout": 60_000_u64});
+        let got = bridge_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_bridge_eval_timeout_defaults_when_missing() {
+        // Mirror the bridge's own fallback: 10_000 ms + buffer.
+        let got = bridge_eval_timeout(None);
+        assert_eq!(
+            got,
+            Duration::from_millis(DEFAULT_BRIDGE_TIMEOUT_MS + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_bridge_eval_timeout_defaults_when_param_not_u64() {
+        // A non-integer "timeout" (string, negative, float) must not panic and
+        // must fall back to the bridge default rather than silently coercing.
+        let params = json!({"timeout": "soon"});
+        let got = bridge_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(DEFAULT_BRIDGE_TIMEOUT_MS + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_bridge_eval_timeout_saturates_on_overflow() {
+        // u64::MAX + buffer must saturate, not wrap to a tiny value.
+        let params = json!({"timeout": u64::MAX});
+        let got = bridge_eval_timeout(Some(&params));
+        assert_eq!(got, Duration::from_millis(u64::MAX));
+    }
+
+    #[test]
+    fn test_bridge_eval_timeout_zero_still_padded() {
+        // A user-supplied 0 ms timeout still gets the buffer — the buffer is a
+        // *ceiling* for stuck JS, not a per-call cost. JS receives `timeout: 0`
+        // and rejects on the next microtask; the buffer never elapses on the
+        // happy path.
+        let got = bridge_eval_timeout(Some(&json!({"timeout": 0_u64})));
+        assert_eq!(got, Duration::from_millis(BRIDGE_TIMEOUT_BUFFER_MS));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_wait_honors_user_timeout_above_default() {
+        // Issue #91: with the previous wiring, `wait --timeout 30000` was
+        // capped at `DEFAULT_TIMEOUT` (10 s) by the Rust channel and surfaced
+        // as "Eval error: eval timed out after 10s" — masking the real bridge
+        // outcome. After the fix, the Rust side must wait
+        // `30_000 + BRIDGE_TIMEOUT_BUFFER_MS` ms before giving up.
+        //
+        // Runs under `start_paused = true`, so virtual time auto-advances to
+        // whatever timer the dispatch is parked on. The elapsed value reflects
+        // the *effective* Rust-side cap.
+        let engine = EvalEngine::new();
+        // eval_fn that accepts the script but never resolves the callback —
+        // the timeout decides who wins.
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+
+        let params = json!({
+            "selector": "[data-testid=\"never-exists\"]",
+            "timeout": 30_000_u64,
+        });
+
+        let start = tokio::time::Instant::now();
+        let err = dispatch(
+            "wait",
+            Some(&params),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("dispatch must time out");
+        let elapsed = start.elapsed();
+
+        // The behavioral invariant being defended: the Rust channel must
+        // outlive the user's JS-side timeout. Pre-fix it expired at
+        // `DEFAULT_TIMEOUT` (10 s), well before the 30 s user_timeout.
+        let user_timeout = Duration::from_secs(30);
+        assert!(
+            elapsed > user_timeout,
+            "elapsed {elapsed:?} should outlive user timeout {user_timeout:?}"
+        );
+        assert_eq!(err.code, -32603);
+        assert!(
+            err.message.contains("timed out"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_wait_default_timeout_outlives_bridge_default() {
+        // Without `timeout` in params the helper falls back to the bridge
+        // default. The Rust channel must still outlive that default so the
+        // bridge gets to surface its own `Timeout waiting for …` rejection.
+        let engine = EvalEngine::new();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+
+        let start = tokio::time::Instant::now();
+        let _err = dispatch(
+            "wait",
+            Some(&json!({"selector": "#root"})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("dispatch must time out");
+        let elapsed = start.elapsed();
+        let bridge_default = Duration::from_millis(DEFAULT_BRIDGE_TIMEOUT_MS);
+        assert!(
+            elapsed > bridge_default,
+            "elapsed {elapsed:?} should outlive bridge default {bridge_default:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_watch_still_outlives_user_timeout() {
+        // Regression guard: `wait` and `watch` share the helper, so the
+        // existing `watch` behavior must remain intact.
+        let engine = EvalEngine::new();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+
+        let start = tokio::time::Instant::now();
+        let _err = dispatch(
+            "watch",
+            Some(&json!({"timeout": 25_000_u64})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("dispatch must time out");
+        let elapsed = start.elapsed();
+        let user_timeout = Duration::from_secs(25);
+        assert!(
+            elapsed > user_timeout,
+            "elapsed {elapsed:?} should outlive user timeout {user_timeout:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_wait_returns_callback_value_before_timeout() {
+        // Happy path: the bridge resolves the callback well before the padded
+        // timeout. The dispatch must return that value rather than the
+        // channel error — the buffer is a ceiling, not a per-call cost.
+        let engine = EvalEngine::new();
+        let engine_clone = engine.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                // The first registered callback on a fresh engine has id == 1
+                // (see EvalEngine::register / next_id init in eval.rs).
+                engine_clone.resolve(1, Ok(json!({"found": true})));
+                Ok(())
+            });
+
+        let result = dispatch(
+            "wait",
+            Some(&json!({"selector": "#root", "timeout": 60_000_u64})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("dispatch should resolve via callback, not time out");
+        assert_eq!(result, json!({"found": true}));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #91. `wait --selector` was capped by the internal Rust `DEFAULT_TIMEOUT` (10 s) regardless of the user's `--timeout` value, surfacing as the cryptic `Eval error: eval timed out after 10s` instead of the bridge's own `Timeout waiting for <selector>` rejection. The reporter described this as "UUID selectors silently fail" — the UUID was a red herring; their UUID-bearing kanban rows simply rendered after the 10 s cap because they hydrate from API state.

## Root cause

In `crates/tauri-plugin-pilot/src/handler.rs`, `wait` shared an arm with non-timeout commands and was dispatched via `handle_eval_method(..., DEFAULT_TIMEOUT)`. The JS bridge honored `options.timeout` faithfully, but the Rust oneshot channel expired first whenever `timeout > 10 000 ms`, swallowing the bridge's own well-formed rejection. The existing `watch` arm already worked around this with a `WATCH_BUFFER_MS = 2_000` buffer (`handler.rs:117-123` pre-fix); `wait` was missed.

## Reproduction (against the local `pilot-test-app`)

```bash
# Pre-fix on 0.5.1
$ tauri-pilot wait --selector '[data-testid="never-exists"]' --timeout 30000
Error: RPC error (-32603): Eval error: eval timed out after 10s   # 10s, not 30s

# Post-fix
$ tauri-pilot wait --selector '[data-testid="never-exists"]' --timeout 30000
Error: RPC error (-32603): Eval error: JavaScript error: Timeout waiting for [data-testid="never-exists"]   # 30s, accurate message
```

## Changes

- Rename `WATCH_BUFFER_MS` → `BRIDGE_TIMEOUT_BUFFER_MS`, add `DEFAULT_BRIDGE_TIMEOUT_MS` mirroring the `bridge.js` defaults.
- Extract `bridge_eval_timeout(params: Option<&Value>) -> Duration` (saturating arithmetic, falls back to bridge default on missing/non-u64 input).
- Consolidate the `"wait" | "watch"` dispatch arm; both methods now route through the helper.
- Tests:
  - `bridge_eval_timeout` unit tests (param, missing, non-u64, overflow, zero).
  - `dispatch_wait_honors_user_timeout_above_default` (the issue #91 regression case).
  - `dispatch_wait_default_timeout_outlives_bridge_default`.
  - `dispatch_watch_still_outlives_user_timeout` (regression guard).
  - `dispatch_wait_returns_callback_value_before_timeout` (happy-path: buffer is a ceiling, not a tax).
- CHANGELOG entry under `[Unreleased] / Fixed`.

## Test plan

- [x] `cargo test --workspace` — 265 passed (4 suites).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] End-to-end reproduction against `pilot-test-app` with UUID `data-testid` elements:
  - existing UUID element → instant resolve.
  - missing element, `--timeout 30000` → fails at 30 s with bridge message.
  - element appears at 12 s, `--timeout 30000` → resolves at 12 s (pre-fix this would have failed at 10 s with the cryptic error).
- [x] Adversarial review across 3 parallel agents (rust-reviewer, code-reviewer, alt-root-cause analysis). Applied feedback: looser invariant assertions in integration tests (test behavior, not constant value), explicit `timeout: 0` test, documented why 2 s buffer.

## Not addressed (filed separately)

The MutationObserver in `bridge.js:908` observes `document.body` only, missing portals mounted under `document.documentElement`. Unrelated to this report (kanban `<li>` lives under `<body>`), but worth a follow-up issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wait/watch timeouts so user-supplied values are respected instead of being capped at 10s by the Rust channel. Also makes `waitFor` honor `timeout: 0`, so instant resolve/reject works and users see the bridge’s own timeout errors.

- **Bug Fixes**
  - `wait` and `watch` now use `bridge_eval_timeout` to set the Rust timeout to `options.timeout + 2s` (mirrors the 10_000 ms default). Removes the 10s cap and surfaces “Timeout waiting for <selector>” (fixes #91).
  - In `bridge.js`, `waitFor` uses `timeout != null` instead of `|| 10000`, so `timeout: 0` is honored and no longer coerced to 10s.
  - Consolidated `wait`/`watch` dispatch; renamed `WATCH_BUFFER_MS` → `BRIDGE_TIMEOUT_BUFFER_MS` and added `DEFAULT_BRIDGE_TIMEOUT_MS`. Added unit/integration tests for param parsing, zero/overflow, honoring >10s, and early callback resolution.

<sup>Written for commit dc4e8b2aab783e511cf3bb4975f75447b5d2a4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `wait` no longer caps user-supplied timeouts at the internal default; bridge-aligned buffering applied consistently
  * JS-side wait now honors `timeout: 0` (immediate resolve/reject) to prevent desynchronization with the bridge

* **Tests**
  * Added comprehensive regression tests validating timeout parsing, padding, overflow saturation, and timing behavior

* **Documentation**
  * Updated changelog with the related issue reference

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/92)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->