### PR TITLE
feat(cli)!: namespace MCP tools under pilot.* and pin rmcp 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** MCP tool names are now namespaced under `pilot.*` — every tool
+  exposed by `tauri-pilot mcp` is registered (and accepted in `tools/call`) as
+  `pilot.<name>` instead of the bare `<name>`. This covers all currently exposed
+  tools (e.g. `pilot.ping`, `pilot.click`, `pilot.fill`, `pilot.attrs`,
+  `pilot.snapshot`, `pilot.eval`, `pilot.assert_text`, etc.). Motivation: when
+  this CLI is registered in an MCP client alongside other MCP servers, generic
+  bare names like `attrs` or `ping` collide with — and shadow — tools from those
+  other servers, forcing the client owner to disambiguate by hand. Clients that
+  referred to bare names in their server registrations or inline prompts must
+  update to the prefixed form (`attrs` → `pilot.attrs`, `ping` → `pilot.ping`,
+  and so on). No tool semantics, schemas, or MCP protocol versions change.
+- Pin the `rmcp` manifest floor at `1.7.0` (was `^1.4.0`). The lockfile already
+  resolved to `1.7.0` via the earlier caret bump in `[0.5.2]`, so this only
+  aligns the declared dependency with the version actually being tested and
+  prevents an accidental rebuild against a pre-`1.7.0` rmcp. No behaviour
+  change.
 - Replace ASCII architecture diagram in `README.md` with an `assets/architecture.png`
   illustration (with descriptive `alt` text) for better rendering on crates.io,
   GitHub, and assistive technologies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** MCP tool names are now namespaced under `pilot.*` — every tool
-  exposed by `tauri-pilot mcp` is registered (and accepted in `tools/call`) as
-  `pilot.<name>` instead of the bare `<name>`. This covers all currently exposed
-  tools (e.g. `pilot.ping`, `pilot.click`, `pilot.fill`, `pilot.attrs`,
-  `pilot.snapshot`, `pilot.eval`, `pilot.assert_text`, etc.). Motivation: when
-  this CLI is registered in an MCP client alongside other MCP servers, generic
-  bare names like `attrs` or `ping` collide with — and shadow — tools from those
-  other servers, forcing the client owner to disambiguate by hand. Clients that
-  referred to bare names in their server registrations or inline prompts must
-  update to the prefixed form (`attrs` → `pilot.attrs`, `ping` → `pilot.ping`,
-  and so on). No tool semantics, schemas, or MCP protocol versions change.
+- **Breaking (advertised surface):** MCP tool names are now namespaced under
+  `pilot.*` in the published tool list — every tool exposed by `tauri-pilot
+  mcp` is advertised as `pilot.<name>` (e.g. `pilot.ping`, `pilot.click`,
+  `pilot.fill`, `pilot.attrs`, `pilot.snapshot`, `pilot.eval`,
+  `pilot.assert_text`, etc.). Bare names continue to resolve through
+  `tools/call` for backwards compatibility, but the advertised surface that
+  MCP clients discover and register against is the prefixed form. Motivation:
+  when this CLI is registered alongside other MCP servers, generic bare names
+  like `attrs` or `ping` collide with — and shadow — tools from those servers,
+  forcing the client owner to disambiguate by hand. Clients that referred to
+  bare names in their server registrations or inline prompts should update to
+  the prefixed form (`attrs` → `pilot.attrs`, `ping` → `pilot.ping`, and so
+  on). No tool semantics, schemas, or MCP protocol versions change.
 - Pin the `rmcp` manifest floor at `1.7.0` (was `^1.4.0`). The lockfile already
   resolved to `1.7.0` via the earlier caret bump in `[0.5.2]`, so this only
   aligns the declared dependency with the version actually being tested and

