### PR TITLE
fix(mcp): block javascript URLs in navigate tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Block `javascript:` URLs in the `pilot.navigate` MCP tool. Because
+  `navigate` is not gated behind the dangerous-tools opt-in, an untrusted MCP
+  client could previously pass a `javascript:` URL that the bridge assigns to
+  `window.location.href`, executing arbitrary JavaScript and bypassing the
+  `pilot.eval` gate added in [#104]. The URL is now normalized the way a
+  browser's URL parser would — stripping ASCII tab/newline/carriage-return
+  anywhere in the string and leading C0 controls/spaces — before any
+  `javascript:` scheme is rejected with `INVALID_PARAMS`, so smuggling
+  variants such as `java\tscript:` or `\0javascript:` are blocked too. [#107]
 - Shell-escape element `ref` values when exporting recordings to shell
   scripts via `replay --export sh`. Refs were previously emitted unquoted
   (e.g. `tauri-pilot click @e1`) while selectors and values were already

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -265,9 +265,11 @@ impl PilotMcpServer {
                     .await
             }
             "navigate" => {
+                let url = required_string(&args, "url")?;
+                validate_navigate_url(&url)?;
                 self.call_app_tool(
                     "navigate",
-                    Some(json!({"url": required_string(&args, "url")?})),
+                    Some(json!({ "url": url })),
                     window,
                 )
                 .await
@@ -675,6 +677,19 @@ fn dangerous_mcp_tools_enabled() -> bool {
                 "1" | "true" | "yes" | "on"
             )
         })
+}
+
+fn validate_navigate_url(url: &str) -> Result<(), McpError> {
+    if url
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("javascript:")
+    {
+        return Err(invalid_params(
+            "navigate does not allow javascript: URLs for security reasons",
+        ));
+    }
+    Ok(())
 }
 
 struct ToolSpec {
@@ -1967,6 +1982,24 @@ mod tests {
                 "dangerous tool '{dangerous}' should be listed when explicitly enabled"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn navigate_rejects_javascript_urls() {
+        let pilot = PilotMcpServer::new(None, None);
+        let mut args = Map::new();
+        args.insert("url".to_owned(), json!(" javascript:alert(1)"));
+
+        let err = pilot
+            .call_tool_by_name("navigate", args)
+            .await
+            .expect_err("javascript URL should be rejected");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("does not allow javascript: URLs"),
+            "unexpected error message: {}",
+            err.message
+        );
     }
 
     #[tokio::test]

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -680,8 +680,19 @@ fn dangerous_mcp_tools_enabled() -> bool {
 }
 
 fn validate_navigate_url(url: &str) -> Result<(), McpError> {
-    if url
-        .trim_start()
+    // Mirror the normalization a browser's URL parser applies before it
+    // resolves the scheme, so a crafted string can't smuggle a `javascript:`
+    // URL past this filter and reach `window.location.href` in the bridge:
+    //   * ASCII tab/LF/CR are stripped from anywhere in the input, so
+    //     `java\tscript:` and `java\nscript:` collapse to `javascript:`.
+    //   * Leading C0 controls and spaces (scalar value <= U+0020) are removed,
+    //     so `\u{0}javascript:` collapses to `javascript:`.
+    let stripped: String = url
+        .chars()
+        .filter(|c| !matches!(c, '\t' | '\n' | '\r'))
+        .collect();
+    if stripped
+        .trim_start_matches(|c| c <= '\u{20}')
         .to_ascii_lowercase()
         .starts_with("javascript:")
     {
@@ -1986,20 +1997,53 @@ mod tests {
 
     #[tokio::test]
     async fn navigate_rejects_javascript_urls() {
-        let pilot = PilotMcpServer::new(None, None);
-        let mut args = Map::new();
-        args.insert("url".to_owned(), json!(" javascript:alert(1)"));
+        // Each payload normalizes to `javascript:` once a browser's URL parser
+        // strips tab/LF/CR and leading C0 controls/spaces, so the MCP filter
+        // must reject them before they reach `window.location.href`.
+        let payloads = [
+            " javascript:alert(1)",          // leading space
+            "JaVaScRiPt:alert(1)",           // mixed case
+            "java\tscript:alert(1)",         // embedded tab
+            "java\nscript:alert(1)",         // embedded newline
+            "java\rscript:alert(1)",         // embedded carriage return
+            "\u{0}javascript:alert(1)",      // leading NUL (C0 control)
+            "\u{1}\u{2}javascript:alert(1)", // leading C0 controls
+        ];
 
-        let err = pilot
-            .call_tool_by_name("navigate", args)
-            .await
-            .expect_err("javascript URL should be rejected");
-        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
-        assert!(
-            err.message.contains("does not allow javascript: URLs"),
-            "unexpected error message: {}",
-            err.message
-        );
+        for payload in payloads {
+            let pilot = PilotMcpServer::new(None, None);
+            let mut args = Map::new();
+            args.insert("url".to_owned(), json!(payload));
+
+            // Validation rejects before any socket call, so this surfaces an
+            // `Err(McpError)` rather than reaching the app tool.
+            let err = pilot
+                .call_tool_by_name("navigate", args)
+                .await
+                .expect_err(&format!("javascript URL should be rejected: {payload:?}"));
+            assert_eq!(err.code, ErrorCode::INVALID_PARAMS, "payload: {payload:?}");
+            assert!(
+                err.message.contains("does not allow javascript: URLs"),
+                "unexpected error message for {payload:?}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn validate_navigate_url_allows_safe_urls() {
+        // Legitimate schemes and paths that merely contain the substring must
+        // not be over-blocked by the prefix check.
+        for url in [
+            "https://example.com/app",
+            "/relative/path",
+            "https://example.com/javascript:not-a-scheme",
+            "about:blank",
+        ] {
+            validate_navigate_url(url).unwrap_or_else(|err| {
+                panic!("safe url wrongly rejected: {url:?} ({})", err.message)
+            });
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Close a security bypass where `pilot.navigate` could be used to execute arbitrary JavaScript (via `javascript:` URLs) even when `pilot.eval` was gated by opt-in. 

### Description
- Validate `pilot.navigate` payloads in `crates/tauri-pilot-cli/src/mcp.rs` and extract the `url` before forwarding to the app tool. 
- Add `fn validate_navigate_url(url: &str) -> Result<(), McpError>` which rejects `javascript:` URLs (case-insensitive and tolerant of leading whitespace) by returning `INVALID_PARAMS`. 
- Preserve normal navigation behavior for non-`javascript:` URLs by forwarding the validated `url` to the existing `navigate` app tool. 
- Add a regression test `navigate_rejects_javascript_urls` exercising `call_tool_by_name("navigate", ...)` to ensure `javascript:` URLs are blocked.

### Testing
- Ran `cargo test -p tauri-pilot-cli navigate_rejects_javascript_urls`, which passed. 
- Ran `cargo test -p tauri-pilot-cli dangerous_tools_`, which ran the existing dangerous-tools tests (`dangerous_tools_hidden_by_default` and `dangerous_tools_can_be_enabled`) and they passed. 
- The change is limited to `crates/tauri-pilot-cli/src/mcp.rs` and the new test to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15470d8fec832caa50ea179ec6965e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block `javascript:` URLs in `pilot.navigate` to prevent arbitrary JS execution bypassing `pilot.eval` opt-in. The MCP server now normalizes the URL like browsers (removes tabs/newlines/CR anywhere and leading C0 controls/spaces), rejects any `javascript:` scheme with `INVALID_PARAMS`, forwards only validated URLs, and adds tests for smuggled variants and safe URLs.

<sup>Written for commit 40dc8d774b6d4e86699144f0acf7c90556b80107. Summary will update on new commits. <a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/107?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation now rejects `javascript:`-style URLs (including obfuscated variants with control or whitespace characters) to prevent unsafe navigation.
* **Documentation**
  * Changelog updated to note the navigation security mitigation.
* **Tests**
  * Added tests ensuring unsafe `javascript:` payloads are rejected and safe URL examples are accepted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->