### PR TITLE
fix: restore eval completion and native screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a `screenshot_native` CLI subcommand to capture a native window PNG by
+  window id. [#108]
+- Make bridge bootstrap idempotent so repeated injection attempts are no-ops.
+  [#108]
+
+### Fixed
+
+- Restore eval result delivery on Tauri 2.11 / wry 0.55 by using native
+  WebView eval callbacks instead of JS-to-Tauri `__callback` IPC for eval
+  results. [#108]
+- Preserve `windows.list` output without panicking when wry 0.55 cannot report
+  a webview URL. [#108]
+
 ### Security
 
 - Block `javascript:` URLs in the `pilot.navigate` MCP tool. Because

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -117,6 +117,16 @@ pub(crate) enum Command {
         #[arg(long)]
         selector: Option<String>,
     },
+    /// Capture a native window screenshot (PNG) by platform window id.
+    #[command(name = "screenshot_native", visible_alias = "screenshot-native")]
+    ScreenshotNative {
+        #[arg(long)]
+        window_id: u32,
+        #[arg(long)]
+        output: PathBuf,
+        #[arg(long, default_value = "png")]
+        format: String,
+    },
     /// Navigate to a URL.
     Navigate { url: String },
     /// Get current URL.
@@ -811,6 +821,32 @@ mod tests {
     fn test_windows_command() {
         let cli = Cli::parse_from(["tauri-pilot", "--socket", "/tmp/test.sock", "windows"]);
         assert!(matches!(cli.command, Command::Windows));
+    }
+
+    #[test]
+    fn test_parse_screenshot_native_command() {
+        let cli = Cli::parse_from([
+            "tauri-pilot",
+            "--socket",
+            "/tmp/test.sock",
+            "screenshot_native",
+            "--window-id",
+            "42",
+            "--output",
+            "/tmp/out.png",
+        ]);
+        if let Command::ScreenshotNative {
+            window_id,
+            output,
+            format,
+        } = cli.command
+        {
+            assert_eq!(window_id, 42);
+            assert_eq!(output, std::path::PathBuf::from("/tmp/out.png"));
+            assert_eq!(format, "png");
+        } else {
+            panic!("Expected ScreenshotNative command");
+        }
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -357,6 +357,25 @@ async fn run_command(
                 )
                 .await
         }
+        Command::ScreenshotNative {
+            window_id,
+            output,
+            format,
+        } => {
+            client
+                .call(
+                    "screenshot_native",
+                    with_window(
+                        Some(json!({
+                            "window_id": window_id,
+                            "output_path": output.display().to_string(),
+                            "format": format,
+                        })),
+                        window,
+                    ),
+                )
+                .await
+        }
         Command::Navigate { url } => {
             client
                 .call("navigate", with_window(Some(json!({"url": url})), window))

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -50,9 +50,13 @@ windows = { version = "0.61", features = [
 enigo = { version = "0.6.1", features = ["wayland"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6"
 core-foundation = "0.10"
 core-graphics = "0.24"
 image = { version = "0.25", default-features = false, features = ["png"] }
+objc2 = "0.6"
+objc2-foundation = "0.3"
+objc2-web-kit = "0.3"
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/tauri-plugin-pilot/build.rs
+++ b/crates/tauri-plugin-pilot/build.rs
@@ -1,4 +1,4 @@
-const COMMANDS: &[&str] = &["__callback"];
+const COMMANDS: &[&str] = &["callback", "__callback"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1,6 +1,8 @@
 (() => {
   "use strict";
 
+  if (window.__PILOT__) return;
+
   const idMap = new Map();
   let refCounter = 0;
 

--- a/crates/tauri-plugin-pilot/permissions/autogenerated/commands/callback.toml
+++ b/crates/tauri-plugin-pilot/permissions/autogenerated/commands/callback.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-callback"
+description = "Enables the callback command without any pre-configured scope."
+commands.allow = ["callback"]
+
+[[permission]]
+identifier = "deny-callback"
+description = "Denies the callback command without any pre-configured scope."
+commands.deny = ["callback"]

--- a/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
@@ -49,7 +49,33 @@ Denies the __callback command without any pre-configured scope.
 </td>
 <td>
 
-Allow the internal __callback IPC command used by the eval engine
+Enables the callback command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`pilot:deny-callback`
+
+</td>
+<td>
+
+Denies the callback command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`pilot:allow-callback`
+
+</td>
+<td>
+
+Allow the internal callback IPC commands used by the eval engine
 
 </td>
 </tr>

--- a/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-pilot/permissions/autogenerated/reference.md
@@ -4,7 +4,7 @@ Default permissions for tauri-plugin-pilot (allows eval callback)
 
 #### This default permission set includes the following:
 
-- `allow-callback`
+- `allow-eval-callbacks`
 
 ## Permission Table
 
@@ -70,7 +70,7 @@ Denies the callback command without any pre-configured scope.
 <tr>
 <td>
 
-`pilot:allow-callback`
+`pilot:allow-eval-callbacks`
 
 </td>
 <td>

--- a/crates/tauri-plugin-pilot/permissions/default.toml
+++ b/crates/tauri-plugin-pilot/permissions/default.toml
@@ -2,10 +2,10 @@
 
 [[permission]]
 identifier = "allow-callback"
-description = "Allow the internal __callback IPC command used by the eval engine"
+description = "Allow the internal callback IPC commands used by the eval engine"
 
 [permission.commands]
-allow = ["__callback"]
+allow = ["callback", "__callback"]
 
 [default]
 description = "Default permissions for tauri-plugin-pilot (allows eval callback)"

--- a/crates/tauri-plugin-pilot/permissions/default.toml
+++ b/crates/tauri-plugin-pilot/permissions/default.toml
@@ -1,7 +1,7 @@
 "$schema" = "schemas/schema.json"
 
 [[permission]]
-identifier = "allow-callback"
+identifier = "allow-eval-callbacks"
 description = "Allow the internal callback IPC commands used by the eval engine"
 
 [permission.commands]
@@ -9,4 +9,4 @@ allow = ["callback", "__callback"]
 
 [default]
 description = "Default permissions for tauri-plugin-pilot (allows eval callback)"
-permissions = ["allow-callback"]
+permissions = ["allow-eval-callbacks"]

--- a/crates/tauri-plugin-pilot/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-pilot/permissions/schemas/schema.json
@@ -307,16 +307,28 @@
           "markdownDescription": "Denies the __callback command without any pre-configured scope."
         },
         {
+          "description": "Enables the callback command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-callback",
+          "markdownDescription": "Enables the callback command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the callback command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-callback",
+          "markdownDescription": "Denies the callback command without any pre-configured scope."
+        },
+        {
           "description": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`",
           "type": "string",
           "const": "default",
           "markdownDescription": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`"
         },
         {
-          "description": "Allow the internal __callback IPC command used by the eval engine",
+          "description": "Allow the internal callback IPC commands used by the eval engine",
           "type": "string",
           "const": "allow-callback",
-          "markdownDescription": "Allow the internal __callback IPC command used by the eval engine"
+          "markdownDescription": "Allow the internal callback IPC commands used by the eval engine"
         }
       ]
     }

--- a/crates/tauri-plugin-pilot/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-pilot/permissions/schemas/schema.json
@@ -319,15 +319,15 @@
           "markdownDescription": "Denies the callback command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`",
+          "description": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-eval-callbacks`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-callback`"
+          "markdownDescription": "Default permissions for tauri-plugin-pilot (allows eval callback)\n#### This default permission set includes:\n\n- `allow-eval-callbacks`"
         },
         {
           "description": "Allow the internal callback IPC commands used by the eval engine",
           "type": "string",
-          "const": "allow-callback",
+          "const": "allow-eval-callbacks",
           "markdownDescription": "Allow the internal callback IPC commands used by the eval engine"
         }
       ]

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -88,9 +88,10 @@ impl EvalEngine {
     }
 
     /// Wrap a user script in the ADR-001 callback pattern.
-    /// Uses `__TAURI_INTERNALS__.invoke` which is always available (even without
-    /// `withGlobalTauri`). The expression is `await`-ed so async results resolve
-    /// before serialization.
+    /// Returns a small callback payload object for `WebviewWindow::eval_with_callback`.
+    /// This avoids routing eval results through JS-to-Tauri IPC, which can fail
+    /// to dispatch from scripts injected with `webview.eval` on newer
+    /// Tauri/wry/WebKit combinations.
     ///
     /// Normalizes `undefined` results to `null` (string `"null"`) so Tauri does
     /// not drop the `result` field — otherwise a void expression (e.g.,
@@ -99,11 +100,9 @@ impl EvalEngine {
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
-            "(async()=>{{try{{let __r=await({script});\
-             await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
-             {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}});\
-             }}catch(__e){{await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
-             {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
+            "(()=>{{try{{let __r=({script});\
+             return {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}};\
+             }}catch(__e){{return {{id:{id},error:(__e&&__e.message)||String(__e)}};}}}})();"
         )
     }
 
@@ -217,9 +216,17 @@ mod tests {
         let script = EvalEngine::wrap_script(42, "document.title");
         assert!(script.contains("42"));
         assert!(script.contains("document.title"));
-        assert!(script.contains("__callback"));
+        assert!(script.contains("return {id:42,result:"));
         assert!(script.contains("try"));
         assert!(script.contains("catch"));
+    }
+
+    #[test]
+    fn test_wrap_script_does_not_depend_on_ipc_callback_bridge() {
+        let script = EvalEngine::wrap_script(1, "document.title");
+        assert!(!script.contains("plugin:pilot|callback"));
+        assert!(!script.contains("plugin:pilot|__callback"));
+        assert!(!script.contains("__TAURI_INTERNALS__"));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -18,9 +18,9 @@ pub(crate) enum EvalError {
 
 type PendingMap = HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>>>;
 
-/// Engine for executing JS in a `WebView` and getting results via callback.
+/// Engine for executing JS in a `WebView` and resolving native eval callback results.
 ///
-/// The core ADR-001 pattern: wrap script in try/catch + invoke callback,
+/// The core ADR-001 pattern: wrap script in try/catch + return a callback payload,
 /// await the result on a oneshot channel with timeout.
 #[derive(Clone)]
 pub(crate) struct EvalEngine {
@@ -69,7 +69,7 @@ impl EvalEngine {
         (id, rx)
     }
 
-    /// Resolve a pending eval by ID. Called from the IPC __callback handler.
+    /// Resolve a pending eval by ID from a `WebView` eval callback payload.
     pub fn resolve(&self, id: u64, result: Result<serde_json::Value, String>) {
         let sender = self
             .pending
@@ -87,7 +87,7 @@ impl EvalEngine {
         }
     }
 
-    /// Wrap a user script in the ADR-001 callback pattern.
+    /// Wrap a user script so `WebView` eval callbacks receive a tagged payload.
     /// Returns a small callback payload object for `WebviewWindow::eval_with_callback`.
     /// This avoids routing eval results through JS-to-Tauri IPC, which can fail
     /// to dispatch from scripts injected with `webview.eval` on newer

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -100,7 +100,7 @@ impl EvalEngine {
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
-            "(()=>{{try{{let __r=({script});\
+            "(async()=>{{try{{let __r=await({script});\
              return {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}};\
              }}catch(__e){{return {{id:{id},error:(__e&&__e.message)||String(__e)}};}}}})();"
         )
@@ -216,6 +216,7 @@ mod tests {
         let script = EvalEngine::wrap_script(42, "document.title");
         assert!(script.contains("42"));
         assert!(script.contains("document.title"));
+        assert!(script.contains("await("));
         assert!(script.contains("return {id:42,result:"));
         assert!(script.contains("try"));
         assert!(script.contains("catch"));

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -290,6 +290,7 @@ async fn handle_diff(
             message: msg,
             data: None,
         })?;
+    let script = ensure_bridge_script(&script);
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
@@ -470,6 +471,7 @@ async fn handle_eval_method(
         message: msg,
         data: None,
     })?;
+    let script = ensure_bridge_script(&script);
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
@@ -518,6 +520,19 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> Result
     Ok(format!("window.__PILOT__.{method}({args})"))
 }
 
+#[cfg(debug_assertions)]
+fn ensure_bridge_script(call: &str) -> String {
+    format!(
+        "(()=>{{if(!window.__PILOT__){{\n{}\n}}return ({call});}})()",
+        crate::BRIDGE_JS
+    )
+}
+
+#[cfg(not(debug_assertions))]
+fn ensure_bridge_script(call: &str) -> String {
+    call.to_owned()
+}
+
 /// Process the IPC callback from the JS bridge (ADR-001).
 pub(crate) fn handle_callback(
     engine: &EvalEngine,
@@ -538,7 +553,22 @@ pub(crate) fn handle_callback(
     }
 }
 
-/// Tauri IPC command for the `__callback` handler.
+/// Tauri IPC command for the eval callback handler.
+#[tauri::command]
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "tauri::command contract — macro wrapper is the real consumer"
+)]
+pub(crate) fn callback(
+    eval_engine: tauri::State<'_, EvalEngine>,
+    id: u64,
+    result: Option<String>,
+    error: Option<String>,
+) {
+    handle_callback(&eval_engine, id, result, error);
+}
+
+/// Legacy Tauri IPC command for the `__callback` handler.
 ///
 /// `#[tauri::command]` binds `State<'_, T>` by value — the generated wrapper
 /// is the true consumer, so clippy's view of the body is incomplete. Cannot

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -290,7 +290,6 @@ async fn handle_diff(
             message: msg,
             data: None,
         })?;
-    let script = ensure_bridge_script(&script);
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
@@ -471,7 +470,6 @@ async fn handle_eval_method(
         message: msg,
         data: None,
     })?;
-    let script = ensure_bridge_script(&script);
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, &script);
 
@@ -518,19 +516,6 @@ fn build_bridge_call(method: &str, params: Option<&serde_json::Value>) -> Result
     }
 
     Ok(format!("window.__PILOT__.{method}({args})"))