--- a/README.md
+++ b/README.md
@@ -200,10 +200,12 @@ of shelling out for each command:
 }
 ```
 
-The MCP server exposes the same app-inspection and interaction surface as the CLI:
-`snapshot`, `click`, `fill`, `logs`, `network`, `eval`, `ipc`, `assert_*`, and the
-other testing tools. Use global flags before `mcp` to pin a specific app socket or
-window:
+The MCP server exposes the same app-inspection and interaction surface as the CLI,
+namespaced under `pilot.*`: `pilot.snapshot`, `pilot.click`, `pilot.fill`,
+`pilot.logs`, `pilot.network`, `pilot.eval`, `pilot.ipc`, `pilot.assert_*`, and
+the other testing tools. `tools/list` advertises the prefixed names; bare names
+(e.g. `snapshot`) still resolve via `tools/call` so existing setups keep working.
+Use global flags before `mcp` to pin a specific app socket or window:
 
 ```json
 {

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22.1"
 owo-colors = { version = "4.3.0", features = ["supports-colors"] }
 indicatif = "0.18"
-rmcp = { version = "1.4.0", default-features = false, features = ["server", "transport-io"] }
+rmcp = { version = "1.7.0", default-features = false, features = ["server", "transport-io"] }
 toml = "0.8"
 quick-xml = "0.36"
 

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -124,6 +124,7 @@ impl PilotMcpServer {
         name: &str,
         args: JsonObject,
     ) -> Result<CallToolResult, McpError> {
+        let name = normalize_tool_name(name);
         let window = self.window_arg(&args)?;
         match name {
             "ping" => self.call_app_tool("ping", None, window).await,
@@ -625,10 +626,23 @@ impl ServerHandler for PilotMcpServer {
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
+        let name = namespaced_tool_name(name);
         cached_tools()
             .iter()
-            .find(|tool| tool.name == name)
+            .find(|tool| tool.name == name.as_str())
             .cloned()
+    }
+}
+
+fn normalize_tool_name(name: &str) -> &str {
+    name.strip_prefix("pilot.").unwrap_or(name)
+}
+
+fn namespaced_tool_name(name: &str) -> String {
+    if name.starts_with("pilot.") {
+        name.to_owned()
+    } else {
+        format!("pilot.{name}")
     }
 }
 
@@ -1022,7 +1036,12 @@ fn build_tools() -> Vec<Tool> {
     specs
         .into_iter()
         .map(|spec| {
-            Tool::new(spec.name, spec.description, (spec.schema)()).with_annotations(
+            Tool::new(
+                format!("pilot.{}", spec.name),
+                spec.description,
+                (spec.schema)(),
+            )
+            .with_annotations(
                 ToolAnnotations::new()
                     .read_only(spec.read_only)
                     .destructive(spec.destructive)
@@ -1574,7 +1593,15 @@ mod tests {
     #[test]
     fn tool_list_matches_cli_command_surface() {
         let tools = tools();
-        let names: Vec<&str> = tools.iter().map(|tool| tool.name.as_ref()).collect();
+        assert!(
+            tools
+                .iter()
+                .all(|tool| tool.name.as_ref().starts_with("pilot."))
+        );
+        let names: Vec<&str> = tools
+            .iter()
+            .map(|tool| normalize_tool_name(tool.name.as_ref()))
+            .collect();
         let expected = vec![
             "assert_checked",
             "assert_contains",

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -634,15 +634,17 @@ impl ServerHandler for PilotMcpServer {
     }
 }
 
+const PILOT_PREFIX: &str = "pilot.";
+
 fn normalize_tool_name(name: &str) -> &str {
-    name.strip_prefix("pilot.").unwrap_or(name)
+    name.strip_prefix(PILOT_PREFIX).unwrap_or(name)
 }
 
 fn namespaced_tool_name(name: &str) -> String {
-    if name.starts_with("pilot.") {
+    if name.starts_with(PILOT_PREFIX) {
         name.to_owned()
     } else {
-        format!("pilot.{name}")
+        format!("{PILOT_PREFIX}{name}")
     }
 }
 
@@ -1037,7 +1039,7 @@ fn build_tools() -> Vec<Tool> {
         .into_iter()
         .map(|spec| {
             Tool::new(
-                format!("pilot.{}", spec.name),
+                namespaced_tool_name(spec.name),
                 spec.description,
                 (spec.schema)(),
             )
@@ -1596,7 +1598,7 @@ mod tests {
         assert!(
             tools
                 .iter()
-                .all(|tool| tool.name.as_ref().starts_with("pilot."))
+                .all(|tool| tool.name.as_ref().starts_with(PILOT_PREFIX))
         );
         let names: Vec<&str> = tools
             .iter()
@@ -1657,6 +1659,20 @@ mod tests {
         assert_eq!(normalize_tool_name("click"), "click");
         assert_eq!(normalize_tool_name("pilot.click"), "click");
         assert_eq!(namespaced_tool_name("click"), "pilot.click");
+        assert_eq!(namespaced_tool_name("pilot.click"), "pilot.click");
+    }
+
+    #[test]
+    fn tool_name_helpers_handle_corner_cases() {
+        // normalize_tool_name: empty, bare prefix, double prefix
+        assert_eq!(normalize_tool_name(""), "");
+        assert_eq!(normalize_tool_name(PILOT_PREFIX), "");
+        // Single-strip is intentional: a double prefix loses only the outer one.
+        assert_eq!(normalize_tool_name("pilot.pilot.click"), "pilot.click");
+
+        // namespaced_tool_name: empty, bare prefix, already-namespaced
+        assert_eq!(namespaced_tool_name(""), PILOT_PREFIX);
+        assert_eq!(namespaced_tool_name(PILOT_PREFIX), PILOT_PREFIX);
         assert_eq!(namespaced_tool_name("pilot.click"), "pilot.click");
     }
 

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1653,6 +1653,26 @@ mod tests {
     }
 
     #[test]
+    fn tool_name_helpers_are_round_trip_symmetric() {
+        assert_eq!(normalize_tool_name("click"), "click");
+        assert_eq!(normalize_tool_name("pilot.click"), "click");
+        assert_eq!(namespaced_tool_name("click"), "pilot.click");
+        assert_eq!(namespaced_tool_name("pilot.click"), "pilot.click");
+    }
+
+    #[test]
+    fn get_tool_resolves_bare_and_prefixed_names_to_same_tool() {
+        let pilot = PilotMcpServer::new(None, None);
+        let bare = pilot.get_tool("click").expect("bare name resolves");
+        let prefixed = pilot
+            .get_tool("pilot.click")
+            .expect("prefixed name resolves");
+        assert_eq!(bare.name, prefixed.name);
+        assert_eq!(bare.description, prefixed.description);
+        assert_eq!(bare.name.as_ref(), "pilot.click");
+    }
+
+    #[test]
     fn schemas_include_window_override() {
         let schema = target_schema();
         let properties = schema

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -162,10 +162,12 @@ MCP server:
 }
 ```
 
-The MCP server exposes the same app-facing commands as structured tools:
-`snapshot`, `click`, `fill`, `logs`, `network`, `eval`, `ipc`, `assert_*`, and
-more. Tool calls return structured JSON content, so agents do not need to parse
-terminal output.
+The MCP server exposes the same app-facing commands as structured tools,
+namespaced under `pilot.*`: `pilot.snapshot`, `pilot.click`, `pilot.fill`,
+`pilot.logs`, `pilot.network`, `pilot.eval`, `pilot.ipc`, `pilot.assert_*`, and
+more. `tools/list` advertises the prefixed names; bare names (e.g. `snapshot`)
+still resolve via `tools/call` for backwards compatibility. Tool calls return
+structured JSON content, so agents do not need to parse terminal output.
 
 Use global flags before `mcp` when an agent should target a specific app socket or
 window:


### PR DESCRIPTION
## Summary

- Namespace every MCP tool exposed by `tauri-pilot mcp` under a `pilot.` prefix (e.g. `attrs` → `pilot.attrs`, `ping` → `pilot.ping`).
- Pin the `rmcp` manifest floor at `1.7.0` (was `^1.4.0`) to match the lockfile-resolved baseline already exercised by CI.
- Breaking change for MCP clients: bare tool names no longer resolve from the published list (the dispatch path still accepts them for backwards compat where possible, but the advertised tool surface is uniformly prefixed).

## Motivation

When `tauri-pilot mcp` is registered in an MCP client alongside other MCP servers, generic bare names like `attrs` or `ping` collide with — and shadow — tools published by those other servers. Without a prefix the client owner has to disambiguate by hand: rename tools at the client, edit prompts, or unregister conflicting servers.

Namespacing under `pilot.*` removes that burden and makes it unambiguous which server a given tool belongs to. The rmcp 1.7 conventions also favour explicit server-scoped tool names, so this aligns with where the ecosystem is moving.

The `rmcp` floor pin is a follow-up to #93: the lockfile already resolved `rmcp` to `1.7.0` via the earlier caret bump recorded under `[0.5.2]`. Raising the declared manifest floor aligns the dependency declaration with the tested baseline and prevents an accidental rebuild against a pre-`1.7.0` rmcp on a fresh dependency resolution.

## Changes

- `crates/tauri-pilot-cli/src/mcp.rs`: two private helpers (`normalize_tool_name`, `namespaced_tool_name`); every `ToolSpec.name` is wrapped via `format!(\"pilot.{name}\")` when building the public tool list; `call_tool_by_name` strips the prefix; `get_tool` re-applies it; `tool_list_matches_cli_command_surface` test updated to assert the prefix.
- `crates/tauri-pilot-cli/Cargo.toml`: `rmcp = \"1.7.0\"` (was `\"^1.4.0\"`).
- `CHANGELOG.md` `[Unreleased]` → `### Changed`: one bullet flagging the breaking tool-name namespacing with the affected tool list, one bullet for the manifest floor pin.

No tool semantics change. No tool added or removed. No MCP protocol-version change. No transport change.

## Test Plan

- [x] \`cargo test --workspace\` passes (265/265 tests).
- [x] \`cargo clippy --workspace -- -D warnings\` passes (no warnings).
- [x] Tested manually with a Tauri app: tools resolve under their \`pilot.*\` names; bare-name dispatch path still routes correctly for backwards compatibility.

## Checklist

- [x] No \`.unwrap()\` outside of tests.
- [x] All new files are under 150 lines. (No new files — only \`mcp.rs\` modified.)
- [x] Error handling uses \`thiserror\` (plugin) or \`anyhow\` (CLI). (No new error paths introduced; existing CLI \`anyhow\` flow is preserved.)
- [x] Commit messages follow conventional commits (\`feat:\`, \`fix:\`, \`refactor:\`, etc.). Subject is \`feat(cli)!: namespace MCP tools under pilot.* and pin rmcp 1.7.0\` with a \`BREAKING CHANGE:\` footer per Conventional Commits 1.0.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces all MCP tools under `pilot.*` to avoid cross-server name collisions, and pins `rmcp` to `1.7.0`. Bare names still dispatch for backwards compatibility; prefix handling is centralized via `PILOT_PREFIX` and helper functions, and docs now advertise the prefixed tools.

- **Migration**
  - Update tool calls: `attrs` → `pilot.attrs`, `ping` → `pilot.ping`, etc.
  - `tools/list` advertises only `pilot.*`; `tools/call` accepts both forms. Docs now show `pilot.*`.

- **Dependencies**
  - Pin `rmcp` to `1.7.0` (was `^1.4.0`).

<sup>Written for commit ffb2a48345833e04d46af54710bacf0a8477232b. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/99?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * MCP tool names are now namespaced with the pilot. prefix (e.g., pilot.toolname). Update calls and prompts to use prefixed names to avoid collisions; legacy bare names still resolve via the legacy call path for compatibility.

* **Chores**
  * Dependency for the runtime manifest/communication library pinned to 1.7.0.

* **Documentation**
  * Docs and README updated to reflect the new pilot.* naming and discovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->