### PR TITLE
fix(plugin): include <p> paragraph text in snapshot (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   results. [#108]
 - Preserve `windows.list` output without panicking when wry 0.55 cannot report
   a webview URL. [#108]
+- Include `<p>` paragraph text in accessibility snapshots by mapping `<p>` to
+  the `paragraph` role. Snapshots previously dropped paragraph content (e.g. the
+  default Tauri template greeting rendered in a `<p>`), so callers could not
+  verify text that appeared after an interaction. The role is non-interactive,
+  so `snapshot --interactive` still omits paragraphs. [#109]
 
 ### Security
 
@@ -444,3 +449,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#105]: https://github.com/mpiton/tauri-pilot/pull/105
 [#106]: https://github.com/mpiton/tauri-pilot/pull/106
 [#107]: https://github.com/mpiton/tauri-pilot/pull/107
+[#109]: https://github.com/mpiton/tauri-pilot/issues/109

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -26,6 +26,7 @@
     H4: "heading",
     H5: "heading",
     H6: "heading",
+    P: "paragraph",
     UL: "list",
     OL: "list",
     LI: "listitem",

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -606,4 +606,32 @@ mod tests {
             "nativeValueSetter must be declared before fill (#85)"
         );
     }
+
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
+    fn bridge_role_map_maps_paragraph_and_keeps_it_noninteractive() {
+        // #109: <p> text (e.g. the default Tauri template greeting rendered in
+        // a <p>) was dropped from snapshots because ROLE_MAP had no P entry, so
+        // getRole returned null and walk() never emitted the node.
+        let js = super::BRIDGE_JS;
+
+        assert!(
+            js.contains("P: \"paragraph\""),
+            "ROLE_MAP must map P to \"paragraph\" so snapshot includes <p> text (#109)"
+        );
+
+        // The paragraph role must stay non-interactive so `snapshot --interactive`
+        // still excludes <p>. Verify INTERACTIVE_ROLES does not list it.
+        let set_start = js
+            .find("INTERACTIVE_ROLES = new Set([")
+            .expect("INTERACTIVE_ROLES set missing");
+        let set_body = &js[set_start..];
+        let set_end = set_body
+            .find("]);")
+            .expect("INTERACTIVE_ROLES set unterminated");
+        assert!(
+            !set_body[..set_end].contains("\"paragraph\""),
+            "paragraph must stay out of INTERACTIVE_ROLES so interactive snapshots still exclude <p> (#109)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #109. `tauri-pilot snapshot` omitted all `<p>` paragraph text, so text rendered after an interaction (e.g. the default Tauri template greeting `<p>{greetMsg}</p>`) was invisible to the accessibility snapshot — callers could click a button but never verify the result.

**Root cause:** `ROLE_MAP` in `bridge.js` had no `P` entry, so `getRole(<p>)` returned `null` and `snapshot()`'s `walk()` never emitted the node. Its text content (a bare text node) is not an element, so it was dropped entirely.

## Changes

- `crates/tauri-plugin-pilot/js/bridge.js`: add `P: "paragraph"` to `ROLE_MAP`.
- `crates/tauri-plugin-pilot/src/lib.rs`: new test `bridge_role_map_maps_paragraph_and_keeps_it_noninteractive` — asserts the mapping exists **and** that `paragraph` stays out of `INTERACTIVE_ROLES` (so `snapshot --interactive` still excludes paragraphs).
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Behavior

- Default `snapshot` now emits `<p>` with role `paragraph` and the text as `name` (existing 50-char `getName` truncation applies, same as other text containers).
- `snapshot --interactive` is unchanged — `<p>` is non-interactive, so it is still skipped while interactive descendants are still walked.

## Testing

- `cargo test --workspace`: 286 passed (incl. the new test).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- Behavioral check via jsdom against the real `bridge.js` + `pilot-test-app` DOM: the 3 page paragraphs **and** an injected greeting `<p>` now appear with role `paragraph`; headings/buttons still present; `--interactive` still yields 0 paragraphs.

---

_Generated by APEX workflow_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `<p>` paragraph text in `tauri-pilot` accessibility snapshots by mapping it to the `paragraph` role. Fixes #109; `snapshot --interactive` still skips paragraphs.

- **Bug Fixes**
  - Map `<p>` to `paragraph` so snapshots include paragraph content.
  - Add test ensuring the mapping exists and `paragraph` stays non-interactive.

<sup>Written for commit 2d68280ad71d791253b3f82f2716a996c35aa5de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/111?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Accessibility snapshots now include paragraph text elements, providing more comprehensive text content coverage in accessibility reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->