### PR TITLE
feat(plugin): add macOS native screenshot backend with pilot.screenshot IPC method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS native screenshot backend (`screencapture` shell-out plus
   `CGWindowListCreateImage` fallback) behind the existing `screenshot`
   module surface; WKWebView path scaffolded for follow-up.
+- `pilot.screenshot` JSON-RPC method (also advertised as `pilot.screenshot`
+  MCP tool) that captures a window by `window_id` to a caller-specified
+  `output_path`. Uses macOS `screencapture` when Screen Recording permission
+  is granted, falls back to `CGWindowListCreateImage` with `tcc_denied: true`
+  in metadata when permission is revoked between probe and call. Path-only
+  response shape — no inline bytes. The bare `screenshot` method continues
+  to route to the bridge html-to-image path for backwards compatibility, and
+  also accepts the new native shape when callers pass `output_path`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- macOS native screenshot backend (`screencapture` shell-out plus
+  `CGWindowListCreateImage` fallback) behind the existing `screenshot`
+  module surface; WKWebView path scaffolded for follow-up.
+
 ### Security
 
 - `SKILL.md`: second pass on skills.sh Snyk findings W007 and W011 — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS native screenshot backend (`screencapture` shell-out plus
   `CGWindowListCreateImage` fallback) behind the existing `screenshot`
   module surface; WKWebView path scaffolded for follow-up.
-- `pilot.screenshot` JSON-RPC method (also advertised as `pilot.screenshot`
+- `screenshot_native` JSON-RPC method (advertised as the `pilot.screenshot_native`
   MCP tool) that captures a window by `window_id` to a caller-specified
   `output_path`. Uses macOS `screencapture` when Screen Recording permission
   is granted, falls back to `CGWindowListCreateImage` with `tcc_denied: true`
   in metadata when permission is revoked between probe and call. Path-only
-  response shape — no inline bytes. The bare `screenshot` method continues
-  to route to the bridge html-to-image path for backwards compatibility, and
-  also accepts the new native shape when callers pass `output_path`.
+  response shape — no inline bytes. Bare `screenshot` keeps its existing
+  bridge html-to-image behaviour and is wholly separate from the new method,
+  so the two surfaces cannot be confused. On Linux and Windows,
+  `pilot.screenshot_native` is registered but every call responds with
+  `PERMISSION_DENIED` and the message `"screenshot is only available on
+  macOS in this release"` — the request shape validators run first, so a
+  contract-violating call sees the validation error on every host.
 
 ### Security
 

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -248,6 +248,17 @@ impl PilotMcpServer {
                 )
                 .await
             }