-}
-
-#[cfg(debug_assertions)]
-fn ensure_bridge_script(call: &str) -> String {
-    format!(
-        "(()=>{{if(!window.__PILOT__){{\n{}\n}}return ({call});}})()",
-        crate::BRIDGE_JS
-    )
-}
-
-#[cfg(not(debug_assertions))]
-fn ensure_bridge_script(call: &str) -> String {
-    call.to_owned()
 }
 
 /// Process the IPC callback from the JS bridge (ADR-001).

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -141,7 +141,7 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>, engine: EvalEngine
         let engine = engine.clone();
         #[cfg(target_os = "macos")]
         {
-            return eval_with_webkit_callback(&target, script, engine);
+            eval_with_webkit_callback(&target, script, engine)
         }
         #[cfg(not(target_os = "macos"))]
         target

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use tauri::Manager;
 
 #[cfg(all(any(unix, windows), debug_assertions))]
-const BRIDGE_JS: &str = concat!(
+pub(crate) const BRIDGE_JS: &str = concat!(
     include_str!("../js/vendor/html-to-image.iife.js"),
     "\n",
     include_str!("../js/bridge.js"),
@@ -52,6 +52,11 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     {
         tauri::plugin::Builder::new("pilot")
             .js_init_script(BRIDGE_JS.to_owned())
+            .on_webview_ready(|webview| {
+                if let Err(err) = webview.eval(BRIDGE_JS) {
+                    tracing::warn!(error = %err, "failed to inject tauri-pilot bridge on webview ready");
+                }
+            })
             .setup(|app, _api| {
                 let engine = EvalEngine::new();
                 app.manage(engine.clone());
@@ -59,7 +64,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 let identifier = sanitize_identifier(&app.config().identifier);
                 let socket_path = server::socket_path(&identifier);
 
-                let eval_fn = make_eval_fn(app);
+                let eval_fn = make_eval_fn(app, engine.clone());
                 let list_fn = make_list_fn(app);
                 let focus_fn = make_focus_fn(app);
 
@@ -82,7 +87,10 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
                 Ok(())
             })
-            .invoke_handler(tauri::generate_handler![handler::__callback])
+            .invoke_handler(tauri::generate_handler![
+                handler::callback,
+                handler::__callback
+            ])
             .build()
     }
 }
@@ -113,25 +121,110 @@ fn sanitize_identifier(raw: &str) -> String {
 /// If `window` is `Some(label)`, targets that specific window (error if not found).
 /// If `window` is `None`, tries "main" first then falls back to the first available window.
 #[cfg(all(any(unix, windows), debug_assertions))]
-fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
+fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>, engine: EvalEngine) -> EvalFn {
     let handle = app.clone();
     Arc::new(move |window: Option<&str>, script: String| {
-        if let Some(label) = window {
-            return handle
+        let target = if let Some(label) = window {
+            handle
                 .get_webview_window(label)
-                .ok_or_else(|| format!("Window '{label}' not found"))
-                .and_then(|w| w.eval(&script).map_err(|e| e.to_string()));
+                .ok_or_else(|| format!("Window '{label}' not found"))?
+        } else if let Some(w) = handle.get_webview_window("main") {
+            w
+        } else {
+            handle
+                .webview_windows()
+                .values()
+                .next()
+                .cloned()
+                .ok_or_else(|| "No webview available".to_owned())?
+        };
+        let engine = engine.clone();
+        #[cfg(target_os = "macos")]
+        {
+            return eval_with_webkit_callback(&target, script, engine);
         }
-        if let Some(w) = handle.get_webview_window("main") {
-            return w.eval(&script).map_err(|e| e.to_string());
-        }
-        let windows = handle.webview_windows();
-        windows
-            .values()
-            .next()
-            .ok_or_else(|| "No webview available".to_owned())
-            .and_then(|w| w.eval(&script).map_err(|e| e.to_string()))
+        #[cfg(not(target_os = "macos"))]
+        target
+            .eval_with_callback(&script, move |payload| {
+                handle_eval_callback_payload(&engine, &payload);
+            })
+            .map_err(|e| e.to_string())
     })
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn eval_with_webkit_callback<R: tauri::Runtime>(
+    target: &tauri::WebviewWindow<R>,
+    script: String,
+    engine: EvalEngine,
+) -> Result<(), String> {
+    target
+        .with_webview(move |platform| unsafe {
+            use objc2::{AnyThread, runtime::AnyObject};
+            use objc2_foundation::{
+                NSError, NSJSONSerialization, NSJSONWritingOptions, NSString, NSUTF8StringEncoding,
+            };
+            use objc2_web_kit::WKWebView;
+
+            let webview: &WKWebView = &*platform.inner().cast();
+            let handler =
+                block2::RcBlock::new(move |value: *mut AnyObject, error: *mut NSError| {
+                    if !error.is_null() {
+                        tracing::warn!("native WebKit eval callback returned an error");
+                        return;
+                    }
+
+                    let mut payload = String::new();
+                    if !value.is_null()
+                        && let Ok(data) = NSJSONSerialization::dataWithJSONObject_options_error(
+                            &*value,
+                            NSJSONWritingOptions::FragmentsAllowed,
+                        )
+                        && let Some(json) = NSString::initWithData_encoding(
+                            NSString::alloc(),
+                            &data,
+                            NSUTF8StringEncoding,
+                        )
+                    {
+                        payload = json.to_string();
+                    }
+                    handle_eval_callback_payload(&engine, &payload);
+                });
+
+            webview
+                .evaluateJavaScript_completionHandler(&NSString::from_str(&script), Some(&handler));
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(all(any(unix, windows), debug_assertions))]
+fn handle_eval_callback_payload(engine: &EvalEngine, payload: &str) {
+    let parsed = serde_json::from_str::<serde_json::Value>(payload)
+        .ok()
+        .and_then(|value| {
+            if let Some(inner) = value.as_str() {
+                serde_json::from_str::<serde_json::Value>(inner).ok()
+            } else {
+                Some(value)
+            }
+        });
+    let Some(value) = parsed else {
+        tracing::warn!(payload, "eval callback returned non-json payload");
+        return;
+    };
+    let Some(id) = value.get("id").and_then(serde_json::Value::as_u64) else {
+        tracing::warn!(payload = %value, "eval callback payload missing id");
+        return;
+    };
+    let result = value
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    let error = value
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    handler::handle_callback(engine, id, result, error);
 }
 
 /// Create a focus function that requests OS focus for a webview window.
@@ -174,7 +267,7 @@ fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
             .map(|(label, wv)| {
                 serde_json::json!({
                     "label": label,
-                    "url": wv.url().map(|u| u.to_string()).unwrap_or_default(),
+                    "url": "",
                     "title": wv.title().unwrap_or_default(),
                 })
             })

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -158,7 +158,12 @@ fn eval_with_webkit_callback<R: tauri::Runtime>(
     script: String,
     engine: EvalEngine,
 ) -> Result<(), String> {
+    let eval_id = extract_eval_callback_id(&script);
     target
+        // SAFETY: `platform.inner()` returns the WKWebView pointer owned by wry
+        // and valid for this `with_webview` closure. `RcBlock` allocates the
+        // completion block on the heap, and WebKit copies it so the callback
+        // stays alive after this scope returns.
         .with_webview(move |platform| unsafe {
             use objc2::{AnyThread, runtime::AnyObject};
             use objc2_foundation::{
@@ -170,24 +175,43 @@ fn eval_with_webkit_callback<R: tauri::Runtime>(
             let handler =
                 block2::RcBlock::new(move |value: *mut AnyObject, error: *mut NSError| {
                     if !error.is_null() {
-                        tracing::warn!("native WebKit eval callback returned an error");
+                        resolve_native_eval_error(
+                            &engine,
+                            eval_id,
+                            "native WebKit eval callback returned an error",
+                        );
                         return;
                     }
 
-                    let mut payload = String::new();
-                    if !value.is_null()
-                        && let Ok(data) = NSJSONSerialization::dataWithJSONObject_options_error(
-                            &*value,
-                            NSJSONWritingOptions::FragmentsAllowed,
-                        )
-                        && let Some(json) = NSString::initWithData_encoding(
+                    if value.is_null() {
+                        resolve_native_eval_error(
+                            &engine,
+                            eval_id,
+                            "native WebKit eval callback returned no value",
+                        );
+                        return;
+                    }
+
+                    let Some(json) = NSJSONSerialization::dataWithJSONObject_options_error(
+                        &*value,
+                        NSJSONWritingOptions::FragmentsAllowed,
+                    )
+                    .ok()
+                    .and_then(|data| {
+                        NSString::initWithData_encoding(
                             NSString::alloc(),
                             &data,
                             NSUTF8StringEncoding,
                         )
-                    {
-                        payload = json.to_string();
-                    }
+                    }) else {
+                        resolve_native_eval_error(
+                            &engine,
+                            eval_id,
+                            "native WebKit eval callback result was not JSON serializable",
+                        );
+                        return;
+                    };
+                    let payload = json.to_string();
                     handle_eval_callback_payload(&engine, &payload);
                 });
 
@@ -195,6 +219,29 @@ fn eval_with_webkit_callback<R: tauri::Runtime>(
                 .evaluateJavaScript_completionHandler(&NSString::from_str(&script), Some(&handler));
         })
         .map_err(|e| e.to_string())
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn extract_eval_callback_id(script: &str) -> Option<u64> {
+    script
+        .split("return {id:")
+        .nth(1)?
+        .split_once(',')?
+        .0
+        .parse()
+        .ok()
+}
+
+#[cfg(all(target_os = "macos", debug_assertions))]
+fn resolve_native_eval_error(engine: &EvalEngine, id: Option<u64>, message: &str) {
+    if let Some(id) = id {
+        handler::handle_callback(engine, id, None, Some(message.to_owned()));
+    } else {
+        tracing::warn!(
+            message,
+            "native WebKit eval callback failed before resolving an id"
+        );
+    }
 }
 
 #[cfg(all(any(unix, windows), debug_assertions))]
@@ -267,7 +314,11 @@ fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
             .map(|(label, wv)| {
                 serde_json::json!({
                     "label": label,
-                    "url": "",
+                    "url": std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wv.url()))
+                        .ok()
+                        .and_then(Result::ok)
+                        .map(|url| url.to_string())
+                        .unwrap_or_default(),
                     "title": wv.title().unwrap_or_default(),
                 })
             })

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -390,7 +390,7 @@ fn tmp_path_for(final_path: &Path) -> std::path::PathBuf {
         .map(std::ffi::OsString::from)
         .unwrap_or_default();
     let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    name.push(format!(".tmp.{}.{}", std::process::id(), counter));
+    name.push(format!(".tmp.{}.{counter}.png", std::process::id()));
     final_path.with_file_name(name)
 }
 
@@ -624,6 +624,19 @@ mod tests {
         assert_eq!(
             err_data(&err).get("error").and_then(Value::as_str),
             Some(codes::UNSUPPORTED_FORMAT)
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn tmp_path_keeps_png_extension_for_image_reader() {
+        let path = Path::new("/tmp/tauri-pilot-shot.png");
+        let tmp = tmp_path_for(path);
+        assert_eq!(tmp.extension().and_then(|ext| ext.to_str()), Some("png"));
+        assert!(
+            tmp.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(".tmp."))
         );
     }
 

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -90,9 +90,9 @@ The `windows.list` method enumerates all open windows (label, URL, title), sorte
 
 `webview.eval()` in Tauri v2 is **fire-and-forget** — it dispatches JS into the WebView but provides no return value. All methods that read from the page require a response, so a callback pattern is used:
 
-1. The plugin wraps the target JS in a `try/catch` block
-2. On completion, the JS invokes `window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback', {id, result})`
-3. The plugin's IPC handler for `__callback` looks up the matching `oneshot::Sender` and resolves it
+1. The plugin wraps the target JS in a `try/catch` block that returns `{id, result}` or `{id, error}`
+2. The WebView eval completion callback receives that payload
+3. The callback handler looks up the matching `oneshot::Sender` and resolves it
 4. Rust awaits the oneshot channel with a 10-second timeout
 
 The `EvalEngine` maintains:


### PR DESCRIPTION
## Summary

- restore eval result delivery on Tauri 2.11 / wry 0.55 by using WebView eval callbacks instead of JS-to-Tauri IPC callbacks
- keep async eval and bridge calls awaited, and make bridge bootstrap idempotent
- add macOS screenshot_native support with path-only PNG output and CLI/MCP routing
- avoid windows.list URL panics by omitting unavailable webview URLs from the listing path

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- EmpireTwo fork CI passed on the same driver head across macOS, Ubuntu, Windows, and CodeQL.

## API Surface

The intended stable surface for downstream harness use is:

- JSON-RPC transport methods: eval, html, snapshot
- windows.list
- screenshot_native with params: window_id, output_path, format optional png
- CLI route: tauri-pilot screenshot_native --window-id <id> --output <path> [--format png]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to capture native window screenshots by platform window ID (configurable output path and format).

* **Bug Fixes**
  * Bridge initialization is now idempotent to avoid duplicate instrumentation.
  * Restored reliable eval result delivery on newer runtimes and prevented window-listing panics when a webview URL can't be reported.
  * Ensured screenshot temp files preserve PNG extension.

* **Refactor**
  * Switched eval callback flow to a callback-style payload with improved macOS handling.

* **Documentation**
  * Updated architecture and permission docs and changelog to reflect these changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->