### PR TITLE
chore: release v0.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,19 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v4
         with:
+          # Intentionally exclude `~/.cargo/bin/`: the toolchain action above
+          # provisions cargo/rustc/clippy/rustfmt, and caching the bin dir
+          # restores stale `rustup-init`-targeted symlinks that break
+          # `cargo clippy` on subsequent runs (see #94).
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # `Cargo.lock` is gitignored, so we key on the workspace `Cargo.toml`
+          # files. Bumped `v2` to invalidate the poisoned cache.
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-v2-
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-14
+
 ### Changed
 
 - Refresh transitive and minor-bump dependency versions via `cargo update`
@@ -285,7 +287,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/mpiton/tauri-pilot/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/mpiton/tauri-pilot/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/mpiton/tauri-pilot/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mpiton/tauri-pilot/compare/v0.3.0...v0.4.0

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Release v0.5.2: fixes the timeout race condition in `wait` (#91), refreshes transitive dependencies within semver constraints, closes an npm audit advisory on Astro, and hardens the SKILL.md documentation for credential safety.

## Why

The `wait --selector` command was incorrectly capping user-supplied timeouts at 10 seconds due to the Rust handler using a hardcoded `DEFAULT_TIMEOUT`, producing cryptic "eval timed out after 10s" errors instead of precise selector-not-found messages. Additionally, `bridge.js` was coercing explicit `timeout: 0` to 10 000 ms, creating JS/Rust desync. Both are now fixed, and dependencies are brought up-to-date within breaking-change boundaries.

## Changes

- Fix timeout race: `wait` and `watch` now share `bridge_eval_timeout` helper that pads JS timeout with 2s headroom, letting Rust channel outlive user deadline (#91)
- Fix bridge timeout coercion: `waitFor` now checks `timeout != null` instead of `||` fallback, honoring explicit `timeout: 0` (#91)
- Refresh Rust crate dependencies: `tauri` 2.10.3→2.11.1, `tokio` 1.50.0→1.52.3, `thiserror` 2.0.x→2.0.18, and 7 others within caret ranges. Breaking upgrades (`quick-xml`, `toml`, `windows`) deferred to separate PRs (#93)
- Refresh npm dependencies: `astro` 6.1.9→6.3.2 (closes GHSA-xr5h-phrj-8vxv), `@astrojs/starlight` 0.38.4→0.38.5, `sharp` 0.34.2→0.34.5 (#93)
- Harden `SKILL.md`: Snyk W007 (credential safety) and W011 (untrusted content) — replaced hardcoded email/password with env-var placeholders, flagged `record` and `replay --export sh` as credential-bearing, added prompt-injection guard for eval output (#89)

## Testing

- `cargo test --workspace`: 265 tests pass
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo publish -p tauri-plugin-pilot --dry-run`: validated
- `cargo publish -p tauri-pilot-cli --dry-run`: validated

Manual e2e: kanban test app with UUID-bearing rows now completes within raised timeouts; `wait --timeout 0` behaves as a rejection guard.

## Related Issues

- Closes #91
- Closes (via #93) the npm audit advisory GHSA-xr5h-phrj-8vxv

## Checklist

- [x] Tests added/updated and passing
- [x] Docs updated (SKILL.md, CHANGELOG.md)
- [x] No breaking changes to public API or CLI
- [x] Dry-run publish validation passed
- [x] CI expected to be green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.5.2 fixes `wait`/`watch` timeout handling (removes the 10s cap and honors `timeout: 0`) and hardens `SKILL.md` for credential safety. It also updates dependencies and stabilizes CI caching to resolve macOS `cargo clippy` failures.

- **Bug Fixes**
  - CI: stop caching `~/.cargo/bin`; switch cargo cache key to `cargo-v2` keyed on `**/Cargo.toml` with `restore-keys` to avoid poisoned caches on macOS.

- **Dependencies**
  - Rust crates refreshed within semver (e.g., `tauri` 2.11.1, `tokio` 1.52.3, `thiserror` 2.0.18); npm: `astro` 6.3.2 (closes GHSA-xr5h-phrj-8vxv), `@astrojs/starlight` 0.38.5, `sharp` 0.34.5.

<sup>Written for commit b6003823b01057b29a7057d5e58332bf23d51c8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.2 and bumped package versions accordingly.
  * Updated CI cache configuration for improved build caching.

* **Documentation**
  * Updated changelog with 0.5.2 release entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/94)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->