### PR TITLE
fix(plugin): restore eval on Linux/Windows via IPC callback (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default Tauri template greeting rendered in a `<p>`), so callers could not
   verify text that appeared after an interaction. The role is non-interactive,
   so `snapshot --interactive` still omits paragraphs. [#109]
+- Restore eval on Linux (`WebKitGTK`) and Windows (`WebView2`). [#108] switched
+  eval delivery to reading the script's return value, which only works on macOS
+  where `WKWebView` resolves a returned Promise; `WebKitGTK` and `WebView2`
+  deliver the unresolved Promise instead, so every eval-based command
+  (`snapshot`, `state`, `click`, …) timed out after 10s. These platforms now
+  deliver eval results through the `__callback` IPC command again, while macOS
+  keeps the native callback path from [#108]. [#110]
 
 ### Security
 
@@ -450,3 +457,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#106]: https://github.com/mpiton/tauri-pilot/pull/106
 [#107]: https://github.com/mpiton/tauri-pilot/pull/107
 [#109]: https://github.com/mpiton/tauri-pilot/issues/109
+[#110]: https://github.com/mpiton/tauri-pilot/issues/110

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -87,16 +87,38 @@ impl EvalEngine {
         }
     }
 
-    /// Wrap a user script so `WebView` eval callbacks receive a tagged payload.
-    /// Returns a small callback payload object for `WebviewWindow::eval_with_callback`.
-    /// This avoids routing eval results through JS-to-Tauri IPC, which can fail
-    /// to dispatch from scripts injected with `webview.eval` on newer
-    /// Tauri/wry/WebKit combinations.
+    /// Wrap a user script in the ADR-001 callback pattern for Linux/Windows.
+    ///
+    /// `WebKitGTK` and `WebView2` do not resolve a Promise returned from a webview
+    /// eval — the eval callback fires with the unresolved Promise object, so a
+    /// return-value delivery never lands and the eval times out (#110). Instead
+    /// the script `await`s the result and delivers it back through the
+    /// `__callback` IPC command, which dispatches fine from eval-injected code.
     ///
     /// Normalizes `undefined` results to `null` (string `"null"`) so Tauri does
     /// not drop the `result` field — otherwise a void expression (e.g.,
     /// `element.click()`) would cause the handler to log a bogus "neither
     /// result nor error" warning (#48).
+    #[cfg(not(target_os = "macos"))]
+    #[must_use]
+    pub fn wrap_script(id: u64, script: &str) -> String {
+        format!(
+            "(async()=>{{try{{let __r=await({script});\
+             await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
+             {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}});\
+             }}catch(__e){{await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
+             {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
+        )
+    }
+
+    /// Wrap a user script so the native macOS `WKWebView` completion handler
+    /// receives a tagged payload as the eval return value (#108).
+    ///
+    /// macOS reads the script's return value via `evaluateJavaScript`, so the
+    /// wrapper returns `{id, result}` directly rather than routing through IPC.
+    /// `undefined` is normalized to the string `"null"` for the same reason as
+    /// the non-macOS variant (#48).
+    #[cfg(target_os = "macos")]
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
@@ -217,16 +239,39 @@ mod tests {
         assert!(script.contains("42"));
         assert!(script.contains("document.title"));
         assert!(script.contains("await("));
-        assert!(script.contains("return {id:42,result:"));
         assert!(script.contains("try"));
         assert!(script.contains("catch"));
     }
 
+    // #110: Linux (WebKitGTK) and Windows (WebView2) do not resolve a Promise
+    // returned from a webview eval — the eval callback fires with the unresolved
+    // Promise, so a return-value delivery never lands and every eval times out.
+    // The wrapped script must therefore `await` the result and deliver it back
+    // through the `__callback` IPC command, which works from eval-injected code.
+    #[cfg(not(target_os = "macos"))]
     #[test]
-    fn test_wrap_script_does_not_depend_on_ipc_callback_bridge() {
-        let script = EvalEngine::wrap_script(1, "document.title");
-        assert!(!script.contains("plugin:pilot|callback"));
-        assert!(!script.contains("plugin:pilot|__callback"));
+    fn test_wrap_script_delivers_via_ipc_callback_on_non_macos() {
+        let script = EvalEngine::wrap_script(7, "document.title");
+        assert!(
+            script.contains("__TAURI_INTERNALS__.invoke('plugin:pilot|__callback'"),
+            "non-macOS wrap must deliver results via the __callback IPC command (#110); got: {script}"
+        );
+        assert!(script.contains("{id:7,result:"));
+        assert!(script.contains("{id:7,error:"));
+    }
+
+    // macOS keeps the #108 native WKWebView completion-handler path, which reads
+    // the script's return value, so the wrapper returns the tagged payload and
+    // must not depend on the IPC bridge.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_wrap_script_returns_payload_for_native_callback_on_macos() {
+        let script = EvalEngine::wrap_script(7, "document.title");
+        assert!(
+            script.contains("return {id:7,result:"),
+            "macOS wrap must return the tagged payload for the native callback; got: {script}"
+        );
+        assert!(!script.contains("__callback"));
         assert!(!script.contains("__TAURI_INTERNALS__"));
     }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -138,17 +138,19 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>, engine: EvalEngine
                 .cloned()
                 .ok_or_else(|| "No webview available".to_owned())?
         };
-        let engine = engine.clone();
         #[cfg(target_os = "macos")]
         {
-            eval_with_webkit_callback(&target, script, engine)
+            eval_with_webkit_callback(&target, script, engine.clone())
         }
         #[cfg(not(target_os = "macos"))]
-        target
-            .eval_with_callback(&script, move |payload| {
-                handle_eval_callback_payload(&engine, &payload);
-            })
-            .map_err(|e| e.to_string())
+        {
+            // Linux (WebKitGTK) and Windows (WebView2) do not resolve a Promise
+            // returned from eval, so results come back via the `__callback` IPC
+            // command (see EvalEngine::wrap_script). This eval is fire-and-forget;
+            // the IPC handler resolves the pending request, not this closure.
+            let _ = &engine;
+            target.eval(&script).map_err(|e| e.to_string())
+        }
     })
 }
 
