### PR TITLE
fix(release): verify packages before tokenized publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,15 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+      - name: Package verify tauri-plugin-pilot (no token)
+        run: cargo package -p tauri-plugin-pilot
+
       - name: Publish tauri-plugin-pilot
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set +e
-          OUTPUT=$(cargo publish -p tauri-plugin-pilot 2>&1)
+          OUTPUT=$(cargo publish -p tauri-plugin-pilot --no-verify 2>&1)
           STATUS=$?
           set -e
           if [ $STATUS -eq 0 ]; then
@@ -111,12 +114,15 @@ jobs:
             sleep 10
           done
 
+      - name: Package verify tauri-pilot-cli (no token)
+        run: cargo package -p tauri-pilot-cli
+
       - name: Publish tauri-pilot-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set +e
-          OUTPUT=$(cargo publish -p tauri-pilot-cli 2>&1)
+          OUTPUT=$(cargo publish -p tauri-pilot-cli --no-verify 2>&1)
           STATUS=$?
           set -e
           if [ $STATUS -eq 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Harden the release workflow against `CARGO_REGISTRY_TOKEN` exfiltration.
+  `cargo publish` ran a verification build with the registry token present in
+  the environment, so a compromised dependency build script or proc-macro
+  could read and leak the token during that build. Each crate is now verified
+  with a secret-free `cargo package` step (no token in scope), and the
+  token-bearing `cargo publish` step runs with `--no-verify` so it only uploads
+  the already-verified package. [#106]
 - Shell-escape element `ref` values when exporting recordings to shell
   scripts via `replay --export sh`. Refs were previously emitted unquoted
   (e.g. `tauri-pilot click @e1`) while selectors and values were already
@@ -411,3 +418,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#91]: https://github.com/mpiton/tauri-pilot/issues/91
 [#104]: https://github.com/mpiton/tauri-pilot/pull/104
 [#105]: https://github.com/mpiton/tauri-pilot/pull/105
+[#106]: https://github.com/mpiton/tauri-pilot/pull/106


### PR DESCRIPTION
### Motivation
- The release workflow exposed `CARGO_REGISTRY_TOKEN` to `cargo publish` verification builds which can execute build scripts/proc-macros/dependency build scripts with that environment.
- This creates a high-risk path for token exfiltration if a dependency or a prior mutable action is compromised.
- The intent is to verify packages without secrets and then publish the already-verified package while avoiding verification-time access to secrets.

### Description
- Add secret-free verification steps using `cargo package -p <crate>` for both `tauri-plugin-pilot` and `tauri-pilot-cli` in the release workflow.
- Change token-bearing publish commands to `cargo publish --no-verify` while preserving the existing idempotent `already uploaded` handling and status logic.
- Only the CI workflow file `.github/workflows/release.yml` was modified.

### Testing
- Inspected the modified workflow with `sed -n '1,220p' .github/workflows/release.yml` which showed the new `cargo package` steps and `--no-verify` usage and they succeeded locally.
- Verified the change via `git diff`/`nl` to confirm the inserted lines and then committed the change with `git commit`, both of which completed successfully.
- No CI jobs were executed as part of this local fix; only static inspection and commit verification were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1484a4f358832ca7682d01cb86f631)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the release workflow by verifying crates without secrets, then publishing with `--no-verify` to avoid exposing `CARGO_REGISTRY_TOKEN` during verification. Applies to `tauri-plugin-pilot` and `tauri-pilot-cli`, and documents the change in `CHANGELOG.md`.

- **Bug Fixes**
  - Add secret-free `cargo package -p <crate>` steps for `tauri-plugin-pilot` and `tauri-pilot-cli`.
  - Change publish to `cargo publish --no-verify` while keeping existing “already uploaded” handling.

<sup>Written for commit 98876760bc44be0b0f113a4e8bb18c1298c546b4. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

