### PR TITLE
fix(cli): gate dangerous MCP tools behind explicit opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Gate the dangerous MCP tools `pilot.drop`, `pilot.eval`, and `pilot.ipc`
+  behind the `TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS` opt-in environment
+  variable. By default these tools are now hidden from `list_tools` and
+  rejected at call time, so an untrusted MCP client can no longer execute
+  arbitrary JavaScript (`eval`), invoke arbitrary Tauri commands (`ipc`), or
+  feed arbitrary local file paths into the app (`drop`). Set the variable to
+  `1`, `true`, `yes`, or `on` to restore the previous behaviour. [#104]
+
 ## [0.6.0] - 2026-05-22
 
 ### Added
@@ -391,3 +401,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#85]: https://github.com/mpiton/tauri-pilot/issues/85
 [#89]: https://github.com/mpiton/tauri-pilot/pull/89
 [#91]: https://github.com/mpiton/tauri-pilot/issues/91
+[#104]: https://github.com/mpiton/tauri-pilot/pull/104

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -669,13 +669,12 @@ fn namespaced_tool_name(name: &str) -> String {
 fn dangerous_mcp_tools_enabled() -> bool {
     std::env::var(ENABLE_DANGEROUS_MCP_TOOLS_ENV)
         .ok()
-        .map(|value| {
+        .is_some_and(|value| {
             matches!(
                 value.trim().to_ascii_lowercase().as_str(),
                 "1" | "true" | "yes" | "on"
             )
         })
-        .unwrap_or(false)
 }
 
 struct ToolSpec {

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -125,6 +125,11 @@ impl PilotMcpServer {
         args: JsonObject,
     ) -> Result<CallToolResult, McpError> {
         let name = normalize_tool_name(name);
+        if DANGEROUS_MCP_TOOLS.contains(&name) && !dangerous_mcp_tools_enabled() {
+            return Err(invalid_params(format!(
+                "tool '{name}' is disabled by default. Set {ENABLE_DANGEROUS_MCP_TOOLS_ENV}=1 to enable dangerous MCP tools."
+            )));
+        }
         let window = self.window_arg(&args)?;
         match name {
             "ping" => self.call_app_tool("ping", None, window).await,
@@ -646,6 +651,8 @@ impl ServerHandler for PilotMcpServer {
 }
 
 const PILOT_PREFIX: &str = "pilot.";
+const ENABLE_DANGEROUS_MCP_TOOLS_ENV: &str = "TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS";
+const DANGEROUS_MCP_TOOLS: &[&str] = &["drop", "eval", "ipc"];
 
 fn normalize_tool_name(name: &str) -> &str {
     name.strip_prefix(PILOT_PREFIX).unwrap_or(name)
@@ -657,6 +664,18 @@ fn namespaced_tool_name(name: &str) -> String {
     } else {
         format!("{PILOT_PREFIX}{name}")
     }
+}
+
+fn dangerous_mcp_tools_enabled() -> bool {
+    std::env::var(ENABLE_DANGEROUS_MCP_TOOLS_ENV)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
 }
 
 struct ToolSpec {
@@ -1052,7 +1071,14 @@ fn cached_tools() -> &'static Vec<Tool> {
 }
 
 fn build_tools() -> Vec<Tool> {
+    build_tools_with_flag(dangerous_mcp_tools_enabled())
+}
+
+fn build_tools_with_flag(enable_dangerous_tools: bool) -> Vec<Tool> {
     let mut specs = tool_specs();
+    if !enable_dangerous_tools {
+        specs.retain(|spec| !DANGEROUS_MCP_TOOLS.contains(&spec.name));
+    }
     specs.sort_by_key(|spec| spec.name);
     specs
         .into_iter()
@@ -1916,6 +1942,30 @@ mod tests {
         assert!(banner.contains("auto-detect on first tool call"));
         assert!(banner.contains("main"));
         assert!(banner.contains("stdout is reserved for MCP JSON-RPC"));
+    }
+
+    #[test]
+    fn dangerous_tools_hidden_by_default() {
+        let tools = build_tools_with_flag(false);
+        for dangerous in DANGEROUS_MCP_TOOLS {
+            let namespaced = namespaced_tool_name(dangerous);
+            assert!(
+                !tools.iter().any(|tool| tool.name == namespaced),
+                "dangerous tool '{dangerous}' must not be listed unless explicitly enabled"
+            );
+        }
+    }
+
+    #[test]
+    fn dangerous_tools_can_be_enabled() {
+        let tools = build_tools_with_flag(true);
+        for dangerous in DANGEROUS_MCP_TOOLS {
+            let namespaced = namespaced_tool_name(dangerous);
+            assert!(
+                tools.iter().any(|tool| tool.name == namespaced),
+                "dangerous tool '{dangerous}' should be listed when explicitly enabled"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1671,7 +1671,9 @@ mod tests {
 
     #[test]
     fn tool_list_matches_cli_command_surface() {
-        let tools = tools();
+        // Validate the complete tool surface; runtime gating of dangerous tools
+        // is covered by `dangerous_tools_hidden_by_default` / `dangerous_tools_can_be_enabled`.
+        let tools = build_tools_with_flag(true);
         assert!(
             tools
                 .iter()


### PR DESCRIPTION
### Motivation
- The MCP server exposed high-risk primitives (`drop`, `eval`, `ipc`) to untrusted MCP clients with no server-side allowlist or explicit opt-in, enabling potential local-file exfiltration and privileged operations. 
- Provide a minimal, backward-compatible mitigation that reduces the attack surface while preserving non-dangerous tool functionality. 

### Description
- Introduce an opt-in environment switch `TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS` and a `DANGEROUS_MCP_TOOLS` list containing `drop`, `eval`, and `ipc`. 
- Reject runtime MCP calls to dangerous tools in `call_tool_by_name` unless the opt-in is enabled, returning a clear error message. 
- Hide dangerous tools from the MCP `list_tools` registration by filtering them out in `build_tools()` unless the opt-in flag is set. 
- Add two unit tests (`dangerous_tools_hidden_by_default` and `dangerous_tools_can_be_enabled`) that assert the default-hidden behavior and the explicit-enable behavior. 

### Testing
- Ran `cargo test -p tauri-pilot-cli dangerous_tools -- --nocapture` which executes the new `mcp` tests and the two new tests passed. 
- Verified the module-level tests exercising the MCP tool registry and call path for non-dangerous tools still succeed (unit tests in the `mcp` test module passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1484d1ad20832cb5ab83879e35cc4c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates high-risk MCP tools behind an explicit opt-in to reduce the attack surface. Safe tools continue to work by default.

- **Bug Fixes**
  - Gate `drop`, `eval`, and `ipc` at runtime and hide them from `list_tools` unless `TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS` is set; return a clear error when blocked.
  - Keep the registry test validating the full tool surface via `build_tools_with_flag(true)`; documented gating under Security in `CHANGELOG.md`.
  - Added tests for default-hidden and explicit-enable behavior.
  - Fix clippy lint by using `Option::is_some_and` in env parsing.

- **Migration**
  - To use these tools, set `TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS` to `1`, `true`, `yes`, or `on`.

<sup>Written for commit 5c587b3f69f8341f72cd39e5fe8ee7675278e7f1. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/104?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dangerous MCP tools are disabled by default and require an explicit environment-variable opt-in to be available.

* **Tests**
  * Added tests verifying dangerous tools are hidden by default and appear only when the opt-in is enabled.

* **Documentation**
  * Changelog updated to document the opt-in behavior and reference the related change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->