@@ -244,7 +246,7 @@ fn resolve_native_eval_error(engine: &EvalEngine, id: Option<u64>, message: &str
     }
 }
 
-#[cfg(all(any(unix, windows), debug_assertions))]
+#[cfg(all(target_os = "macos", debug_assertions))]
 fn handle_eval_callback_payload(engine: &EvalEngine, payload: &str) {
     let parsed = serde_json::from_str::<serde_json::Value>(payload)
         .ok()


### PR DESCRIPTION
## Summary

Fixes #110. After #108, every eval-based command (`snapshot`, `state`, `click`, `fill`, `eval`, …) timed out after 10s on **Linux (WebKitGTK)** and **Windows (WebView2)**. Only `ping`/`windows` (Rust-side, no eval) worked.

**Root cause:** #108 switched eval result delivery to reading the script's return value. The wrapped script is an async IIFE, so it returns a `Promise`. Only macOS `WKWebView` resolves a returned Promise before firing the completion handler; `WebKitGTK` (`run_javascript`) and `WebView2` (`ExecuteScriptAsync`) hand back the **unresolved** Promise, so the callback payload never contains `{id, result}` and the pending `oneshot` never resolves.

## Fix

Platform-split the delivery, keeping #108's macOS path intact:

- **non-macOS** (`eval.rs`): `wrap_script` `await`s the result and delivers it via `window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback', {id, result})` — the pre-#108 transport, which dispatches fine from eval-injected code. `make_eval_fn` uses fire-and-forget `target.eval(&script)`.
- **macOS** (`eval.rs`/`lib.rs`): unchanged — native `WKWebView` completion handler reading the return value. `handle_eval_callback_payload` is now `#[cfg(target_os = "macos")]` (its only caller).

The `__callback`/`callback` IPC commands and their `allow-eval-callbacks` permission already exist, so no capability changes are needed.

## Testing

- Empirically verified **live on Linux** against `pilot-test-app` (Tauri 2.11.2, wry 0.55.1): `state`, `eval 1+1` → `2`, top-level `await`, async `Promise`, and `snapshot` all return correctly. Before the fix every one timed out.
- `cargo test --workspace`: 286 passed. New cfg-split unit tests assert the non-macOS IPC delivery and the macOS native-return form.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --all --check`: clean.

## Notes / unverified

- macOS and Windows were **not** runtime-tested (no access). macOS keeps #108's path untouched (no behavior change). Windows uses the restored pre-#108 IPC path, which worked before #108.
- Research note: per vendor docs, none of the three webviews await a returned Promise on the standard eval API (WebView2/WebKitGTK confirmed; WKWebView via `evaluateJavaScript` per Apple docs needs `callAsyncJavaScript`). #108's macOS path is left as-is here; if it proves unreliable, a follow-up could move macOS to the same IPC delivery.

---

_Generated by APEX workflow_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores eval-based commands on Linux (`WebKitGTK`) and Windows (`WebView2`) by sending results via the `__callback` IPC, fixing the 10s timeouts introduced in #108. macOS (`WKWebView`) keeps the native return-value path.

- **Bug Fixes**
  - Split eval delivery by platform: non-macOS wraps the script, awaits the result, and calls `window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback', {id, result})`; macOS returns `{id, result}` to the native callback.
  - Non-macOS eval is fire-and-forget; the IPC handler resolves pending requests. `handle_eval_callback_payload` is macOS-only.
  - Added cfg-split tests and changelog entry; no capability changes (reuses `__callback`/`callback` and `allow-eval-callbacks`).

<sup>Written for commit 01a892fcc910a4bfc9bb56ae10f80d3c45e7f113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/112?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Restored JavaScript `eval` functionality on Linux (WebKitGTK) and Windows (WebView2) platforms. The fix ensures proper script evaluation, promise resolution, and error handling through platform-specific result delivery mechanisms. Each platform uses optimized delivery paths while maintaining full backward compatibility with macOS implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->