### PR TITLE
fix(plugin): match select by label and error on no-match (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`snapshot`, `state`, `click`, …) timed out after 10s. These platforms now
   deliver eval results through the `__callback` IPC command again, while macOS
   keeps the native callback path from [#108]. [#110]
+- Make `select` match by visible option label as well as `value`, and error
+  instead of silently reporting `ok` when no option matches. Setting
+  `HTMLSelectElement.value` to an unmatched string leaves `value=""` /
+  `selectedIndex=-1` per the DOM spec, so passing a label (which snapshots
+  surface) or a typo previously cleared the selection while the command still
+  exited `0`. A successful `select` now guarantees an option was selected.
+  [#113]
 
 ### Security
 
@@ -458,3 +465,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#107]: https://github.com/mpiton/tauri-pilot/pull/107
 [#109]: https://github.com/mpiton/tauri-pilot/issues/109
 [#110]: https://github.com/mpiton/tauri-pilot/issues/110
+[#113]: https://github.com/mpiton/tauri-pilot/issues/113

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -563,11 +563,25 @@
       const reported = (tag || String(el)).slice(0, 64);
       throw new Error("select requires a <select> element, got: " + reported);
     }
+    // Resolve the target option before mutating anything. Setting
+    // `HTMLSelectElement.value` to a string that matches no option `value`
+    // silently yields `value=""` / `selectedIndex=-1` per the DOM spec, so
+    // "set then trust" reports success on a no-op (#113). Match the option
+    // first — by `value`, then by visible label — and error if none matches so
+    // a reported `ok` always means an option was actually selected.
+    const wanted = String(params.value);
+    const options = Array.from(el.options || []);
+    const matched =
+      options.find((o) => o.value === wanted) ||
+      options.find((o) => (o.text || "").trim() === wanted.trim());
+    if (!matched) {
+      throw new Error("select: no option matches " + JSON.stringify(params.value));
+    }
     const setter = nativeValueSetter(el);
     if (setter) {
-      setter.call(el, params.value);
+      setter.call(el, matched.value);
     } else {
-      el.value = params.value;
+      el.value = matched.value;
     }
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };

--- a/crates/tauri-plugin-pilot/js/bridge.select.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.select.test.mjs
@@ -1,0 +1,149 @@
+// Dependency-free behavioural tests for the bridge `select` action (#113).
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// *real* file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation. The mock `<select>` reproduces the DOM spec
+// quirk at the heart of #113: assigning `HTMLSelectElement.value` a string that
+// matches no `<option>` silently yields `value === ""` / `selectedIndex === -1`.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.select.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+// Real console methods, captured once so each bridge load re-wraps the
+// originals instead of stacking wrappers across tests.
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// Build a fake <select> whose prototype carries a `value` accessor matching the
+// HTMLSelectElement spec: setting `.value` selects the option whose value
+// matches, otherwise clears the selection. `nativeValueSetter` in the bridge
+// reads the setter off this prototype, so the accessor must live on the proto.
+function makeSelect(options) {
+  const proto = {
+    get value() {
+      const sel = this._options.find((o) => o.selected);
+      return sel ? sel.value : "";
+    },
+    set value(v) {
+      const target = String(v);
+      let hit = false;
+      for (const o of this._options) {
+        if (!hit && o.value === target) {
+          o.selected = true;
+          hit = true;
+        } else {
+          o.selected = false;
+        }
+      }
+    },
+    get selectedIndex() {
+      return this._options.findIndex((o) => o.selected);
+    },
+    dispatchEvent(event) {
+      this.events.push(event.type);
+      return true;
+    },
+    focus() {},
+  };
+  const el = Object.create(proto);
+  el.tagName = "SELECT";
+  el._options = options.map((o) => ({ value: o.value, text: o.text, selected: false }));
+  el.events = [];
+  Object.defineProperty(el, "options", { get() { return this._options; } });
+  return el;
+}
+
+// Fresh globals + a fresh bridge instance for each test (the IIFE early-returns
+// if `window.__PILOT__` already exists, so `window` must be new every time).
+function loadBridge({ queryResult } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    querySelector(selector) {
+      if (queryResult === undefined) {
+        throw new Error("unexpected querySelector(" + selector + ")");
+      }
+      return queryResult;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+
+  // Indirect eval runs in global scope; the IIFE then resolves bare `window`,
+  // `document`, etc. against the globals set above.
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("select by option value selects the matching option", () => {
+  const el = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+    { value: "editor", text: "Editor" },
+  ]);
+  const pilot = loadBridge({ queryResult: el });
+
+  const result = pilot.select({ selector: "select[name=role]", value: "admin" });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(el.value, "admin");
+  assert.equal(el.selectedIndex, 1);
+  assert.ok(el.events.includes("change"), "should dispatch a change event");
+});
+
+test("select by visible label selects the matching option", () => {
+  const el = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+    { value: "editor", text: "Editor" },
+  ]);
+  const pilot = loadBridge({ queryResult: el });
+
+  const result = pilot.select({ selector: "select[name=role]", value: "Editor" });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(el.value, "editor");
+  assert.equal(el.selectedIndex, 2);
+  assert.ok(el.events.includes("change"), "should dispatch a change event");
+});
+
+test("select throws when no option matches value or label", () => {
+  const el = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+    { value: "editor", text: "Editor" },
+  ]);
+  const pilot = loadBridge({ queryResult: el });
+
+  assert.throws(
+    () => pilot.select({ selector: "select[name=role]", value: "zzz" }),
+    /no option/i,
+  );
+  // The selection must be left untouched, never silently cleared to -1.
+  assert.equal(el.selectedIndex, -1);
+});
+
+test("select still rejects a non-<select> target", () => {
+  const notSelect = { tagName: "INPUT", dispatchEvent() { return true; }, focus() {} };
+  const pilot = loadBridge({ queryResult: notSelect });
+
+  assert.throws(
+    () => pilot.select({ selector: "input[name=role]", value: "admin" }),
+    /<select>/i,
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #113. `tauri-pilot select <selector> <value>` matched **strictly by option `value`** and, on no match, silently set the `<select>` to an invalid state (`value=""`, `selectedIndex=-1`) while still reporting `✓ ok` / exit `0`. Because snapshots surface option **labels**, a user naturally passes a label, the command claims success, and the form is left with no option selected — a silent-corruption footgun.

## Change

`crates/tauri-plugin-pilot/js/bridge.js` — `select()` now resolves the target option **before** mutating:

1. match by option `value` (existing behaviour, preserved),
2. fall back to matching the visible **label/text**,
3. **throw** if no option matches.

A reported `ok` now guarantees an option was actually selected. The thrown error propagates through the ADR-001 eval `catch` path (`eval.rs`) to `EvalError::JavaScript` → **non-zero CLI exit**, consistent with the pre-existing non-`<select>` guard.

## Tests

Adds `crates/tauri-plugin-pilot/js/bridge.select.test.mjs` — a **dependency-free** `node --test` suite that loads the *real* bridge.js into a minimal DOM mock reproducing the DOM spec quirk:

- ✅ select by `value` selects the option (no regression)
- ✅ select by visible **label** selects the option (new)
- ✅ select with **no match throws** and leaves `selectedIndex = -1` (no silent ok)
- ✅ non-`<select>` target still rejected (regression guard)

```
node --test crates/tauri-plugin-pilot/js/bridge.select.test.mjs   # 4/4 pass
```

Verified RED→GREEN. Full workspace: `cargo test` 286 pass · `cargo clippy -D warnings` clean · `cargo fmt --check` clean · `node --check bridge.js` OK.

## Notes

- Value-match takes precedence over label-match (per the issue's suggested fix).
- Placeholder options with `value=""` remain selectable; React compatibility unchanged (native setter + `change` event).
- The repo has no JS test runner in CI (CI is `*.rs`-path-filtered, cargo-only), so this suite is a local/manual artifact like prior bridge validation. Wiring JS tests into CI is out of scope for #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #113. The `select` action now matches by option value, falls back to label text, and throws when nothing matches, preventing silent clears and ensuring failures exit non-zero.

- **Bug Fixes**
  - Resolve the target option before mutating: try `value` first, then label text; throw if no match.
  - A successful call now guarantees an option is selected; non-<select> guard and change event behavior are unchanged.

<sup>Written for commit 3bda78820ee8d712828e9b2cdc53c4768e113956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/116?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The select command now matches dropdown options by visible label text in addition to their value attribute, providing more flexible option selection.
  * Error handling has been enhanced: the select command now returns an error when no matching option is found, preventing silent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->