+            "pilot.screenshot" => {
+                let mut payload = json!({
+                    "window_id": required_u64(&args, "window_id")?,
+                    "output_path": required_string(&args, "output_path")?,
+                });
+                if let Some(format) = optional_string(&args, "format")? {
+                    payload["format"] = json!(format);
+                }
+                self.call_app_tool("pilot.screenshot", Some(payload), window)
+                    .await
+            }
             "navigate" => {
                 self.call_app_tool(
                     "navigate",
@@ -829,6 +840,14 @@ fn tool_specs() -> Vec<ToolSpec> {
             idempotent: false,
         },
         ToolSpec {
+            name: "pilot.screenshot",
+            description: "Capture a native window by `window_id` and write a PNG to `output_path`. Returns path + metadata; never inlines bytes.",
+            schema: pilot_screenshot_schema,
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+        },
+        ToolSpec {
             name: "scroll",
             description: "Scroll the page or an element ref.",
             schema: scroll_schema,
@@ -1386,6 +1405,28 @@ fn ipc_schema() -> Arc<JsonObject> {
     )
 }
 
+fn pilot_screenshot_schema() -> Arc<JsonObject> {
+    object_schema(
+        props([
+            (
+                "window_id",
+                integer_prop("Native window id (e.g. `CGWindowID` on macOS) to capture."),
+            ),
+            (
+                "output_path",
+                string_prop(
+                    "Absolute path where the PNG is written. The parent directory must already exist; the file is written atomically via a temp + rename.",
+                ),
+            ),
+            (
+                "format",
+                enum_prop("Image format. v1 accepts only \"png\".", &["png"]),
+            ),
+        ]),
+        &["window_id", "output_path"],
+    )
+}
+
 fn selector_schema() -> Arc<JsonObject> {
     object_schema(
         props([("selector", string_prop("Optional CSS selector."))]),
@@ -1627,6 +1668,7 @@ mod tests {
             "logs",
             "navigate",
             "network",
+            "pilot.screenshot",
             "ping",
             "press",
             "record_start",
@@ -1726,6 +1768,120 @@ mod tests {
                 "scroll direction enum must include {expected}"
             );
         }
+    }
+
+    #[test]
+    fn pilot_screenshot_tool_advertises_path_only_contract() {
+        let tool = cached_tools()
+            .iter()
+            .find(|t| t.name == "pilot.screenshot")
+            .expect("pilot.screenshot tool registered");
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema has properties");
+        for required in ["window_id", "output_path", "format"] {
+            assert!(
+                props.contains_key(required),
+                "pilot.screenshot must advertise `{required}` in its schema"
+            );
+        }
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("required list present");
+        let required: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
+        assert!(
+            required.contains(&"window_id"),
+            "pilot.screenshot must require `window_id`"
+        );
+        assert!(
+            required.contains(&"output_path"),
+            "pilot.screenshot must require `output_path`"
+        );
+        // The path-only contract forbids inline byte / base64 fields on either
+        // surface — guard against a future revision silently growing one.
+        for forbidden in ["bytes", "base64", "data"] {
+            assert!(
+                !props.contains_key(forbidden),
+                "pilot.screenshot must not advertise `{forbidden}` (path-only contract)"
+            );
+        }
+    }
+
+    #[test]
+    fn pilot_screenshot_tool_routes_native_method() {
+        // The native contract requires `pilot.screenshot` (namespaced) on
+        // JSON-RPC so the existing bridge `screenshot` (html-to-image,
+        // base64) keeps working for current CLI/scenario callers. This test
+        // pins the surface so a future refactor cannot silently fold the two
+        // tools together and resurrect the bytes-inline payload shape.
+        let bare = cached_tools()
+            .iter()
+            .find(|t| t.name == "screenshot")
+            .expect("bridge screenshot tool still registered");
+        let prefixed = cached_tools()
+            .iter()
+            .find(|t| t.name == "pilot.screenshot")
+            .expect("pilot.screenshot tool registered");
+        assert_ne!(
+            bare.input_schema, prefixed.input_schema,
+            "bridge `screenshot` and native `pilot.screenshot` advertise different schemas"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn pilot_screenshot_forwards_native_params_to_jsonrpc() {
+        let socket = std::env::temp_dir().join(format!(
+            "tauri-pilot-mcp-pilot-screenshot-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read request");
+            let request: Request = serde_json::from_str(line.trim()).expect("parse request");
+            assert_eq!(request.method, "pilot.screenshot");
+            let params = request.params.expect("native screenshot params present");
+            assert_eq!(params["window_id"], json!(42_u64));
+            assert_eq!(params["output_path"], json!("/tmp/out.png"));
+            let response = Response::success(
+                request.id,
+                json!({
+                    "output_path": "/tmp/out.png",
+                    "window_id": 42_u32,
+                    "width": 100_u32,
+                    "height": 50_u32,
+                    "scale_factor": 2.0_f32,
+                    "byte_size": 1234_u64,
+                    "backend": "screencapture",
+                    "tcc_denied": false,
+                }),
+            );
+            let mut bytes = serde_json::to_vec(&response).expect("serialize response");
+            bytes.push(b'\n');
+            writer.write_all(&bytes).await.expect("write response");
+        });
+
+        let pilot = PilotMcpServer::new(Some(socket.clone()), None);
+        let mut args = Map::new();
+        args.insert("window_id".to_owned(), json!(42_u32));
+        args.insert("output_path".to_owned(), json!("/tmp/out.png"));
+        let result = pilot
+            .call_tool_by_name("pilot.screenshot", args)
+            .await
+            .expect("tool call succeeds");
+        assert_eq!(result.is_error, Some(false));
+
+        server.await.expect("mock server task");
+        let _ = std::fs::remove_file(&socket);
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -248,15 +248,15 @@ impl PilotMcpServer {
                 )
                 .await
             }
-            "pilot.screenshot" => {
+            "screenshot_native" => {
                 let mut payload = json!({
-                    "window_id": required_u64(&args, "window_id")?,
+                    "window_id": required_u32(&args, "window_id")?,
                     "output_path": required_string(&args, "output_path")?,
                 });
                 if let Some(format) = optional_string(&args, "format")? {
                     payload["format"] = json!(format);
                 }
-                self.call_app_tool("pilot.screenshot", Some(payload), window)
+                self.call_app_tool("screenshot_native", Some(payload), window)
                     .await
             }
             "navigate" => {
@@ -840,7 +840,7 @@ fn tool_specs() -> Vec<ToolSpec> {
             idempotent: false,
         },
         ToolSpec {
-            name: "pilot.screenshot",
+            name: "screenshot_native",
             description: "Capture a native window by `window_id` and write a PNG to `output_path`. Returns path + metadata; never inlines bytes.",
             schema: pilot_screenshot_schema,
             read_only: false,
@@ -1110,6 +1110,11 @@ fn required_u64(args: &JsonObject, name: &str) -> Result<u64, McpError> {
     args.get(name)
         .and_then(Value::as_u64)
         .ok_or_else(|| invalid_params(format!("'{name}' is required and must be an integer")))
+}
+
+fn required_u32(args: &JsonObject, name: &str) -> Result<u32, McpError> {
+    let value = required_u64(args, name)?;
+    u32::try_from(value).map_err(|_| invalid_params(format!("'{name}' is out of range for u32")))
 }
 
 fn optional_u64(args: &JsonObject, name: &str) -> Result<Option<u64>, McpError> {
@@ -1410,7 +1415,12 @@ fn pilot_screenshot_schema() -> Arc<JsonObject> {
         props([
             (
                 "window_id",
-                integer_prop("Native window id (e.g. `CGWindowID` on macOS) to capture."),
+                json!({
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": u32::MAX,
+                    "description": "Native window id (e.g. `CGWindowID` on macOS) to capture. Must fit in u32.",
+                }),
             ),
             (
                 "output_path",
@@ -1668,7 +1678,6 @@ mod tests {
             "logs",
             "navigate",
             "network",
-            "pilot.screenshot",
             "ping",
             "press",
             "record_start",
@@ -1676,6 +1685,7 @@ mod tests {
             "record_stop",
             "replay",
             "screenshot",
+            "screenshot_native",
             "scroll",
             "select",
             "snapshot",
@@ -1774,8 +1784,8 @@ mod tests {
     fn pilot_screenshot_tool_advertises_path_only_contract() {
         let tool = cached_tools()
             .iter()
-            .find(|t| t.name == "pilot.screenshot")
-            .expect("pilot.screenshot tool registered");
+            .find(|t| t.name == "pilot.screenshot_native")
+            .expect("pilot.screenshot_native tool registered");
         let props = tool
             .input_schema
             .get("properties")
@@ -1784,7 +1794,7 @@ mod tests {
         for required in ["window_id", "output_path", "format"] {
             assert!(
                 props.contains_key(required),
-                "pilot.screenshot must advertise `{required}` in its schema"
+                "pilot.screenshot_native must advertise `{required}` in its schema"
             );
         }
         let required = tool
@@ -1795,40 +1805,41 @@ mod tests {
         let required: Vec<&str> = required.iter().filter_map(Value::as_str).collect();
         assert!(
             required.contains(&"window_id"),
-            "pilot.screenshot must require `window_id`"
+            "pilot.screenshot_native must require `window_id`"
         );
         assert!(
             required.contains(&"output_path"),
-            "pilot.screenshot must require `output_path`"
+            "pilot.screenshot_native must require `output_path`"
         );
         // The path-only contract forbids inline byte / base64 fields on either
         // surface — guard against a future revision silently growing one.
         for forbidden in ["bytes", "base64", "data"] {
             assert!(
                 !props.contains_key(forbidden),
-                "pilot.screenshot must not advertise `{forbidden}` (path-only contract)"
+                "pilot.screenshot_native must not advertise `{forbidden}` (path-only contract)"
             );
         }
     }
 
     #[test]
     fn pilot_screenshot_tool_routes_native_method() {
-        // The native contract requires `pilot.screenshot` (namespaced) on
-        // JSON-RPC so the existing bridge `screenshot` (html-to-image,
-        // base64) keeps working for current CLI/scenario callers. This test
-        // pins the surface so a future refactor cannot silently fold the two
-        // tools together and resurrect the bytes-inline payload shape.
-        let bare = cached_tools()
-            .iter()
-            .find(|t| t.name == "screenshot")
-            .expect("bridge screenshot tool still registered");
-        let prefixed = cached_tools()
+        // The native contract lives under a distinct name (`screenshot_native`
+        // advertised as `pilot.screenshot_native`) so the existing bridge
+        // `screenshot` (html-to-image, base64) keeps working for current
+        // CLI/scenario callers. This test pins the surface so a future
+        // refactor cannot silently fold the two tools together and resurrect
+        // the bytes-inline payload shape.
+        let bridge = cached_tools()
             .iter()
             .find(|t| t.name == "pilot.screenshot")
-            .expect("pilot.screenshot tool registered");
+            .expect("bridge pilot.screenshot tool still registered");
+        let native = cached_tools()
+            .iter()
+            .find(|t| t.name == "pilot.screenshot_native")
+            .expect("pilot.screenshot_native tool registered");
         assert_ne!(
-            bare.input_schema, prefixed.input_schema,
-            "bridge `screenshot` and native `pilot.screenshot` advertise different schemas"
+            bridge.input_schema, native.input_schema,
+            "bridge `pilot.screenshot` and native `pilot.screenshot_native` advertise different schemas"
         );
     }
 
@@ -1836,7 +1847,7 @@ mod tests {
     #[cfg(unix)]
     async fn pilot_screenshot_forwards_native_params_to_jsonrpc() {
         let socket = std::env::temp_dir().join(format!(
-            "tauri-pilot-mcp-pilot-screenshot-{}.sock",
+            "tauri-pilot-mcp-screenshot-native-{}.sock",
             std::process::id()
         ));
         let _ = std::fs::remove_file(&socket);
@@ -1848,10 +1859,11 @@ mod tests {
             let mut line = String::new();
             reader.read_line(&mut line).await.expect("read request");
             let request: Request = serde_json::from_str(line.trim()).expect("parse request");
-            assert_eq!(request.method, "pilot.screenshot");
+            assert_eq!(request.method, "screenshot_native");
             let params = request.params.expect("native screenshot params present");
             assert_eq!(params["window_id"], json!(42_u64));
             assert_eq!(params["output_path"], json!("/tmp/out.png"));
+            assert_eq!(params["format"], json!("png"));
             let response = Response::success(
                 request.id,
                 json!({
@@ -1874,8 +1886,9 @@ mod tests {
         let mut args = Map::new();
         args.insert("window_id".to_owned(), json!(42_u32));
         args.insert("output_path".to_owned(), json!("/tmp/out.png"));
+        args.insert("format".to_owned(), json!("png"));
         let result = pilot
-            .call_tool_by_name("pilot.screenshot", args)
+            .call_tool_by_name("screenshot_native", args)
             .await
             .expect("tool call succeeds");
         assert_eq!(result.is_error, Some(false));

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -49,6 +49,11 @@ windows = { version = "0.61", features = [
 [target.'cfg(target_os="linux")'.dependencies]
 enigo = { version = "0.6.1", features = ["wayland"], optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-graphics = "0.24"
+image = { version = "0.25", default-features = false, features = ["png"] }
+
 [dev-dependencies]
 serial_test = "3"
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -4,6 +4,7 @@ use crate::eval::EvalEngine;
 use crate::key;
 use crate::protocol::RpcError;
 use crate::recorder::{RecordEntry, Recorder};
+use crate::screenshot;
 use crate::server::{EvalFn, FocusFn, ListWindowsFn};
 
 use std::time::Duration;
@@ -152,9 +153,21 @@ pub(crate) async fn dispatch(
             )
             .await
         }
+        // The bare `screenshot` JSON-RPC method has been the bridge-side
+        // html-to-image path since v0.1 (returns a base64 PNG data URL). The
+        // new native contract ships under `pilot.screenshot` to avoid breaking
+        // those callers. As a convenience, a `screenshot` request that carries
+        // the native-shape `output_path` param is dispatched to the native
+        // handler too — old callers (no `output_path`) keep getting the
+        // bridge result.
         "screenshot" => {
-            handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
+            if params.and_then(|p| p.get("output_path")).is_some() {
+                screenshot::handle_screenshot(params).await
+            } else {
+                handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
+            }
         }
+        "pilot.screenshot" => screenshot::handle_screenshot(params).await,
         "console.getLogs" => {
             handle_eval_method("consoleLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
@@ -1132,6 +1145,78 @@ mod tests {
         // "window" param must not appear in the JS call args
         assert!(!script.contains("\"window\""));
         assert!(script.contains("\"ref\""));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_pilot_screenshot_rejects_missing_window_id() {
+        // The bare native method must validate `window_id` before any platform
+        // path is touched, so this works the same on every host.
+        let engine = EvalEngine::new();
+        let params = json!({"output_path": "/tmp/x.png"});
+        let err = dispatch(
+            "pilot.screenshot",
+            Some(&params),
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("missing window_id must surface as Err");
+        assert_eq!(err.code, -32602);
+        assert!(
+            err.message.contains("window_id"),
+            "error message must reference window_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_screenshot_with_output_path_uses_native_handler() {
+        // Backwards-compat sanity: a `screenshot` call that carries the
+        // native-shape `output_path` is dispatched to the native handler so
+        // callers that adopt the new contract under the bare name do not fall
+        // back to the bridge by accident.
+        let engine = EvalEngine::new();
+        let params = json!({"window_id": 1_u32, "output_path": "relative/path.png"});
+        let err = dispatch(
+            "screenshot",
+            Some(&params),
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("relative path must error before any capture");
+        assert_eq!(err.code, -32602);
+        let data = err.data.as_ref().expect("error data present");
+        assert_eq!(
+            data.get("error").and_then(|v| v.as_str()),
+            Some("INVALID_OUTPUT_PATH")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_screenshot_without_output_path_routes_to_bridge() {
+        // The legacy bridge call path (no `output_path`) must keep its old
+        // "No webview available for eval" error when no eval_fn is wired —
+        // that proves it did not get diverted into the native handler.
+        let engine = EvalEngine::new();
+        let result = dispatch(
+            "screenshot",
+            Some(&json!({})),
+            &engine,
+            None,
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await;
+        let err = result.expect_err("dispatch returns Err");
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview"));
     }
 
     #[tokio::test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -153,21 +153,15 @@ pub(crate) async fn dispatch(
             )
             .await
         }
-        // The bare `screenshot` JSON-RPC method has been the bridge-side
-        // html-to-image path since v0.1 (returns a base64 PNG data URL). The
-        // new native contract ships under `pilot.screenshot` to avoid breaking
-        // those callers. As a convenience, a `screenshot` request that carries
-        // the native-shape `output_path` param is dispatched to the native
-        // handler too — old callers (no `output_path`) keep getting the
-        // bridge result.
+        // The bare `screenshot` JSON-RPC method is the bridge-side
+        // html-to-image path (returns a base64 PNG data URL); native window
+        // capture ships under the distinct `screenshot_native` method so the
+        // two surfaces can't be confused by callers or accidentally folded
+        // together by a future refactor.
         "screenshot" => {
-            if params.and_then(|p| p.get("output_path")).is_some() {
-                screenshot::handle_screenshot(params).await
-            } else {
-                handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
-            }
+            handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
         }
-        "pilot.screenshot" => screenshot::handle_screenshot(params).await,
+        "screenshot_native" => screenshot::handle_screenshot(params).await,
         "console.getLogs" => {
             handle_eval_method("consoleLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
@@ -1148,13 +1142,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_pilot_screenshot_rejects_missing_window_id() {
-        // The bare native method must validate `window_id` before any platform
+    async fn test_dispatch_screenshot_native_rejects_missing_window_id() {
+        // The native method must validate `window_id` before any platform
         // path is touched, so this works the same on every host.
         let engine = EvalEngine::new();
         let params = json!({"output_path": "/tmp/x.png"});
         let err = dispatch(
-            "pilot.screenshot",
+            "screenshot_native",
             Some(&params),
             &engine,
             None,
@@ -1172,15 +1166,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_screenshot_with_output_path_uses_native_handler() {
-        // Backwards-compat sanity: a `screenshot` call that carries the
-        // native-shape `output_path` is dispatched to the native handler so
-        // callers that adopt the new contract under the bare name do not fall
-        // back to the bridge by accident.
+    async fn test_dispatch_screenshot_native_rejects_relative_output_path() {
+        // The native method must reject a non-absolute `output_path` before
+        // any platform capture work — this works the same on every host.
         let engine = EvalEngine::new();
         let params = json!({"window_id": 1_u32, "output_path": "relative/path.png"});
         let err = dispatch(
-            "screenshot",
+            "screenshot_native",
             Some(&params),
             &engine,
             None,
@@ -1199,24 +1191,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_screenshot_without_output_path_routes_to_bridge() {
-        // The legacy bridge call path (no `output_path`) must keep its old
-        // "No webview available for eval" error when no eval_fn is wired —
-        // that proves it did not get diverted into the native handler.
+    async fn test_dispatch_screenshot_routes_to_bridge_regardless_of_params() {
+        // The bare `screenshot` JSON-RPC method always goes to the bridge
+        // (html-to-image, base64) — even if a caller mistakenly includes an
+        // `output_path` field, that is no longer a signal to dispatch to the
+        // native handler. The two surfaces are wholly separate methods.
         let engine = EvalEngine::new();
-        let result = dispatch(
-            "screenshot",
-            Some(&json!({})),
-            &engine,
-            None,
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await;
-        let err = result.expect_err("dispatch returns Err");
-        assert_eq!(err.code, -32603);
-        assert!(err.message.contains("No webview"));
+        for params in [json!({}), json!({"output_path": "/tmp/x.png"})] {
+            let result = dispatch(
+                "screenshot",
+                Some(&params),
+                &engine,
+                None,
+                None,
+                None,
+                &Recorder::new(),
+            )
+            .await;
+            let err = result.expect_err("dispatch returns Err");
+            assert_eq!(err.code, -32603);
+            assert!(err.message.contains("No webview"));
+        }
     }
 
     #[tokio::test]

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -8,11 +8,8 @@ mod handler;
 pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;
-// Scaffolded native screenshot surface; wired to internal callers in a
-// follow-up milestone. `dead_code` and `unused_imports` are suppressed at the
-// module boundary so the scaffolding can land independently of its first
-// caller.
-#[allow(dead_code, unused_imports)]
+// Native screenshot capture for the `pilot.screenshot` JSON-RPC method.
+// macOS-only today; non-macOS callers receive `PERMISSION_DENIED`.
 pub(crate) mod screenshot;
 #[cfg(any(unix, windows))]
 pub(crate) mod server;

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -8,6 +8,12 @@ mod handler;
 pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;
+// Scaffolded native screenshot surface; wired to internal callers in a
+// follow-up milestone. `dead_code` and `unused_imports` are suppressed at the
+// module boundary so the scaffolding can land independently of its first
+// caller.
+#[allow(dead_code, unused_imports)]
+pub(crate) mod screenshot;
 #[cfg(any(unix, windows))]
 pub(crate) mod server;
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -8,7 +8,7 @@ mod handler;
 pub(crate) mod key;
 pub(crate) mod protocol;
 pub(crate) mod recorder;
-// Native screenshot capture for the `pilot.screenshot` JSON-RPC method.
+// Native screenshot capture for the `screenshot_native` JSON-RPC method.
 // macOS-only today; non-macOS callers receive `PERMISSION_DENIED`.
 pub(crate) mod screenshot;
 #[cfg(any(unix, windows))]

--- a/crates/tauri-plugin-pilot/src/protocol.rs
+++ b/crates/tauri-plugin-pilot/src/protocol.rs
@@ -1,5 +1,20 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
+/// JSON-RPC 2.0 numeric error codes (subset used by this crate).
+///
+/// Centralised here so every handler and test references the same constants
+/// rather than scattering `-32602`/`-32603` literals across modules.
+#[cfg_attr(
+    not(any(unix, windows)),
+    allow(dead_code, reason = "only referenced by the macOS/IPC handlers")
+)]
+pub(crate) const RPC_INVALID_PARAMS: i32 = -32602;
+#[cfg_attr(
+    not(any(unix, windows)),
+    allow(dead_code, reason = "only referenced by the macOS/IPC handlers")
+)]
+pub(crate) const RPC_INTERNAL_ERROR: i32 = -32603;
+
 /// Deserialize params, normalizing `null` to `None`.
 fn deserialize_params<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
 where

--- a/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+
+use super::ScreenshotError;
+
+/// Capture a window's pixels via `CGWindowListCreateImage` and write a PNG to `path`.
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns no image,
+/// the raw buffer is too small for the reported dimensions, the dimensions do
+/// not fit a `u32`, or the PNG encoder fails to write the file.
+#[cfg(target_os = "macos")]
+pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), ScreenshotError> {
+    use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+    use core_graphics::window::{
+        create_image, kCGWindowImageBoundsIgnoreFraming, kCGWindowImageNominalResolution,
+        kCGWindowListOptionIncludingWindow,
+    };
+
+    let rect = CGRect::new(
+        &CGPoint::new(0.0, 0.0),
+        &CGSize::new(f64::INFINITY, f64::INFINITY),
+    );
+    let cg_image = create_image(
+        rect,
+        kCGWindowListOptionIncludingWindow,
+        window_id,
+        kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution,
+    )
+    .ok_or_else(|| ScreenshotError::CaptureFailed {
+        message: "CGWindowListCreateImage returned null".to_owned(),
+    })?;
+
+    let width = cg_image.width();
+    let height = cg_image.height();
+    let bytes_per_row = cg_image.bytes_per_row();
+    let data = cg_image.data();
+    let src = data.bytes();
+
+    let row_bytes = width
+        .checked_mul(4)
+        .ok_or_else(|| ScreenshotError::CaptureFailed {
+            message: "row size overflow".to_owned(),
+        })?;
+    let total = row_bytes
+        .checked_mul(height)
+        .ok_or_else(|| ScreenshotError::CaptureFailed {
+            message: "buffer size overflow".to_owned(),
+        })?;
+    let mut rgba: Vec<u8> = Vec::with_capacity(total);
+    for y in 0..height {
+        let row_start = y * bytes_per_row;
+        let row_end =
+            row_start
+                .checked_add(row_bytes)
+                .ok_or_else(|| ScreenshotError::CaptureFailed {
+                    message: "CGImage row offset overflow".to_owned(),
+                })?;
+        if row_end > src.len() {
+            return Err(ScreenshotError::CaptureFailed {
+                message: "CGImage row out of bounds".to_owned(),
+            });
+        }
+        let row = &src[row_start..row_end];
+        for px in row.chunks_exact(4) {
+            // BGRA -> RGBA
+            rgba.extend_from_slice(&[px[2], px[1], px[0], px[3]]);
+        }
+    }
+
+    let w = u32::try_from(width).map_err(|_| ScreenshotError::CaptureFailed {
+        message: "width does not fit in u32".to_owned(),
+    })?;
+    let h = u32::try_from(height).map_err(|_| ScreenshotError::CaptureFailed {
+        message: "height does not fit in u32".to_owned(),
+    })?;
+
+    image::save_buffer(path, &rgba, w, h, image::ColorType::Rgba8).map_err(|err| {
+        ScreenshotError::CaptureFailed {
+            message: format!("write cgwindow png {}: {err}", path.display()),
+        }
+    })
+}
+
+/// Non-macOS stub for the CGWindow capture path.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn capture_cgwindow(_window_id: u32, _path: &Path) -> Result<(), ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
@@ -4,6 +4,14 @@ use super::ScreenshotError;
 
 /// Capture a window's pixels via `CGWindowListCreateImage` and write a PNG to `path`.
 ///
+/// # Output color
+///
+/// CoreGraphics returns the captured buffer as **premultiplied BGRA**. This
+/// function demultiplies into **straight RGBA** before encoding, so the PNG
+/// on disk holds an unassociated alpha channel — what downstream pixel-diff
+/// and image-processing pipelines expect by default. Pixels with `alpha == 0`
+/// are written as transparent black.
+///
 /// # Errors
 ///
 /// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns no
@@ -36,6 +44,15 @@ pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), Screen
     let data = cg_image.data();
     let src = data.bytes();
 
+    // Fail fast on dimensions that the PNG encoder can't accept before any
+    // large allocation is attempted.
+    let width_u32 = u32::try_from(width).map_err(|_| ScreenshotError::CaptureFailed {
+        message: "width does not fit in u32".to_owned(),
+    })?;
+    let height_u32 = u32::try_from(height).map_err(|_| ScreenshotError::CaptureFailed {
+        message: "height does not fit in u32".to_owned(),
+    })?;
+
     let row_bytes = width
         .checked_mul(4)
         .ok_or_else(|| ScreenshotError::CaptureFailed {
@@ -48,6 +65,10 @@ pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), Screen
         })?;
     let mut rgba: Vec<u8> = Vec::with_capacity(total);
     for y in 0..height {
+        // `y * bytes_per_row` cannot overflow `usize`: `y < height` and the
+        // resulting offset is bounded above by `src.len()`, which is a `usize`
+        // by construction (CFData length). The two `checked_mul`s above guard
+        // the only unconstrained arithmetic (`Vec::with_capacity(total)`).
         let row_start = y * bytes_per_row;
         let row_end =
             row_start
@@ -62,19 +83,31 @@ pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), Screen
         }
         let row = &src[row_start..row_end];
         for px in row.chunks_exact(4) {
-            // BGRA -> RGBA
-            rgba.extend_from_slice(&[px[2], px[1], px[0], px[3]]);
+            // CoreGraphics returns premultiplied BGRA. Demultiply into
+            // straight RGBA so downstream pixel-diff and image-processing
+            // pipelines see a normal alpha channel; `alpha == 0` collapses to
+            // transparent black per the standard convention.
+            let blue = px[0];
+            let green = px[1];
+            let red = px[2];
+            let alpha = px[3];
+            let (red_out, green_out, blue_out) = if alpha == 0 {
+                (0u8, 0u8, 0u8)
+            } else if alpha == 255 {
+                (red, green, blue)
+            } else {
+                let alpha_u16 = u16::from(alpha);
+                let demul = |channel: u8| {
+                    let value = (u16::from(channel) * 255 + alpha_u16 / 2) / alpha_u16;
+                    value.min(255) as u8
+                };
+                (demul(red), demul(green), demul(blue))
+            };
+            rgba.extend_from_slice(&[red_out, green_out, blue_out, alpha]);
         }
     }
 
-    let w = u32::try_from(width).map_err(|_| ScreenshotError::CaptureFailed {
-        message: "width does not fit in u32".to_owned(),
-    })?;
-    let h = u32::try_from(height).map_err(|_| ScreenshotError::CaptureFailed {
-        message: "height does not fit in u32".to_owned(),
-    })?;
-
-    image::save_buffer(path, &rgba, w, h, image::ColorType::Rgba8).map_err(|err| {
+    image::save_buffer(path, &rgba, width_u32, height_u32, image::ColorType::Rgba8).map_err(|err| {
         ScreenshotError::CaptureFailed {
             message: format!("write cgwindow png {}: {err}", path.display()),
         }

--- a/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/cgwindow.rs
@@ -6,11 +6,9 @@ use super::ScreenshotError;
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns no image,
-/// the raw buffer is too small for the reported dimensions, the dimensions do
-/// not fit a `u32`, or the PNG encoder fails to write the file.
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns no
+/// image, the raw buffer is too small for the reported dimensions, the
+/// dimensions do not fit a `u32`, or the PNG encoder fails to write the file.
 pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), ScreenshotError> {
     use core_graphics::geometry::{CGPoint, CGRect, CGSize};
     use core_graphics::window::{
@@ -81,14 +79,4 @@ pub(crate) fn capture_cgwindow(window_id: u32, path: &Path) -> Result<(), Screen
             message: format!("write cgwindow png {}: {err}", path.display()),
         }
     })
-}
-
-/// Non-macOS stub for the CGWindow capture path.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn capture_cgwindow(_window_id: u32, _path: &Path) -> Result<(), ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/error.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/error.rs
@@ -2,6 +2,13 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum ScreenshotError {
+    // Constructed only in `cfg(not(target_os = "macos"))` stubs; the macOS
+    // build still matches it so the cross-platform handler can map it to the
+    // `PERMISSION_DENIED` IPC error without a per-arch dispatch table.
+    #[allow(
+        dead_code,
+        reason = "constructed in cfg(not(target_os = \"macos\")) stubs"
+    )]
     #[error("native screenshot capture is unsupported on this platform")]
     PlatformUnsupported,
     #[error("native screenshot capture failed: {message}")]

--- a/crates/tauri-plugin-pilot/src/screenshot/error.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum ScreenshotError {
+    #[error("native screenshot capture is unsupported on this platform")]
+    PlatformUnsupported,
+    #[error("native screenshot capture failed: {message}")]
+    CaptureFailed { message: String },
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/error.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/error.rs
@@ -2,12 +2,13 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum ScreenshotError {
-    // Constructed only in `cfg(not(target_os = "macos"))` stubs; the macOS
-    // build still matches it so the cross-platform handler can map it to the
-    // `PERMISSION_DENIED` IPC error without a per-arch dispatch table.
+    // Never constructed today; the non-macOS IPC branch returns
+    // `PERMISSION_DENIED` directly without going through this enum. Kept so
+    // the macOS dispatcher's exhaustive match stays honest if a future stub
+    // ever surfaces an unsupported-platform error from the macOS code path.
     #[allow(
         dead_code,
-        reason = "constructed in cfg(not(target_os = \"macos\")) stubs"
+        reason = "kept for the exhaustive match in the macOS dispatcher"
     )]
     #[error("native screenshot capture is unsupported on this platform")]
     PlatformUnsupported,

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -1,0 +1,561 @@
+//! JSON-RPC handler for `pilot.screenshot`.
+//!
+//! The contract (path-only, `window_id`-targeted, atomic write, TCC-fallback
+//! surfaced as metadata) is implemented in [`handle_screenshot`]. The handler
+//! validates the request shape on every platform, then dispatches to the
+//! macOS-only native capture pipeline; non-macOS callers always receive
+//! `PERMISSION_DENIED` so the contract surface is identical on every host.
+
+#[cfg(target_os = "macos")]
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+use crate::protocol::RpcError;
+
+/// Numeric JSON-RPC error code for invalid params per the JSON-RPC 2.0 spec.
+const RPC_INVALID_PARAMS: i32 = -32602;
+/// Numeric JSON-RPC error code for internal errors per the JSON-RPC 2.0 spec.
+const RPC_INTERNAL_ERROR: i32 = -32603;
+
+/// Domain error codes carried in the JSON-RPC `error.data.error` field.
+///
+/// Kept centralized so tests, the implementation, and the docs cannot drift.
+pub(crate) mod codes {
+    pub(crate) const INVALID_OUTPUT_PATH: &str = "INVALID_OUTPUT_PATH";
+    pub(crate) const UNSUPPORTED_FORMAT: &str = "UNSUPPORTED_FORMAT";
+    pub(crate) const WINDOW_NOT_FOUND: &str = "WINDOW_NOT_FOUND";
+    pub(crate) const CAPTURE_FAILED: &str = "CAPTURE_FAILED";
+    pub(crate) const PERMISSION_DENIED: &str = "PERMISSION_DENIED";
+}
+
+/// Build a JSON-RPC error response with the given numeric code, message, and
+/// domain error code carried in `data.error`. Extra structured detail can be
+/// merged in via `extras`.
+fn rpc_error(rpc_code: i32, domain: &str, message: impl Into<String>, extras: Value) -> RpcError {
+    let message = message.into();
+    let mut data = serde_json::Map::new();
+    data.insert("error".to_owned(), Value::String(domain.to_owned()));
+    data.insert("message".to_owned(), Value::String(message.clone()));
+    if let Value::Object(obj) = extras {
+        for (k, v) in obj {
+            data.insert(k, v);
+        }
+    }
+    RpcError {
+        code: rpc_code,
+        message,
+        data: Some(Value::Object(data)),
+    }
+}
+
+/// Parsed view of the `pilot.screenshot` request params with all field-level
+/// validation already enforced by the validators below.
+struct ScreenshotRequest {
+    window_id: u32,
+    output_path: std::path::PathBuf,
+}
+
+/// Validate the request envelope. Order of checks is fixed by the contract:
+///   1. `format` must be `"png"` if present (`UNSUPPORTED_FORMAT`)
+///   2. `window_id` must be a u32 (`INVALID_PARAMS`)
+///   3. `output_path` must be a string, absolute, with an existing parent
+///      directory (`INVALID_OUTPUT_PATH`)
+fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> {
+    let obj = params.and_then(Value::as_object).ok_or_else(|| {
+        rpc_error(
+            RPC_INVALID_PARAMS,
+            "INVALID_PARAMS",
+            "screenshot requires an object params payload",
+            Value::Null,
+        )
+    })?;
+
+    // `format` is validated before `window_id` so callers using an unsupported
+    // codec see the specific error rather than a generic missing-field one
+    // when they also forgot `window_id`.
+    let format = obj.get("format").and_then(Value::as_str).unwrap_or("png");
+    if format != "png" {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::UNSUPPORTED_FORMAT,
+            format!("format \"{format}\" is not supported in v1 (only \"png\")"),
+            Value::Null,
+        ));
+    }
+
+    let window_id_value = obj.get("window_id").ok_or_else(|| {
+        rpc_error(
+            RPC_INVALID_PARAMS,
+            "INVALID_PARAMS",
+            "screenshot requires a numeric \"window_id\"",
+            Value::Null,
+        )
+    })?;
+    let window_id_u64 = window_id_value.as_u64().ok_or_else(|| {
+        rpc_error(
+            RPC_INVALID_PARAMS,
+            "INVALID_PARAMS",
+            "\"window_id\" must be a non-negative integer",
+            Value::Null,
+        )
+    })?;
+    let window_id = u32::try_from(window_id_u64).map_err(|_| {
+        rpc_error(
+            RPC_INVALID_PARAMS,
+            "INVALID_PARAMS",
+            "\"window_id\" overflows u32",
+            Value::Null,
+        )
+    })?;
+
+    let output_path_str = obj
+        .get("output_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            rpc_error(
+                RPC_INVALID_PARAMS,
+                codes::INVALID_OUTPUT_PATH,
+                "screenshot requires a string \"output_path\"",
+                Value::Null,
+            )
+        })?;
+    let output_path = std::path::PathBuf::from(output_path_str);
+    if !output_path.is_absolute() {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::INVALID_OUTPUT_PATH,
+            format!(
+                "output_path must be absolute, got \"{}\"",
+                output_path.display()
+            ),
+            Value::Null,
+        ));
+    }
+    let parent = output_path.parent().ok_or_else(|| {
+        rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::INVALID_OUTPUT_PATH,
+            format!(
+                "output_path \"{}\" has no parent directory",
+                output_path.display()
+            ),
+            Value::Null,
+        )
+    })?;
+    // Refuse to create parent directories: an absolute path beneath a
+    // non-existent directory could be an attacker-controlled prefix on a
+    // shared host. Caller must pre-create the destination directory.
+    if !parent.as_os_str().is_empty() && !parent.is_dir() {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::INVALID_OUTPUT_PATH,
+            format!(
+                "output_path parent directory does not exist: {}",
+                parent.display()
+            ),
+            Value::Null,
+        ));
+    }
+
+    Ok(ScreenshotRequest {
+        window_id,
+        output_path,
+    })
+}
+
+/// Top-level entry point used by the JSON-RPC dispatcher.
+///
+/// Returns the contract-shaped success result or a structured `RpcError`. The
+/// success result fills the response with `output_path`, `window_id`, pixel
+/// dimensions, `scale_factor`, `byte_size`, the chosen `backend`, and the
+/// `tcc_denied` flag.
+pub(crate) async fn handle_screenshot(params: Option<&Value>) -> Result<Value, RpcError> {
+    let req = parse_request(params)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        tokio::task::spawn_blocking(move || run_macos(req))
+            .await
+            .map_err(|join_err| {
+                rpc_error(
+                    RPC_INTERNAL_ERROR,
+                    codes::CAPTURE_FAILED,
+                    format!("screenshot capture task did not complete: {join_err}"),
+                    Value::Null,
+                )
+            })?
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        // The validators above always run so non-macOS callers see contract
+        // violations (bad format, relative path) ahead of the platform error.
+        let _ = req;
+        Err(rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::PERMISSION_DENIED,
+            "screenshot is only available on macOS in this release",
+            Value::Null,
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
+    use super::{
+        ScreenshotBackend, ScreenshotError, WindowBounds, get_window_bounds,
+        list_layer_zero_windows, selected_backend,
+    };
+
+    let ScreenshotRequest {
+        window_id,
+        output_path,
+    } = req;
+
+    let discovered = list_layer_zero_windows().map_err(|err| match err {
+        ScreenshotError::PlatformUnsupported => rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::PERMISSION_DENIED,
+            "screenshot is only available on macOS in this release",
+            Value::Null,
+        ),
+        ScreenshotError::CaptureFailed { message } => rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::CAPTURE_FAILED,
+            format!("failed to enumerate windows: {message}"),
+            Value::Null,
+        ),
+    })?;
+
+    if !discovered.iter().any(|w| w.window_id == window_id) {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::WINDOW_NOT_FOUND,
+            format!("window_id {window_id} not found"),
+            json!({
+                "available_windows": render_available_windows(&discovered),
+            }),
+        ));
+    }
+
+    let tmp_path = tmp_path_for(&output_path);
+
+    let primary = selected_backend();
+    let (backend, tcc_denied) = capture_with_fallback(primary, window_id, &tmp_path)?;
+
+    let metadata = match read_png_metadata(&tmp_path) {
+        Ok(m) => m,
+        Err(err) => {
+            cleanup_tmp(&tmp_path);
+            return Err(err);
+        }
+    };
+
+    let logical_bounds = get_window_bounds(window_id).unwrap_or(WindowBounds {
+        width: 0.0,
+        height: 0.0,
+    });
+    let scale_factor = compute_scale_factor(metadata.width, logical_bounds);
+
+    if let Err(err) = std::fs::rename(&tmp_path, &output_path) {
+        cleanup_tmp(&tmp_path);
+        return Err(rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::CAPTURE_FAILED,
+            format!(
+                "failed to rename {} to {}: {err}",
+                tmp_path.display(),
+                output_path.display()
+            ),
+            Value::Null,
+        ));
+    }
+
+    // The other `ScreenshotBackend` variants never reach this point because
+    // the dispatcher in `capture_with_fallback` already maps them to error
+    // responses, so we only need to encode the two backends that produce a
+    // success result.
+    let backend_label = match backend {
+        ScreenshotBackend::ScreencaptureProbe => "screencapture",
+        _ => "cgwindow",
+    };
+    Ok(json!({
+        "output_path": output_path.display().to_string(),
+        "window_id": window_id,
+        "width": metadata.width,
+        "height": metadata.height,
+        "scale_factor": scale_factor,
+        "byte_size": metadata.byte_size,
+        "backend": backend_label,
+        "tcc_denied": tcc_denied,
+    }))
+}
+
+#[cfg(target_os = "macos")]
+fn render_available_windows(discovered: &[super::DiscoveredWindow]) -> Vec<Value> {
+    discovered
+        .iter()
+        .map(|w| {
+            json!({
+                "window_id": w.window_id,
+                "owner": w.owner,
+                "title": w.title,
+                "layer": w.layer,
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+struct PngMetadata {
+    width: u32,
+    height: u32,
+    byte_size: u64,
+}
+
+/// Compute the temp-write target alongside the final output path. Embedding
+/// the pid avoids two concurrent captures racing on the same final path from
+/// stomping each other's tmp file before the rename.
+#[cfg(target_os = "macos")]
+fn tmp_path_for(final_path: &Path) -> std::path::PathBuf {
+    let mut name = final_path
+        .file_name()
+        .map(std::ffi::OsString::from)
+        .unwrap_or_default();
+    name.push(format!(".tmp.{}", std::process::id()));
+    final_path.with_file_name(name)
+}
+
+/// Remove the tmp file if it exists. Errors during cleanup are intentionally
+/// swallowed because the caller is already returning an error and we do not
+/// want to mask the original cause.
+#[cfg(target_os = "macos")]
+fn cleanup_tmp(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+#[cfg(target_os = "macos")]
+fn capture_with_fallback(
+    primary: super::ScreenshotBackend,
+    window_id: u32,
+    tmp_path: &Path,
+) -> Result<(super::ScreenshotBackend, bool), RpcError> {
+    use super::{ScreenshotBackend, capture_cgwindow, capture_screencapture};
+
+    match primary {
+        ScreenshotBackend::ScreencaptureProbe => {
+            match capture_screencapture(window_id, tmp_path) {
+                Ok(()) => Ok((ScreenshotBackend::ScreencaptureProbe, false)),
+                Err(primary_err) => {
+                    // TCC was granted at probe time but the per-window capture
+                    // still failed. Try the CGWindow fallback so the caller
+                    // does not lose the artifact when permission was revoked
+                    // between probe and call.
+                    match capture_cgwindow(window_id, tmp_path) {
+                        Ok(()) => Ok((ScreenshotBackend::CgWindowList, true)),
+                        Err(fallback_err) => {
+                            cleanup_tmp(tmp_path);
+                            Err(rpc_error(
+                                RPC_INTERNAL_ERROR,
+                                codes::CAPTURE_FAILED,
+                                format!(
+                                    "screencapture failed ({primary_err}) and CGWindow fallback also failed ({fallback_err})"
+                                ),
+                                Value::Null,
+                            ))
+                        }
+                    }
+                }
+            }
+        }
+        ScreenshotBackend::CgWindowList => match capture_cgwindow(window_id, tmp_path) {
+            Ok(()) => Ok((ScreenshotBackend::CgWindowList, true)),
+            Err(err) => {
+                cleanup_tmp(tmp_path);
+                Err(rpc_error(
+                    RPC_INTERNAL_ERROR,
+                    codes::CAPTURE_FAILED,
+                    format!("CGWindow capture failed: {err}"),
+                    Value::Null,
+                ))
+            }
+        },
+        ScreenshotBackend::WkWebViewSnapshot | ScreenshotBackend::PlatformUnsupported => {
+            Err(rpc_error(
+                RPC_INTERNAL_ERROR,
+                codes::PERMISSION_DENIED,
+                "screenshot is only available on macOS in this release",
+                Value::Null,
+            ))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn read_png_metadata(path: &Path) -> Result<PngMetadata, RpcError> {
+    let metadata = std::fs::metadata(path).map_err(|err| {
+        rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::CAPTURE_FAILED,
+            format!("failed to stat captured PNG {}: {err}", path.display()),
+            Value::Null,
+        )
+    })?;
+    let byte_size = metadata.len();
+
+    let img = image::open(path).map_err(|err| {
+        rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::CAPTURE_FAILED,
+            format!("failed to decode captured PNG {}: {err}", path.display()),
+            Value::Null,
+        )
+    })?;
+    Ok(PngMetadata {
+        width: img.width(),
+        height: img.height(),
+        byte_size,
+    })
+}
+
+/// Derive `scale_factor` by dividing pixel width by logical (point) width.
+/// Falls back to 1.0 when the logical bounds are unknown or zero so the
+/// response never returns NaN/Inf.
+#[cfg(target_os = "macos")]
+fn compute_scale_factor(pixel_width: u32, logical: super::WindowBounds) -> f32 {
+    if logical.width <= 0.0 {
+        return 1.0;
+    }
+    let scale = f64::from(pixel_width) / logical.width;
+    if scale.is_finite() && scale > 0.0 {
+        // Round to 2 decimal places to avoid `2.00000003` artifacts when the
+        // CGWindowBounds Width carries float noise. Strict-pixel-diff harnesses
+        // tag artifacts by this value, so stability matters more than exact
+        // bit-for-bit fidelity. Truncation to f32 is intentional: Retina scale
+        // factors land in a small finite range (1.0 / 2.0 / 3.0) that f32
+        // represents losslessly.
+        let rounded = (scale * 100.0).round() / 100.0;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "Retina scale factors fit in f32 without loss"
+        )]
+        let scale_f32 = rounded as f32;
+        scale_f32
+    } else {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn err_data(err: &RpcError) -> &Value {
+        err.data.as_ref().expect("error data present")
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_window_id() {
+        let params = json!({"output_path": "/tmp/x.png"});
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject missing window_id");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert!(
+            err.message.contains("window_id"),
+            "message must mention window_id, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_relative_output_path() {
+        let params = json!({"window_id": 42_u32, "output_path": "relative/path.png"});
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject relative output_path");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert_eq!(
+            err_data(&err).get("error").and_then(Value::as_str),
+            Some(codes::INVALID_OUTPUT_PATH)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_nonexistent_parent_directory() {
+        let params = json!({
+            "window_id": 42_u32,
+            "output_path": "/tauri-pilot-test-no-such-dir-9f3a/x.png",
+        });
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject missing parent dir");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert_eq!(
+            err_data(&err).get("error").and_then(Value::as_str),
+            Some(codes::INVALID_OUTPUT_PATH)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_format() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "tauri-pilot-test-screenshot-{}.png",
+            std::process::id()
+        ));
+        let params = json!({
+            "window_id": 42_u32,
+            "output_path": path.display().to_string(),
+            "format": "jpeg",
+        });
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject jpeg format");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert_eq!(
+            err_data(&err).get("error").and_then(Value::as_str),
+            Some(codes::UNSUPPORTED_FORMAT)
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn window_not_found_returns_available_list() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "tauri-pilot-test-screenshot-not-found-{}.png",
+            std::process::id()
+        ));
+        // 0 is `kCGNullWindowID` per CoreGraphics and never identifies a real
+        // window, so this is the most reliably-missing window_id we can pick
+        // without touching the host's display state.
+        let params = json!({
+            "window_id": u32::MAX,
+            "output_path": path.display().to_string(),
+        });
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject unknown window_id");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert_eq!(
+            err_data(&err).get("error").and_then(Value::as_str),
+            Some(codes::WINDOW_NOT_FOUND)
+        );
+        let list = err_data(&err)
+            .get("available_windows")
+            .and_then(Value::as_array)
+            .expect("available_windows present");
+        // On a headless CI runner the list may be empty; the contract only
+        // requires the key, not a minimum length. Assert shape on any entry
+        // that does come back so the discovery payload stays stable.
+        if let Some(first) = list.first() {
+            assert!(first.get("window_id").is_some());
+            assert!(first.get("owner").is_some());
+            assert!(first.get("title").is_some());
+            assert!(first.get("layer").is_some());
+        }
+    }
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -1,4 +1,4 @@
-//! JSON-RPC handler for `pilot.screenshot`.
+//! JSON-RPC handler for `screenshot_native`.
 //!
 //! The contract (path-only, `window_id`-targeted, atomic write, TCC-fallback
 //! surfaced as metadata) is implemented in [`handle_screenshot`]. The handler
@@ -8,22 +8,20 @@
 
 #[cfg(target_os = "macos")]
 use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::Value;
 #[cfg(target_os = "macos")]
 use serde_json::json;
 
-use crate::protocol::RpcError;
-
-/// Numeric JSON-RPC error code for invalid params per the JSON-RPC 2.0 spec.
-const RPC_INVALID_PARAMS: i32 = -32602;
-/// Numeric JSON-RPC error code for internal errors per the JSON-RPC 2.0 spec.
-const RPC_INTERNAL_ERROR: i32 = -32603;
+use crate::protocol::{RPC_INTERNAL_ERROR, RPC_INVALID_PARAMS, RpcError};
 
 /// Domain error codes carried in the JSON-RPC `error.data.error` field.
 ///
 /// Kept centralized so tests, the implementation, and the docs cannot drift.
 pub(crate) mod codes {
+    pub(crate) const INVALID_PARAMS: &str = "INVALID_PARAMS";
     pub(crate) const INVALID_OUTPUT_PATH: &str = "INVALID_OUTPUT_PATH";
     pub(crate) const UNSUPPORTED_FORMAT: &str = "UNSUPPORTED_FORMAT";
     #[cfg_attr(
@@ -59,7 +57,7 @@ fn rpc_error(rpc_code: i32, domain: &str, message: impl Into<String>, extras: Va
     }
 }
 
-/// Parsed view of the `pilot.screenshot` request params with all field-level
+/// Parsed view of the `screenshot_native` request params with all field-level
 /// validation already enforced by the validators below.
 #[cfg_attr(
     not(target_os = "macos"),
@@ -82,7 +80,7 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
     let obj = params.and_then(Value::as_object).ok_or_else(|| {
         rpc_error(
             RPC_INVALID_PARAMS,
-            "INVALID_PARAMS",
+            codes::INVALID_PARAMS,
             "screenshot requires an object params payload",
             Value::Null,
         )
@@ -104,7 +102,7 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
     let window_id_value = obj.get("window_id").ok_or_else(|| {
         rpc_error(
             RPC_INVALID_PARAMS,
-            "INVALID_PARAMS",
+            codes::INVALID_PARAMS,
             "screenshot requires a numeric \"window_id\"",
             Value::Null,
         )
@@ -112,7 +110,7 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
     let window_id_u64 = window_id_value.as_u64().ok_or_else(|| {
         rpc_error(
             RPC_INVALID_PARAMS,
-            "INVALID_PARAMS",
+            codes::INVALID_PARAMS,
             "\"window_id\" must be a non-negative integer",
             Value::Null,
         )
@@ -120,12 +118,24 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
     let window_id = u32::try_from(window_id_u64).map_err(|_| {
         rpc_error(
             RPC_INVALID_PARAMS,
-            "INVALID_PARAMS",
+            codes::INVALID_PARAMS,
             "\"window_id\" overflows u32",
             Value::Null,
         )
     })?;
 
+    let output_path = parse_output_path(obj)?;
+
+    Ok(ScreenshotRequest {
+        window_id,
+        output_path,
+    })
+}
+
+/// Pull `output_path` out of the request payload and apply the security
+/// contract: must be a string, absolute, not a symlink, and live under an
+/// existing parent directory.
+fn parse_output_path(obj: &serde_json::Map<String, Value>) -> Result<std::path::PathBuf, RpcError> {
     let output_path_str = obj
         .get("output_path")
         .and_then(Value::as_str)
@@ -144,6 +154,22 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
             codes::INVALID_OUTPUT_PATH,
             format!(
                 "output_path must be absolute, got \"{}\"",
+                output_path.display()
+            ),
+            Value::Null,
+        ));
+    }
+    // A pre-existing symlink at `output_path` is a footgun: the atomic rename
+    // would replace the symlink itself (so the link's target is unchanged), but
+    // a future read-back through the same path follows the link to wherever the
+    // attacker last pointed it. Refusing symlinks here makes the contract
+    // ("output_path is the file on disk") hold for the caller.
+    if output_path.is_symlink() {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::INVALID_OUTPUT_PATH,
+            format!(
+                "output_path must not be a symlink: {}",
                 output_path.display()
             ),
             Value::Null,
@@ -174,11 +200,7 @@ fn parse_request(params: Option<&Value>) -> Result<ScreenshotRequest, RpcError> 
             Value::Null,
         ));
     }
-
-    Ok(ScreenshotRequest {
-        window_id,
-        output_path,
-    })
+    Ok(output_path)
 }
 
 /// Top-level entry point used by the JSON-RPC dispatcher.
@@ -221,8 +243,8 @@ pub(crate) async fn handle_screenshot(params: Option<&Value>) -> Result<Value, R
 #[cfg(target_os = "macos")]
 fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
     use super::{
-        ScreenshotBackend, ScreenshotError, WindowBounds, get_window_bounds,
-        list_layer_zero_windows, selected_backend,
+        EnumeratedLayerZeroWindows, ScreenshotBackend, ScreenshotError, WindowBounds,
+        enumerate_layer_zero_windows, selected_backend,
     };
 
     let ScreenshotRequest {
@@ -230,7 +252,14 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         output_path,
     } = req;
 
-    let discovered = list_layer_zero_windows().map_err(|err| match err {
+    // Single pass over the on-screen window list collects both the
+    // `available_windows` payload for WINDOW_NOT_FOUND and the target's
+    // bounds — one CGWindowListCopyWindowInfo snapshot instead of two,
+    // which also closes the TOCTOU between the two former calls.
+    let EnumeratedLayerZeroWindows {
+        available: discovered,
+        target_bounds,
+    } = enumerate_layer_zero_windows(window_id).map_err(|err| match err {
         ScreenshotError::PlatformUnsupported => rpc_error(
             RPC_INTERNAL_ERROR,
             codes::PERMISSION_DENIED,
@@ -269,7 +298,7 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         }
     };
 
-    let logical_bounds = get_window_bounds(window_id).unwrap_or(WindowBounds {
+    let logical_bounds = target_bounds.unwrap_or(WindowBounds {
         width: 0.0,
         height: 0.0,
     });
@@ -291,11 +320,14 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
 
     // The other `ScreenshotBackend` variants never reach this point because
     // the dispatcher in `capture_with_fallback` already maps them to error
-    // responses, so we only need to encode the two backends that produce a
-    // success result.
+    // responses. The match is exhaustive so a future backend variant forces
+    // an explicit decision here instead of silently flowing into a fallback.
     let backend_label = match backend {
         ScreenshotBackend::ScreencaptureProbe => "screencapture",
-        _ => "cgwindow",
+        ScreenshotBackend::CgWindowList => "cgwindow",
+        ScreenshotBackend::WkWebViewSnapshot | ScreenshotBackend::PlatformUnsupported => {
+            unreachable!("capture_with_fallback returns Err for these variants")
+        }
     };
     Ok(json!({
         "output_path": output_path.display().to_string(),
@@ -331,25 +363,40 @@ struct PngMetadata {
     byte_size: u64,
 }
 
-/// Compute the temp-write target alongside the final output path. Embedding
-/// the pid avoids two concurrent captures racing on the same final path from
-/// stomping each other's tmp file before the rename.
+/// Monotonic counter appended to the tmp filename so two concurrent captures
+/// from the same process targeting the same final path never collide on disk.
+#[cfg(target_os = "macos")]
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Compute the temp-write target alongside the final output path. Combining
+/// the pid (cross-process disambiguator) with a process-local atomic counter
+/// (intra-process disambiguator) guarantees a fresh tmp filename even when
+/// multiple captures race on the same final path.
 #[cfg(target_os = "macos")]
 fn tmp_path_for(final_path: &Path) -> std::path::PathBuf {
     let mut name = final_path
         .file_name()
         .map(std::ffi::OsString::from)
         .unwrap_or_default();
-    name.push(format!(".tmp.{}", std::process::id()));
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    name.push(format!(".tmp.{}.{}", std::process::id(), counter));
     final_path.with_file_name(name)
 }
 
-/// Remove the tmp file if it exists. Errors during cleanup are intentionally
-/// swallowed because the caller is already returning an error and we do not
-/// want to mask the original cause.
+/// Remove the tmp file if it exists. Errors during cleanup do not propagate —
+/// the caller is already returning the original capture failure — but they are
+/// logged so a lingering tmp file does not vanish silently from operator view.
 #[cfg(target_os = "macos")]
 fn cleanup_tmp(path: &Path) {
-    let _ = std::fs::remove_file(path);
+    if let Err(err) = std::fs::remove_file(path)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            tmp_path = %path.display(),
+            error = %err,
+            "failed to remove tauri-pilot screenshot tmp file",
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -421,17 +468,32 @@ fn read_png_metadata(path: &Path) -> Result<PngMetadata, RpcError> {
     })?;
     let byte_size = metadata.len();
 
-    let img = image::open(path).map_err(|err| {
+    // `ImageReader::into_dimensions` parses the PNG header (IHDR chunk) only —
+    // a few hundred bytes — instead of decoding the entire raster. For a 4K
+    // Retina capture this avoids ~33 MiB of pointless RGBA allocation just to
+    // read width/height for the response payload.
+    let reader = image::ImageReader::open(path).map_err(|err| {
         rpc_error(
             RPC_INTERNAL_ERROR,
             codes::CAPTURE_FAILED,
-            format!("failed to decode captured PNG {}: {err}", path.display()),
+            format!("failed to open captured PNG {}: {err}", path.display()),
+            Value::Null,
+        )
+    })?;
+    let (width, height) = reader.into_dimensions().map_err(|err| {
+        rpc_error(
+            RPC_INTERNAL_ERROR,
+            codes::CAPTURE_FAILED,
+            format!(
+                "failed to read PNG dimensions from {}: {err}",
+                path.display()
+            ),
             Value::Null,
         )
     })?;
     Ok(PngMetadata {
-        width: img.width(),
-        height: img.height(),
+        width,
+        height,
         byte_size,
     })
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -9,7 +9,9 @@
 #[cfg(target_os = "macos")]
 use std::path::Path;
 
-use serde_json::{Value, json};
+use serde_json::Value;
+#[cfg(target_os = "macos")]
+use serde_json::json;
 
 use crate::protocol::RpcError;
 
@@ -24,7 +26,15 @@ const RPC_INTERNAL_ERROR: i32 = -32603;
 pub(crate) mod codes {
     pub(crate) const INVALID_OUTPUT_PATH: &str = "INVALID_OUTPUT_PATH";
     pub(crate) const UNSUPPORTED_FORMAT: &str = "UNSUPPORTED_FORMAT";
+    #[cfg_attr(
+        not(target_os = "macos"),
+        allow(dead_code, reason = "only referenced by the macOS capture path")
+    )]
     pub(crate) const WINDOW_NOT_FOUND: &str = "WINDOW_NOT_FOUND";
+    #[cfg_attr(
+        not(target_os = "macos"),
+        allow(dead_code, reason = "only referenced by the macOS capture path")
+    )]
     pub(crate) const CAPTURE_FAILED: &str = "CAPTURE_FAILED";
     pub(crate) const PERMISSION_DENIED: &str = "PERMISSION_DENIED";
 }
@@ -51,6 +61,13 @@ fn rpc_error(rpc_code: i32, domain: &str, message: impl Into<String>, extras: Va
 
 /// Parsed view of the `pilot.screenshot` request params with all field-level
 /// validation already enforced by the validators below.
+#[cfg_attr(
+    not(target_os = "macos"),
+    allow(
+        dead_code,
+        reason = "fields are read by the macOS-only capture pipeline"
+    )
+)]
 struct ScreenshotRequest {
     window_id: u32,
     output_path: std::path::PathBuf,

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -175,6 +175,17 @@ fn parse_output_path(obj: &serde_json::Map<String, Value>) -> Result<std::path::
             Value::Null,
         ));
     }
+    if output_path.is_dir() {
+        return Err(rpc_error(
+            RPC_INVALID_PARAMS,
+            codes::INVALID_OUTPUT_PATH,
+            format!(
+                "output_path must be a file path, got directory: {}",
+                output_path.display()
+            ),
+            Value::Null,
+        ));
+    }
     let parent = output_path.parent().ok_or_else(|| {
         rpc_error(
             RPC_INVALID_PARAMS,
@@ -274,7 +285,7 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         ),
     })?;
 
-    if !discovered.iter().any(|w| w.window_id == window_id) {
+    if target_bounds.is_none() {
         return Err(rpc_error(
             RPC_INVALID_PARAMS,
             codes::WINDOW_NOT_FOUND,
@@ -571,6 +582,22 @@ mod tests {
         let err = handle_screenshot(Some(&params))
             .await
             .expect_err("must reject missing parent dir");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert_eq!(
+            err_data(&err).get("error").and_then(Value::as_str),
+            Some(codes::INVALID_OUTPUT_PATH)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_directory_output_path() {
+        let params = json!({
+            "window_id": 42_u32,
+            "output_path": std::env::temp_dir().display().to_string(),
+        });
+        let err = handle_screenshot(Some(&params))
+            .await
+            .expect_err("must reject directory output_path");
         assert_eq!(err.code, RPC_INVALID_PARAMS);
         assert_eq!(
             err_data(&err).get("error").and_then(Value::as_str),

--- a/crates/tauri-plugin-pilot/src/screenshot/mod.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cgwindow;
 pub(crate) mod error;
+pub(crate) mod ipc;
 pub(crate) mod native;
 pub(crate) mod probe;
 pub(crate) mod screencapture;
@@ -7,7 +8,9 @@ pub(crate) mod window_id;
 
 pub(crate) use cgwindow::capture_cgwindow;
 pub(crate) use error::ScreenshotError;
-pub(crate) use native::capture_wkwebview_png;
+pub(crate) use ipc::handle_screenshot;
 pub(crate) use probe::{ScreenshotBackend, selected_backend};
 pub(crate) use screencapture::capture_screencapture;
-pub(crate) use window_id::get_window_id;
+pub(crate) use window_id::{
+    DiscoveredWindow, WindowBounds, get_window_bounds, list_layer_zero_windows,
+};

--- a/crates/tauri-plugin-pilot/src/screenshot/mod.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/mod.rs
@@ -1,0 +1,13 @@
+pub(crate) mod cgwindow;
+pub(crate) mod error;
+pub(crate) mod native;
+pub(crate) mod probe;
+pub(crate) mod screencapture;
+pub(crate) mod window_id;
+
+pub(crate) use cgwindow::capture_cgwindow;
+pub(crate) use error::ScreenshotError;
+pub(crate) use native::capture_wkwebview_png;
+pub(crate) use probe::{ScreenshotBackend, selected_backend};
+pub(crate) use screencapture::capture_screencapture;
+pub(crate) use window_id::get_window_id;

--- a/crates/tauri-plugin-pilot/src/screenshot/mod.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/mod.rs
@@ -23,5 +23,5 @@ pub(crate) use probe::{ScreenshotBackend, selected_backend};
 pub(crate) use screencapture::capture_screencapture;
 #[cfg(target_os = "macos")]
 pub(crate) use window_id::{
-    DiscoveredWindow, WindowBounds, get_window_bounds, list_layer_zero_windows,
+    DiscoveredWindow, EnumeratedLayerZeroWindows, WindowBounds, enumerate_layer_zero_windows,
 };

--- a/crates/tauri-plugin-pilot/src/screenshot/mod.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/mod.rs
@@ -1,16 +1,27 @@
+#[cfg(target_os = "macos")]
 pub(crate) mod cgwindow;
+#[cfg(target_os = "macos")]
 pub(crate) mod error;
 pub(crate) mod ipc;
+#[cfg(target_os = "macos")]
 pub(crate) mod native;
+#[cfg(target_os = "macos")]
 pub(crate) mod probe;
+#[cfg(target_os = "macos")]
 pub(crate) mod screencapture;
+#[cfg(target_os = "macos")]
 pub(crate) mod window_id;
 
+#[cfg(target_os = "macos")]
 pub(crate) use cgwindow::capture_cgwindow;
+#[cfg(target_os = "macos")]
 pub(crate) use error::ScreenshotError;
 pub(crate) use ipc::handle_screenshot;
+#[cfg(target_os = "macos")]
 pub(crate) use probe::{ScreenshotBackend, selected_backend};
+#[cfg(target_os = "macos")]
 pub(crate) use screencapture::capture_screencapture;
+#[cfg(target_os = "macos")]
 pub(crate) use window_id::{
     DiscoveredWindow, WindowBounds, get_window_bounds, list_layer_zero_windows,
 };

--- a/crates/tauri-plugin-pilot/src/screenshot/native.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/native.rs
@@ -13,6 +13,7 @@ use super::ScreenshotError;
 /// [`ScreenshotError::CaptureFailed`] on macOS until the `WKWebView` path is
 /// wired in a follow-up milestone.
 #[cfg(target_os = "macos")]
+#[allow(dead_code, reason = "wired in the WkWebView milestone")]
 pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
     _window: &tauri::WebviewWindow<R>,
 ) -> Result<Vec<u8>, ScreenshotError> {
@@ -27,6 +28,7 @@ pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
 ///
 /// Always returns [`ScreenshotError::PlatformUnsupported`].
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code, reason = "wired in the WkWebView milestone")]
 pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
     _window: &tauri::WebviewWindow<R>,
 ) -> Result<Vec<u8>, ScreenshotError> {

--- a/crates/tauri-plugin-pilot/src/screenshot/native.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/native.rs
@@ -1,0 +1,34 @@
+use super::ScreenshotError;
+
+/// Capture a Tauri `WebviewWindow` via the `WKWebView` `takeSnapshot:` path.
+///
+/// Scaffolded for a follow-up milestone — the `objc2-web-kit` wiring is not in
+/// this release, so the macOS arm currently returns a `CaptureFailed` with a
+/// descriptive message. Callers that want a working capture should select the
+/// `screencapture` or `CGWindowList` backends.
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] on macOS until the `WKWebView` path is
+/// wired in a follow-up milestone.
+#[cfg(target_os = "macos")]
+pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
+    _window: &tauri::WebviewWindow<R>,
+) -> Result<Vec<u8>, ScreenshotError> {
+    Err(ScreenshotError::CaptureFailed {
+        message: "WKWebView takeSnapshot backend is not wired in this milestone".to_owned(),
+    })
+}
+
+/// Non-macOS stub for the `WKWebView` capture path.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
+    _window: &tauri::WebviewWindow<R>,
+) -> Result<Vec<u8>, ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/native.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/native.rs
@@ -9,10 +9,8 @@ use super::ScreenshotError;
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] on macOS until the `WKWebView` path is
-/// wired in a follow-up milestone.
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] on macOS until the `WKWebView`
+/// path is wired in a follow-up milestone.
 #[allow(dead_code, reason = "wired in the WkWebView milestone")]
 pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
     _window: &tauri::WebviewWindow<R>,
@@ -20,17 +18,4 @@ pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
     Err(ScreenshotError::CaptureFailed {
         message: "WKWebView takeSnapshot backend is not wired in this milestone".to_owned(),
     })
-}
-
-/// Non-macOS stub for the `WKWebView` capture path.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-#[allow(dead_code, reason = "wired in the WkWebView milestone")]
-pub(crate) fn capture_wkwebview_png<R: tauri::Runtime>(
-    _window: &tauri::WebviewWindow<R>,
-) -> Result<Vec<u8>, ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/probe.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/probe.rs
@@ -6,10 +6,18 @@ pub(crate) enum ScreenshotBackend {
     /// `takeSnapshot:` wiring lands. The auto-probe never selects it today;
     /// it stays in the enum so callers can opt in explicitly when the
     /// follow-up milestone wires it.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "constructed in the WkWebView milestone")]
     WkWebViewSnapshot,
     CgWindowList,
     ScreencaptureProbe,
+    /// Returned by [`selected_backend`] on hosts where no native capture
+    /// surface is available. Constructed in `cfg(not(target_os = "macos"))`
+    /// builds; matched on macOS so the dispatcher can map it to a
+    /// `PERMISSION_DENIED` IPC error.
+    #[allow(
+        dead_code,
+        reason = "constructed in cfg(not(target_os = \"macos\")) builds"
+    )]
     PlatformUnsupported,
 }
 

--- a/crates/tauri-plugin-pilot/src/screenshot/probe.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/probe.rs
@@ -36,9 +36,13 @@ fn probe_backend() -> ScreenshotBackend {
     }
 }
 
+/// Ask CoreGraphics whether the current process has screen-recording
+/// permission via the documented `CGPreflightScreenCaptureAccess` entry point.
+///
+/// Replaces the previous `screencapture -l 0 /dev/null` probe — that shell-out
+/// returned different exit codes across macOS releases and required forking a
+/// child process every cold boot, while this call is in-process and is the
+/// API Apple's own screen-recording prompt sits on top of.
 fn screencapture_probe_allows_window_capture() -> bool {
-    std::process::Command::new("screencapture")
-        .args(["-l", "0", "/dev/null"])
-        .status()
-        .is_ok_and(|status| status.success())
+    core_graphics::access::ScreenCaptureAccess.preflight()
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/probe.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/probe.rs
@@ -1,0 +1,58 @@
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScreenshotBackend {
+    /// Scaffolded path that returns to a working impl once the `WKWebView`
+    /// `takeSnapshot:` wiring lands. The auto-probe never selects it today;
+    /// it stays in the enum so callers can opt in explicitly when the
+    /// follow-up milestone wires it.
+    #[allow(dead_code)]
+    WkWebViewSnapshot,
+    CgWindowList,
+    ScreencaptureProbe,
+    PlatformUnsupported,
+}
+
+static BACKEND: OnceLock<ScreenshotBackend> = OnceLock::new();
+
+/// Return the cached screenshot backend selected for the current host.
+#[must_use]
+pub(crate) fn selected_backend() -> ScreenshotBackend {
+    *BACKEND.get_or_init(probe_backend)
+}
+
+fn probe_backend() -> ScreenshotBackend {
+    #[cfg(target_os = "macos")]
+    {
+        if screencapture_probe_allows_window_capture() {
+            ScreenshotBackend::ScreencaptureProbe
+        } else {
+            ScreenshotBackend::CgWindowList
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        ScreenshotBackend::PlatformUnsupported
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn screencapture_probe_allows_window_capture() -> bool {
+    std::process::Command::new("screencapture")
+        .args(["-l", "0", "/dev/null"])
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_backend_is_closed_unsupported_variant() {
+        assert_eq!(
+            super::selected_backend(),
+            super::ScreenshotBackend::PlatformUnsupported
+        );
+    }
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/probe.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/probe.rs
@@ -10,13 +10,12 @@ pub(crate) enum ScreenshotBackend {
     WkWebViewSnapshot,
     CgWindowList,
     ScreencaptureProbe,
-    /// Returned by [`selected_backend`] on hosts where no native capture
-    /// surface is available. Constructed in `cfg(not(target_os = "macos"))`
-    /// builds; matched on macOS so the dispatcher can map it to a
-    /// `PERMISSION_DENIED` IPC error.
+    /// Sentinel matched by the macOS dispatcher to surface a
+    /// `PERMISSION_DENIED` IPC error. Never constructed today; the non-macOS
+    /// IPC branch short-circuits before reaching the probe.
     #[allow(
         dead_code,
-        reason = "constructed in cfg(not(target_os = \"macos\")) builds"
+        reason = "kept for the exhaustive match in the macOS dispatcher"
     )]
     PlatformUnsupported,
 }
@@ -30,37 +29,16 @@ pub(crate) fn selected_backend() -> ScreenshotBackend {
 }
 
 fn probe_backend() -> ScreenshotBackend {
-    #[cfg(target_os = "macos")]
-    {
-        if screencapture_probe_allows_window_capture() {
-            ScreenshotBackend::ScreencaptureProbe
-        } else {
-            ScreenshotBackend::CgWindowList
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        ScreenshotBackend::PlatformUnsupported
+    if screencapture_probe_allows_window_capture() {
+        ScreenshotBackend::ScreencaptureProbe
+    } else {
+        ScreenshotBackend::CgWindowList
     }
 }
 
-#[cfg(target_os = "macos")]
 fn screencapture_probe_allows_window_capture() -> bool {
     std::process::Command::new("screencapture")
         .args(["-l", "0", "/dev/null"])
         .status()
         .is_ok_and(|status| status.success())
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn non_macos_backend_is_closed_unsupported_variant() {
-        assert_eq!(
-            super::selected_backend(),
-            super::ScreenshotBackend::PlatformUnsupported
-        );
-    }
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+
+use super::ScreenshotError;
+
+/// Capture a window's pixels by shelling out to the `screencapture` system tool.
+///
+/// Invokes `screencapture -x -l <window_id> <path>` so the call is silent and
+/// targets one window rather than the whole screen. Requires Screen Recording
+/// permission in System Settings -> Privacy & Security; the first invocation
+/// under a sandboxed host surfaces the macOS permission dialog.
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] when the child process cannot be
+/// spawned or exits with a non-zero status (TCC-denied, unknown window id,
+/// or unwritable output path).
+#[cfg(target_os = "macos")]
+pub(crate) fn capture_screencapture(window_id: u32, path: &Path) -> Result<(), ScreenshotError> {
+    use std::process::Command;
+
+    let status = Command::new("screencapture")
+        .arg("-x")
+        .arg("-l")
+        .arg(window_id.to_string())
+        .arg(path)
+        .status()
+        .map_err(|err| ScreenshotError::CaptureFailed {
+            message: format!("spawn screencapture: {err}"),
+        })?;
+    if !status.success() {
+        return Err(ScreenshotError::CaptureFailed {
+            message: format!("screencapture exited with {status}"),
+        });
+    }
+    Ok(())
+}
+
+/// Non-macOS stub for the `screencapture` shell-out path.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn capture_screencapture(_window_id: u32, _path: &Path) -> Result<(), ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
@@ -11,11 +11,9 @@ use super::ScreenshotError;
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] when the child process cannot be
-/// spawned or exits with a non-zero status (TCC-denied, unknown window id,
-/// or unwritable output path).
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] when the child process cannot be
+/// spawned or exits with a non-zero status (TCC-denied, unknown window id, or
+/// unwritable output path).
 pub(crate) fn capture_screencapture(window_id: u32, path: &Path) -> Result<(), ScreenshotError> {
     use std::process::Command;
 
@@ -34,14 +32,4 @@ pub(crate) fn capture_screencapture(window_id: u32, path: &Path) -> Result<(), S
         });
     }
     Ok(())
-}
-
-/// Non-macOS stub for the `screencapture` shell-out path.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn capture_screencapture(_window_id: u32, _path: &Path) -> Result<(), ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
@@ -1,5 +1,208 @@
 use super::ScreenshotError;
 
+/// Minimal description of a layer-0 on-screen window, used to populate the
+/// `available_windows` payload returned with `WINDOW_NOT_FOUND` errors so
+/// callers can pick the right `window_id` without a second round-trip.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct DiscoveredWindow {
+    pub(crate) window_id: u32,
+    pub(crate) owner: String,
+    pub(crate) title: String,
+    pub(crate) layer: i32,
+}
+
+/// Logical (in points, not pixels) bounds of a window, used to derive
+/// `scale_factor` by comparing against the captured PNG's pixel dimensions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct WindowBounds {
+    pub(crate) width: f64,
+    pub(crate) height: f64,
+}
+
+/// Walk the on-screen window list and return every layer-0 entry, capped at
+/// [`AVAILABLE_WINDOWS_CAP`] to keep `WINDOW_NOT_FOUND` payloads bounded.
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns null.
+#[cfg(target_os = "macos")]
+pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, ScreenshotError> {
+    use core_foundation::array::CFArray;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use core_graphics::window::{
+        CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowLayer,
+        kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
+        kCGWindowNumber, kCGWindowOwnerName,
+    };
+
+    let raw = unsafe {
+        CGWindowListCopyWindowInfo(
+            kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+            kCGNullWindowID,
+        )
+    };
+    if raw.is_null() {
+        return Err(ScreenshotError::CaptureFailed {
+            message: "CGWindowListCopyWindowInfo returned null".to_owned(),
+        });
+    }
+    let windows: CFArray<CFDictionary<CFString, CFType>> =
+        unsafe { TCFType::wrap_under_create_rule(raw) };
+
+    let owner_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerName) };
+    let title_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
+    let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
+    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+
+    let mut out: Vec<DiscoveredWindow> = Vec::new();
+    for idx in 0..windows.len() {
+        if out.len() >= AVAILABLE_WINDOWS_CAP {
+            break;
+        }
+        let Some(dict) = windows.get(idx) else {
+            continue;
+        };
+        let layer = dict
+            .find(&layer_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i32())
+            .unwrap_or(-1);
+        if layer != 0 {
+            continue;
+        }
+        let number_i64 = dict
+            .find(&number_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i64())
+            .unwrap_or(0);
+        let Ok(window_id) = u32::try_from(number_i64) else {
+            continue;
+        };
+        if window_id == 0 {
+            continue;
+        }
+        let owner = dict
+            .find(&owner_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let title = dict
+            .find(&title_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        out.push(DiscoveredWindow {
+            window_id,
+            owner,
+            title,
+            layer,
+        });
+    }
+    Ok(out)
+}
+
+/// Non-macOS stub for the window-discovery helper.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}
+
+/// Look up the logical bounds of a window by `window_id`.
+///
+/// Used to derive `scale_factor` for the IPC response by comparing pixel
+/// dimensions of the captured PNG to these logical (point) dimensions.
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns null or the
+/// window list does not contain `window_id`.
+#[cfg(target_os = "macos")]
+pub(crate) fn get_window_bounds(window_id: u32) -> Result<WindowBounds, ScreenshotError> {
+    use core_foundation::array::CFArray;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use core_graphics::geometry::CGRect;
+    use core_graphics::window::{
+        CGWindowListCopyWindowInfo, kCGWindowBounds, kCGWindowListExcludeDesktopElements,
+        kCGWindowListOptionIncludingWindow, kCGWindowNumber,
+    };
+
+    let raw = unsafe {
+        CGWindowListCopyWindowInfo(
+            kCGWindowListOptionIncludingWindow | kCGWindowListExcludeDesktopElements,
+            window_id,
+        )
+    };
+    if raw.is_null() {
+        return Err(ScreenshotError::CaptureFailed {
+            message: "CGWindowListCopyWindowInfo returned null".to_owned(),
+        });
+    }
+    let windows: CFArray<CFDictionary<CFString, CFType>> =
+        unsafe { TCFType::wrap_under_create_rule(raw) };
+
+    let bounds_key = unsafe { CFString::wrap_under_get_rule(kCGWindowBounds) };
+    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+
+    for idx in 0..windows.len() {
+        let Some(dict) = windows.get(idx) else {
+            continue;
+        };
+        let entry_id = dict
+            .find(&number_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i64())
+            .unwrap_or(0);
+        if u32::try_from(entry_id).ok() != Some(window_id) {
+            continue;
+        }
+        // CGWindowList stores the bounds rect as a `{Width,Height,X,Y}` dict
+        // rather than a CGRect struct; CoreGraphics ships
+        // `CGRectMakeWithDictionaryRepresentation` for exactly this case so
+        // we don't have to walk the keys by hand.
+        if let Some(bounds_dict) = dict
+            .find(&bounds_key)
+            .and_then(|v| v.downcast::<CFDictionary>())
+            && let Some(rect) = CGRect::from_dict_representation(&bounds_dict)
+        {
+            return Ok(WindowBounds {
+                width: rect.size.width,
+                height: rect.size.height,
+            });
+        }
+    }
+    Err(ScreenshotError::CaptureFailed {
+        message: format!("window_id {window_id} has no bounds entry"),
+    })
+}
+
+/// Non-macOS stub for the bounds lookup.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn get_window_bounds(_window_id: u32) -> Result<WindowBounds, ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}
+
+/// Hard cap on the `available_windows` list returned in `WINDOW_NOT_FOUND`
+/// errors. A host with many open windows can otherwise produce a multi-KB
+/// payload; 20 is enough to spot a typo or wrong owner without bloating the
+/// JSON-RPC frame.
+pub(crate) const AVAILABLE_WINDOWS_CAP: usize = 20;
+
 /// Find a `CGWindowID` by owner name (exact match) and an optional title substring.
 ///
 /// Walks the on-screen window list, skipping desktop elements, and returns the
@@ -12,6 +215,10 @@ use super::ScreenshotError;
 /// [`ScreenshotError::CaptureFailed`] when the CoreGraphics window list call
 /// returns null or no layer-0 window matches the filter.
 #[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "kept for owner-name lookups in a follow-up milestone"
+)]
 pub(crate) fn get_window_id(owner: &str, title: Option<&str>) -> Result<u32, ScreenshotError> {
     use core_foundation::array::CFArray;
     use core_foundation::base::{CFType, TCFType};

--- a/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
@@ -19,24 +19,54 @@ pub(crate) struct WindowBounds {
     pub(crate) height: f64,
 }
 
-/// Walk the on-screen window list and return every layer-0 entry, capped at
-/// [`AVAILABLE_WINDOWS_CAP`] to keep `WINDOW_NOT_FOUND` payloads bounded.
+/// Result of a single-pass walk over the on-screen window list. Bundles the
+/// truncated `available_windows` payload that powers `WINDOW_NOT_FOUND` errors
+/// with the bounds of the requested target (when it is a layer-0 window).
+pub(crate) struct EnumeratedLayerZeroWindows {
+    pub(crate) available: Vec<DiscoveredWindow>,
+    pub(crate) target_bounds: Option<WindowBounds>,
+}
+
+/// Hard cap on the `available_windows` list returned in `WINDOW_NOT_FOUND`
+/// errors. A host with many open windows can otherwise produce a multi-KB
+/// payload; 20 is enough to spot a typo or wrong owner without bloating the
+/// JSON-RPC frame.
+pub(crate) const AVAILABLE_WINDOWS_CAP: usize = 20;
+
+/// Walk the on-screen window list once and collect both the layer-0 windows
+/// available for capture (capped at [`AVAILABLE_WINDOWS_CAP`]) and the bounds
+/// of `target` when it is itself a layer-0 window.
+///
+/// Doing this in one pass — instead of separate `list_layer_zero_windows` +
+/// `get_window_bounds` calls — avoids a second `CGWindowListCopyWindowInfo`
+/// snapshot and removes a TOCTOU window where the target could vanish between
+/// the discovery list and the bounds lookup.
 ///
 /// # Errors
 ///
 /// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns null.
-pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, ScreenshotError> {
+pub(crate) fn enumerate_layer_zero_windows(
+    target: u32,
+) -> Result<EnumeratedLayerZeroWindows, ScreenshotError> {
     use core_foundation::array::CFArray;
     use core_foundation::base::{CFType, TCFType};
     use core_foundation::dictionary::CFDictionary;
     use core_foundation::number::CFNumber;
     use core_foundation::string::CFString;
+    use core_graphics::geometry::CGRect;
     use core_graphics::window::{
-        CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowLayer,
+        CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowBounds, kCGWindowLayer,
         kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
         kCGWindowNumber, kCGWindowOwnerName,
     };
 
+    // SAFETY: `CGWindowListCopyWindowInfo` is a thread-safe CoreGraphics entry
+    // point that requires only a connection to the WindowServer — which the
+    // host app already holds for any UI to render. Passing `kCGNullWindowID`
+    // with `OnScreenOnly` is the documented "give me every on-screen window"
+    // form. The returned CFArrayRef follows create-rule ownership: the caller
+    // is responsible for `CFRelease`, which `wrap_under_create_rule` arranges
+    // via `Drop`.
     let raw = unsafe {
         CGWindowListCopyWindowInfo(
             kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
@@ -48,22 +78,26 @@ pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, Screens
             message: "CGWindowListCopyWindowInfo returned null".to_owned(),
         });
     }
+    // SAFETY: `raw` is a non-null CFArrayRef just produced under create-rule
+    // ownership (see comment above). `wrap_under_create_rule` takes that
+    // ownership without retaining again, so the `Drop` impl on the wrapper
+    // performs the matching `CFRelease`.
     let windows: CFArray<CFDictionary<CFString, CFType>> =
         unsafe { TCFType::wrap_under_create_rule(raw) };
 
+    // SAFETY: every `kCGWindow*` symbol is a `CFStringRef` extern static
+    // exported by CoreGraphics, owned by the framework. `wrap_under_get_rule`
+    // retains the existing reference so our handle is balanced when it drops.
     let owner_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerName) };
     let title_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
     let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
     let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+    let bounds_key = unsafe { CFString::wrap_under_get_rule(kCGWindowBounds) };
 
-    let mut out: Vec<DiscoveredWindow> = Vec::new();
-    for idx in 0..windows.len() {
-        if out.len() >= AVAILABLE_WINDOWS_CAP {
-            break;
-        }
-        let Some(dict) = windows.get(idx) else {
-            continue;
-        };
+    let mut available: Vec<DiscoveredWindow> = Vec::new();
+    let mut target_bounds: Option<WindowBounds> = None;
+
+    for dict in windows.iter() {
         let layer = dict
             .find(&layer_key)
             .and_then(|v| v.downcast::<CFNumber>())
@@ -93,182 +127,40 @@ pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, Screens
             .and_then(|v| v.downcast::<CFString>())
             .map(|v| v.to_string())
             .unwrap_or_default();
-        out.push(DiscoveredWindow {
-            window_id,
-            owner,
-            title,
-            layer,
-        });
-    }
-    Ok(out)
-}
 
-/// Look up the logical bounds of a window by `window_id`.
-///
-/// Used to derive `scale_factor` for the IPC response by comparing pixel
-/// dimensions of the captured PNG to these logical (point) dimensions.
-///
-/// # Errors
-///
-/// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns null
-/// or the window list does not contain `window_id`.
-pub(crate) fn get_window_bounds(window_id: u32) -> Result<WindowBounds, ScreenshotError> {
-    use core_foundation::array::CFArray;
-    use core_foundation::base::{CFType, TCFType};
-    use core_foundation::dictionary::CFDictionary;
-    use core_foundation::number::CFNumber;
-    use core_foundation::string::CFString;
-    use core_graphics::geometry::CGRect;
-    use core_graphics::window::{
-        CGWindowListCopyWindowInfo, kCGWindowBounds, kCGWindowListExcludeDesktopElements,
-        kCGWindowListOptionIncludingWindow, kCGWindowNumber,
-    };
-
-    let raw = unsafe {
-        CGWindowListCopyWindowInfo(
-            kCGWindowListOptionIncludingWindow | kCGWindowListExcludeDesktopElements,
-            window_id,
-        )
-    };
-    if raw.is_null() {
-        return Err(ScreenshotError::CaptureFailed {
-            message: "CGWindowListCopyWindowInfo returned null".to_owned(),
-        });
-    }
-    let windows: CFArray<CFDictionary<CFString, CFType>> =
-        unsafe { TCFType::wrap_under_create_rule(raw) };
-
-    let bounds_key = unsafe { CFString::wrap_under_get_rule(kCGWindowBounds) };
-    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
-
-    for idx in 0..windows.len() {
-        let Some(dict) = windows.get(idx) else {
-            continue;
-        };
-        let entry_id = dict
-            .find(&number_key)
-            .and_then(|v| v.downcast::<CFNumber>())
-            .and_then(|v| v.to_i64())
-            .unwrap_or(0);
-        if u32::try_from(entry_id).ok() != Some(window_id) {
-            continue;
+        if window_id == target && target_bounds.is_none() {
+            // CGWindowList stores the bounds rect as a `{Width,Height,X,Y}`
+            // dict rather than a CGRect struct; CoreGraphics ships
+            // `CGRectMakeWithDictionaryRepresentation` for exactly this case
+            // so we do not have to walk the keys by hand.
+            if let Some(bounds_dict) = dict
+                .find(&bounds_key)
+                .and_then(|v| v.downcast::<CFDictionary>())
+                && let Some(rect) = CGRect::from_dict_representation(&bounds_dict)
+            {
+                target_bounds = Some(WindowBounds {
+                    width: rect.size.width,
+                    height: rect.size.height,
+                });
+            }
         }
-        // CGWindowList stores the bounds rect as a `{Width,Height,X,Y}` dict
-        // rather than a CGRect struct; CoreGraphics ships
-        // `CGRectMakeWithDictionaryRepresentation` for exactly this case so
-        // we don't have to walk the keys by hand.
-        if let Some(bounds_dict) = dict
-            .find(&bounds_key)
-            .and_then(|v| v.downcast::<CFDictionary>())
-            && let Some(rect) = CGRect::from_dict_representation(&bounds_dict)
-        {
-            return Ok(WindowBounds {
-                width: rect.size.width,
-                height: rect.size.height,
+
+        if available.len() < AVAILABLE_WINDOWS_CAP {
+            available.push(DiscoveredWindow {
+                window_id,
+                owner,
+                title,
+                layer,
             });
+        } else if target_bounds.is_some() {
+            // List is full and we already have what the success path needs;
+            // continuing would just walk the rest of the array for nothing.
+            break;
         }
     }
-    Err(ScreenshotError::CaptureFailed {
-        message: format!("window_id {window_id} has no bounds entry"),
-    })
-}
 
-/// Hard cap on the `available_windows` list returned in `WINDOW_NOT_FOUND`
-/// errors. A host with many open windows can otherwise produce a multi-KB
-/// payload; 20 is enough to spot a typo or wrong owner without bloating the
-/// JSON-RPC frame.
-pub(crate) const AVAILABLE_WINDOWS_CAP: usize = 20;
-
-/// Find a `CGWindowID` by owner name (exact match) and an optional title substring.
-///
-/// Walks the on-screen window list, skipping desktop elements, and returns the
-/// first layer-0 window whose owner equals `owner` and whose title contains
-/// `title` (when provided).
-///
-/// # Errors
-///
-/// Returns [`ScreenshotError::CaptureFailed`] when the `CoreGraphics` window
-/// list call returns null or no layer-0 window matches the filter.
-#[allow(
-    dead_code,
-    reason = "kept for owner-name lookups in a follow-up milestone"
-)]
-pub(crate) fn get_window_id(owner: &str, title: Option<&str>) -> Result<u32, ScreenshotError> {
-    use core_foundation::array::CFArray;
-    use core_foundation::base::{CFType, TCFType};
-    use core_foundation::dictionary::CFDictionary;
-    use core_foundation::number::CFNumber;
-    use core_foundation::string::CFString;
-    use core_graphics::window::{
-        CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowLayer,
-        kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
-        kCGWindowNumber, kCGWindowOwnerName,
-    };
-
-    let raw = unsafe {
-        CGWindowListCopyWindowInfo(
-            kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
-            kCGNullWindowID,
-        )
-    };
-    if raw.is_null() {
-        return Err(ScreenshotError::CaptureFailed {
-            message: "CGWindowListCopyWindowInfo returned null".to_owned(),
-        });
-    }
-    let windows: CFArray<CFDictionary<CFString, CFType>> =
-        unsafe { TCFType::wrap_under_create_rule(raw) };
-
-    let owner_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerName) };
-    let title_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
-    let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
-    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
-
-    for idx in 0..windows.len() {
-        let Some(dict) = windows.get(idx) else {
-            continue;
-        };
-        let owner_value = dict
-            .find(&owner_key)
-            .and_then(|v| v.downcast::<CFString>())
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let title_value = dict
-            .find(&title_key)
-            .and_then(|v| v.downcast::<CFString>())
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let layer = dict
-            .find(&layer_key)
-            .and_then(|v| v.downcast::<CFNumber>())
-            .and_then(|v| v.to_i32())
-            .unwrap_or(-1);
-        let number_i64 = dict
-            .find(&number_key)
-            .and_then(|v| v.downcast::<CFNumber>())
-            .and_then(|v| v.to_i64())
-            .unwrap_or(0);
-
-        if owner_value != owner {
-            continue;
-        }
-        if let Some(needle) = title
-            && !title_value.contains(needle)
-        {
-            continue;
-        }
-        if layer != 0 {
-            continue;
-        }
-        let Ok(number) = u32::try_from(number_i64) else {
-            continue;
-        };
-        if number == 0 {
-            continue;
-        }
-        return Ok(number);
-    }
-    Err(ScreenshotError::CaptureFailed {
-        message: format!("no layer-0 window matched owner={owner}"),
+    Ok(EnumeratedLayerZeroWindows {
+        available,
+        target_bounds,
     })
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
@@ -1,0 +1,103 @@
+use super::ScreenshotError;
+
+/// Find a `CGWindowID` by owner name (exact match) and an optional title substring.
+///
+/// Walks the on-screen window list, skipping desktop elements, and returns the
+/// first layer-0 window whose owner equals `owner` and whose title contains
+/// `title` (when provided).
+///
+/// # Errors
+///
+/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
+/// [`ScreenshotError::CaptureFailed`] when the CoreGraphics window list call
+/// returns null or no layer-0 window matches the filter.
+#[cfg(target_os = "macos")]
+pub(crate) fn get_window_id(owner: &str, title: Option<&str>) -> Result<u32, ScreenshotError> {
+    use core_foundation::array::CFArray;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use core_graphics::window::{
+        CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowLayer,
+        kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
+        kCGWindowNumber, kCGWindowOwnerName,
+    };
+
+    let raw = unsafe {
+        CGWindowListCopyWindowInfo(
+            kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+            kCGNullWindowID,
+        )
+    };
+    if raw.is_null() {
+        return Err(ScreenshotError::CaptureFailed {
+            message: "CGWindowListCopyWindowInfo returned null".to_owned(),
+        });
+    }
+    let windows: CFArray<CFDictionary<CFString, CFType>> =
+        unsafe { TCFType::wrap_under_create_rule(raw) };
+
+    let owner_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerName) };
+    let title_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
+    let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
+    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+
+    for idx in 0..windows.len() {
+        let Some(dict) = windows.get(idx) else {
+            continue;
+        };
+        let owner_value = dict
+            .find(&owner_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let title_value = dict
+            .find(&title_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let layer = dict
+            .find(&layer_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i32())
+            .unwrap_or(-1);
+        let number_i64 = dict
+            .find(&number_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i64())
+            .unwrap_or(0);
+
+        if owner_value != owner {
+            continue;
+        }
+        if let Some(needle) = title
+            && !title_value.contains(needle)
+        {
+            continue;
+        }
+        if layer != 0 {
+            continue;
+        }
+        let Ok(number) = u32::try_from(number_i64) else {
+            continue;
+        };
+        if number == 0 {
+            continue;
+        }
+        return Ok(number);
+    }
+    Err(ScreenshotError::CaptureFailed {
+        message: format!("no layer-0 window matched owner={owner}"),
+    })
+}
+
+/// Non-macOS stub for the window-id resolver.
+///
+/// # Errors
+///
+/// Always returns [`ScreenshotError::PlatformUnsupported`].
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn get_window_id(_owner: &str, _title: Option<&str>) -> Result<u32, ScreenshotError> {
+    Err(ScreenshotError::PlatformUnsupported)
+}

--- a/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
@@ -24,9 +24,7 @@ pub(crate) struct WindowBounds {
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns null.
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns null.
 pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, ScreenshotError> {
     use core_foundation::array::CFArray;
     use core_foundation::base::{CFType, TCFType};
@@ -105,16 +103,6 @@ pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, Screens
     Ok(out)
 }
 
-/// Non-macOS stub for the window-discovery helper.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
-}
-
 /// Look up the logical bounds of a window by `window_id`.
 ///
 /// Used to derive `scale_factor` for the IPC response by comparing pixel
@@ -122,10 +110,8 @@ pub(crate) fn list_layer_zero_windows() -> Result<Vec<DiscoveredWindow>, Screens
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] when CoreGraphics returns null or the
-/// window list does not contain `window_id`.
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] when `CoreGraphics` returns null
+/// or the window list does not contain `window_id`.
 pub(crate) fn get_window_bounds(window_id: u32) -> Result<WindowBounds, ScreenshotError> {
     use core_foundation::array::CFArray;
     use core_foundation::base::{CFType, TCFType};
@@ -187,16 +173,6 @@ pub(crate) fn get_window_bounds(window_id: u32) -> Result<WindowBounds, Screensh
     })
 }
 
-/// Non-macOS stub for the bounds lookup.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn get_window_bounds(_window_id: u32) -> Result<WindowBounds, ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
-}
-
 /// Hard cap on the `available_windows` list returned in `WINDOW_NOT_FOUND`
 /// errors. A host with many open windows can otherwise produce a multi-KB
 /// payload; 20 is enough to spot a typo or wrong owner without bloating the
@@ -211,10 +187,8 @@ pub(crate) const AVAILABLE_WINDOWS_CAP: usize = 20;
 ///
 /// # Errors
 ///
-/// Returns [`ScreenshotError::PlatformUnsupported`] off macOS, and
-/// [`ScreenshotError::CaptureFailed`] when the CoreGraphics window list call
-/// returns null or no layer-0 window matches the filter.
-#[cfg(target_os = "macos")]
+/// Returns [`ScreenshotError::CaptureFailed`] when the `CoreGraphics` window
+/// list call returns null or no layer-0 window matches the filter.
 #[allow(
     dead_code,
     reason = "kept for owner-name lookups in a follow-up milestone"
@@ -297,14 +271,4 @@ pub(crate) fn get_window_id(owner: &str, title: Option<&str>) -> Result<u32, Scr
     Err(ScreenshotError::CaptureFailed {
         message: format!("no layer-0 window matched owner={owner}"),
     })
-}
-
-/// Non-macOS stub for the window-id resolver.
-///
-/// # Errors
-///
-/// Always returns [`ScreenshotError::PlatformUnsupported`].
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn get_window_id(_owner: &str, _title: Option<&str>) -> Result<u32, ScreenshotError> {
-    Err(ScreenshotError::PlatformUnsupported)
 }


### PR DESCRIPTION
## Summary

- New `pilot.screenshot` IPC method on `tauri-plugin-pilot` for macOS window capture. Path-returning shape, atomic write, TCC fallback surfaced as response metadata.
- Bare `screenshot` JSON-RPC method now dispatches on `output_path` presence: with → native; without → existing bridge html-to-image base64. Backwards compatible.
- New MCP tool `pilot.screenshot` advertised in `tools/list` with a path-only schema. Existing bridge `screenshot` MCP route unchanged.

## Motivation

Test-harness consumers running file-based regression-canary pipelines need deterministic per-window screenshot capture without driving the system's hotkey-based `screencapture` shell tool or maintaining out-of-tree FFI to `CGWindowListCreateImage`. Today those callers chain `open -a <app>` → `screencapture -x` → Swift CGWindow probe → `image` crate crop → strict pixel diff. That's two shell-outs and one out-of-tree FFI wrapper per capture. A path-returning `pilot.screenshot` collapses that chain.

**Path-returning over inline bytes.** Retina captures land in the 700KB–1.9MB range. Sending them over JSON-RPC framing + UDS buffer — and especially over MCP base64 — is the wrong transport choice when the caller is going to write the bytes to disk anyway. Path-only also keeps the MCP advertised surface small enough that agent runtimes don't bump into response-size limits.

**Atomic write contract.** Caller can assume the file at `output_path` is either the fresh capture or unchanged from before the call. Plugin writes to `<output_path>.tmp.<pid>` and `rename(tmp, final)` is the single atomic step. Every error branch after capture-success cleans up the tmp file. The PNG is decoded before the rename, so malformed bytes never land at the final path. Strict-diff pipelines depend on this fresh-vs-stale guarantee.

**TCC denial as metadata, not silent.** When macOS Screen Recording permission is denied, the plugin falls back to `CGWindowListCreateImage` and returns the capture with `backend: "cgwindow"` + `tcc_denied: true` in the response. Silent fallback would break strict-diff pipelines (the two backends produce visibly different output — CGWindow loses cursor + some compositor effects). Hard-erroring would prevent any CI use without an interactive Screen Recording grant. Surfacing the flag lets callers tag baselines per backend.

**Discovery in error payload.** When `window_id` doesn't resolve, the `WINDOW_NOT_FOUND` error carries an `available_windows[]` list (up to 20 entries: window_id + owner + title + layer 0). Caller doesn't need a separate `list_windows` round-trip to recover.

## Changes

- **`crates/tauri-plugin-pilot/src/screenshot/ipc.rs`** (new) — request validators, atomic write, TCC fallback dispatch, success/error response builders, 5 contract tests.
- **`crates/tauri-plugin-pilot/src/screenshot/window_id.rs`** — adds `DiscoveredWindow`, `WindowBounds`, `list_layer_zero_windows`, `get_window_bounds` for the `WINDOW_NOT_FOUND` discovery payload (cap at `AVAILABLE_WINDOWS_CAP = 20`).
- **`crates/tauri-plugin-pilot/src/screenshot/{mod,native,probe,error}.rs`** — re-exports + per-variant `#[allow(dead_code)]` on unused stub variants now that the module-wide allow is dropped.
- **`crates/tauri-plugin-pilot/src/handler.rs`** — `pilot.screenshot` dispatch arm; bare `screenshot` arm dispatches on `output_path` shape (preserves backwards compatibility for existing bridge callers); +3 dispatch-tier tests including a regression test for the no-`output_path` → bridge route.
- **`crates/tauri-pilot-cli/src/mcp.rs`** — `pilot.screenshot` `ToolSpec` + schema (`window_id` integer, `output_path` string, `format` enum["png"]; `window_id` + `output_path` required); `call_tool_by_name` arm; +3 MCP-tier tests including a path-only-contract assertion that fails closed if the schema ever grows `bytes`/`base64`/`data` keys.
- **`crates/tauri-plugin-pilot/src/lib.rs`** — drops the `#[allow(dead_code, unused_imports)]` on `mod screenshot` now that there are real callers.
- **`CHANGELOG.md`** — `[Unreleased] ### Added` entry.

### Contract surface

```jsonc
// Request
{
  "method": "pilot.screenshot",
  "params": {
    "window_id": <u32>,             // required
    "output_path": "<absolute>",     // required, parent dir must exist
    "format": "png"                  // optional; v1 accepts only "png"
  }
}

// Success response
{
  "output_path": "<absolute>",
  "window_id": <u32>,
  "width": <u32>,
  "height": <u32>,
  "scale_factor": <f32>,
  "byte_size": <u64>,
  "backend": "screencapture" | "cgwindow",
  "tcc_denied": <bool>
}

// Error: window not found
{
  "error": {
    "code": "WINDOW_NOT_FOUND",
    "message": "window_id <id> not found",
    "available_windows": [
      { "window_id": <u32>, "owner": "<name>", "title": "<string>", "layer": 0 }
    ]
  }
}
```

Other error codes: `INVALID_PARAMS`, `INVALID_OUTPUT_PATH`, `UNSUPPORTED_FORMAT`, `PERMISSION_DENIED`, `CAPTURE_FAILED`.

**Non-macOS** (Linux/Windows): the method is registered but returns `PERMISSION_DENIED` with an explanatory message. Native backends for those platforms are out of scope for this PR.

## Test Plan

- [x] `cargo test --workspace` passes (276 tests: 143 plugin + 131 cli + 2 cli integration; 11 new tests landed on this commit covering all 5 validator paths, the dispatch-on-shape behaviour for bare `screenshot`, the `WINDOW_NOT_FOUND` discovery payload, the path-only MCP schema invariant, and the bridge backwards-compat route).
- [x] `cargo clippy --workspace -- -D warnings` passes (no diagnostics, no warnings escalated).
- [ ] Tested manually with a Tauri app: validator + dispatch + MCP-tier paths have unit coverage; the real-capture round-trip needs an interactive Screen Recording grant and a windowed host, so I've deferred it to a maintainer's local manual run. Happy to add an `#[ignore]`d integration test that drives the full pipeline behind an env-gated host if useful.

## Checklist

- [x] No `.unwrap()` outside of tests. Workspace lint `clippy::unwrap_used = "deny"` enforces this; clippy is clean.
- [ ] All new files are under 150 lines. **Honest note**: `screenshot/ipc.rs` is 561 LOC and `screenshot/window_id.rs` is 310 LOC, both over the 150-line cap declared in `CONTRIBUTING.md`. The seams for a 4-module split of `ipc.rs` are clear (`ipc/validators.rs`, `ipc/dispatch.rs`, `ipc/tcc.rs`, `ipc/atomic_write.rs`); `window_id.rs` is harder to split usefully because the three functions all share the same `CGWindowListCopyWindowInfo` enumeration shape and splitting would duplicate the unsafe `wrap_under_*` block. Happy to land the split as either a follow-up PR or a pre-merge amend depending on which you prefer. Noting the existing files in this crate already over cap (`handler.rs` 1475, `lib.rs` 465, `mcp.rs` 1999); flagging the inconsistency rather than silently shipping over.
- [x] Error handling uses `thiserror` — `ScreenshotError` and the new `ipc::error::Code` are both `#[derive(thiserror::Error)]`. No `anyhow` in the plugin crate paths.
- [x] Commit messages follow conventional commits: two commits on top of `main` — `feat(plugin): add macOS native screenshot backend` (c8cec44) and `feat(plugin): wire pilot.screenshot IPC method` (52a9091). Both with multi-paragraph bodies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS-native screenshot backend and a new `screenshot_native` JSON-RPC/MCP method to capture a window directly to a PNG on disk and return its path with metadata. The bridge `screenshot` stays separate and unchanged.

- **New Features**
  - New `screenshot_native` method in `tauri-plugin-pilot` and MCP tool `pilot.screenshot_native`; capture by `window_id` to an absolute `output_path` (`format: "png"` only).
  - Atomic write via temp + rename; response includes `output_path`, `window_id`, `width`, `height`, `scale_factor`, `byte_size`, `backend` ("screencapture" | "cgwindow"), and `tcc_denied`.
  - macOS: auto-selects backend with CoreGraphics preflight; falls back to `CGWindowListCreateImage` when Screen Recording is denied and sets `tcc_denied: true`.
  - `WINDOW_NOT_FOUND` includes a capped `available_windows` list to aid discovery.
  - Non-macOS: method is registered, validators run, then `PERMISSION_DENIED`. The bridge `screenshot` remains html-to-image (base64) and never routes to native.

- **Bug Fixes**
  - Hardened validators: reject relative paths, symlinks, directories, and missing parent dirs with clear `INVALID_OUTPUT_PATH` errors.
  - Gated macOS-only screenshot modules to fix cross-platform clippy errors; no runtime changes.

<sup>Written for commit 4aa5d638de2fce15d28995159afcc3144697a7e8. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS-native screenshot tool (pilot.screenshot_native) that captures a window to a caller-provided output path and returns the path plus metadata (dimensions, scale, size, backend, tcc_denied). Uses screencapture when permitted, falls back to CoreGraphics when not; on Linux/Windows the tool returns PERMISSION_DENIED.
* **Documentation**
  * CHANGELOG updated with native screenshot behavior and permission details.
* **Tests**
  * Added tests covering tool registration, input validation, platform behavior, and Unix IPC flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->