### PR TITLE
fix(cli): shell-escape refs in replay shell export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Shell-escape element `ref` values when exporting recordings to shell
+  scripts via `replay --export sh`. Refs were previously emitted unquoted
+  (e.g. `tauri-pilot click @e1`) while selectors and values were already
+  escaped, so a recording carrying a crafted `ref` (injectable through the
+  `record.add` IPC method or a hand-edited recording file) could inject
+  arbitrary shell commands into the generated script. All `@ref` tokens —
+  top-level targets, nested `source`/`target` refs, and `scroll --ref`
+  arguments — are now single-quoted. [#105]
 - Gate the dangerous MCP tools `pilot.drop`, `pilot.eval`, and `pilot.ipc`
   behind the `TAURI_PILOT_MCP_ENABLE_DANGEROUS_TOOLS` opt-in environment
   variable. By default these tools are now hidden from `list_tools` and
@@ -402,3 +410,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#89]: https://github.com/mpiton/tauri-pilot/pull/89
 [#91]: https://github.com/mpiton/tauri-pilot/issues/91
 [#104]: https://github.com/mpiton/tauri-pilot/pull/104
+[#105]: https://github.com/mpiton/tauri-pilot/pull/105

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1181,6 +1181,13 @@ fn shell_escape(s: &str) -> String {
     escaped
 }
 
+
+
+/// Build a shell-safe CLI target for element refs (e.g. `@e1`).
+fn shell_escape_ref_target(ref_id: &str) -> String {
+    shell_escape(&format!("@{ref_id}"))
+}
+
 /// Returns `true` for actions that are safe to replay.
 fn is_replayable(action: &str) -> bool {
     matches!(
@@ -1206,7 +1213,7 @@ fn is_replayable(action: &str) -> bool {
 fn resolve_export_target(val: Option<&Value>) -> Option<String> {
     let obj = val?;
     if let Some(r) = obj.get("ref").and_then(|r| r.as_str()) {
-        return Some(format!("@{r}"));
+        return Some(shell_escape_ref_target(r));
     }
     if let Some(s) = obj.get("selector").and_then(|s| s.as_str()) {
         return Some(shell_escape(s));
@@ -1224,7 +1231,7 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
     let ref_id = entry.get("ref").and_then(|r| r.as_str());
     let selector = entry.get("selector").and_then(|s| s.as_str());
     let target = if let Some(r) = ref_id {
-        format!("@{r}")
+        shell_escape_ref_target(r)
     } else if let Some(s) = selector {
         shell_escape(s)
     } else {
@@ -1260,7 +1267,7 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
                 let _ = write!(cmd, " {amt}");
             }
             if let Some(r) = entry.get("ref").and_then(|r| r.as_str()) {
-                let _ = write!(cmd, " --ref @{r}");
+                let _ = write!(cmd, " --ref {}", shell_escape_ref_target(r));
             }
             cmd
         }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1181,8 +1181,6 @@ fn shell_escape(s: &str) -> String {
     escaped
 }
 
-
-
 /// Build a shell-safe CLI target for element refs (e.g. `@e1`).
 fn shell_escape_ref_target(ref_id: &str) -> String {
     shell_escape(&format!("@{ref_id}"))

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -2003,7 +2003,7 @@ mod tests {
             .and_then(Value::as_str)
             .expect("script result");
         assert!(script.starts_with("#!/bin/bash"));
-        assert!(script.contains("tauri-pilot click @e1"));
+        assert!(script.contains("tauri-pilot click '@e1'"));
 
         let _ = std::fs::remove_file(&recording);
     }


### PR DESCRIPTION
### Motivation
- Prevent command-injection when exporting recordings to shell scripts because element `ref` values were emitted unescaped into CLI commands used in `replay --export sh`.
- Recorded entries (including `record.add` payloads) can contain attacker-controlled `ref` strings, so the exporter must treat refs as untrusted input.

### Description
- Add a helper `shell_escape_ref_target()` that builds a shell-safe CLI target by quoting and escaping `@<ref>` with the existing `shell_escape()` helper.
- Use `shell_escape_ref_target()` when producing top-level `ref` targets, nested `source`/`target` refs via `resolve_export_target()`, and `--ref` arguments in `scroll` so all emitted `@ref` tokens are quoted.
- Leave other export formatting unchanged so normal selector/value quoting and command layout are preserved.
- Update the MCP replay export test in `crates/tauri-pilot-cli/src/mcp.rs` to assert the new quoted `@ref` form (e.g. `tauri-pilot click '@e1'`).

### Testing
- Ran `cargo test -p tauri-pilot-cli --quiet` which passed (all CLI tests succeeded after updating the test expectation).
- The modified test `mcp::tests::replay_export_does_not_connect_to_socket` was updated to match the safe-quoted output and passes under the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1484af5454832c8a11b03afbc3e50e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes element refs in `replay --export sh` to prevent command injection. All `@ref` tokens are now single-quoted (e.g., `tauri-pilot click '@e1'`).

- **Bug Fixes**
  - Added `shell_escape_ref_target()` and used it for top-level `ref`, nested `source`/`target` via `resolve_export_target()`, and `scroll --ref`.
  - Updated CLI test and `CHANGELOG.md`; test suite passes.
  - Fixed formatting to satisfy `cargo fmt --check` in CI.

<sup>Written for commit f1540bef5067903dfc5b5ed522d94d4b84c6f59a. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/105?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exported shell scripts and CLI commands now safely quote/escape element references to prevent injection and ensure special characters are handled correctly.

* **Tests**
  * Tests updated to expect quoted/escaped element references in generated scripts and command outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->