### PR TITLE
fix(plugin): fire Control+digit X11 global shortcuts via raw keycode injection (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surface) or a typo previously cleared the selection while the command still
   exited `0`. A successful `select` now guarantees an option was selected.
   [#113]
+- Fire `Control`+digit global shortcuts via `press` on X11 layouts where the
+  digit row is shifted (e.g. French AZERTY). `press "Control+1"` now triggers a
+  registered `Control+Digit1` accelerator, consistent with `Control+Shift+P`.
+  `enigo` resolves a `Key::Unicode` digit only at shift-level 0, so on AZERTY
+  (where `1` is `Shift`+`&`) it remapped the digit onto a spare keycode that no
+  physical-key `XGrabKey` grab matched, while letters (always level 0) worked —
+  the asymmetry #75 could not explain. Main-row digits are now injected as raw
+  physical keycodes, matching the keycode `global-hotkey` grabs and aligning
+  with Playwright's physical-`code` semantics. [#114]
 
 ### Security
 
@@ -466,3 +475,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#109]: https://github.com/mpiton/tauri-pilot/issues/109
 [#110]: https://github.com/mpiton/tauri-pilot/issues/110
 [#113]: https://github.com/mpiton/tauri-pilot/issues/113
+[#114]: https://github.com/mpiton/tauri-pilot/issues/114

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `enigo` resolves a `Key::Unicode` digit only at shift-level 0, so on AZERTY
   (where `1` is `Shift`+`&`) it remapped the digit onto a spare keycode that no
   physical-key `XGrabKey` grab matched, while letters (always level 0) worked —
-  the asymmetry #75 could not explain. Main-row digits are now injected as raw
-  physical keycodes, matching the keycode `global-hotkey` grabs and aligning
-  with Playwright's physical-`code` semantics. [#114]
+  the asymmetry #75 could not explain. A digit that is part of a modified combo
+  is now injected as its raw physical keycode, matching the keycode
+  `global-hotkey` grabs. A bare `press "1"` keeps the layout-aware path, so it
+  still types the layout's digit rather than the unshifted physical key. [#114]
 
 ### Security
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -352,9 +352,11 @@ async fn handle_diff(
 /// reach Tauri accelerators (#45). Native injection via `enigo` produces real
 /// keyboard events that DOM listeners and Tauri accelerators see as trusted.
 ///
-/// Note: on X11, `enigo`'s `XTestFakeKeyEvent` backend does not reliably
-/// drive `XGrabKey`-based passive grabs, so `tauri-plugin-global-shortcut`
-/// handlers may not fire (#75). See the `key` module-level docs for details.
+/// Note: on X11, global shortcuts (`tauri-plugin-global-shortcut` / `XGrabKey`
+/// passive grabs) are keyed on physical keycodes. Letter and digit combos fire
+/// (#114), but characters that sit above shift-level 0 on an exotic layout may
+/// still be remapped by `enigo` and miss the grab. See the `key` module-level
+/// docs (#45, #75, #114).
 #[cfg(feature = "press")]
 async fn handle_press(
     params: Option<&serde_json::Value>,

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -29,10 +29,13 @@
 //! `Control+Shift+P` fires while `Control+1` did not (issue #114).
 //!
 //! To keep digit shortcuts working regardless of layout, [`simulate_press`]
-//! injects main-row digits as raw physical keycodes (see [`tap_main_key`])
-//! rather than as Unicode characters. Other characters that live above
-//! shift-level 0 on an exotic layout may still be remapped and miss a
-//! physical-key grab.
+//! injects a digit as a raw physical keycode (see [`tap_main_key`]) when it is
+//! part of a modified combo such as `Control+1` — the case that targets a
+//! physical-key grab. A bare `press "1"` keeps enigo's layout-aware
+//! `Key::Unicode` path, so it still types the layout's digit rather than the
+//! unshifted physical key (`&` on AZERTY); reach for `fill` to set input text.
+//! Other characters that live above shift-level 0 on an exotic layout may still
+//! be remapped and miss a physical-key grab.
 //!
 //! See issues #45, #75 and #114.
 use enigo::{Direction, Enigo, Key, Keyboard, Settings};
@@ -213,24 +216,48 @@ fn linux_digit_keycode(ch: char) -> Option<u16> {
     }
 }
 
-/// Tap (press + release) the combo's main key.
+/// The raw physical keycode to inject for the combo's main key, or `None` to
+/// use enigo's layout-aware [`Key`] path.
 ///
-/// On Linux, main-row digits are injected as raw physical keycodes (see
-/// [`linux_digit_keycode`]) so they reach the exact physical key that
+/// Returns a keycode only for a digit that is part of a *modified* combo (e.g.
+/// `Control+1`): that is the case targeting a physical-key grab, where matching
+/// `global-hotkey`'s keycode matters more than the character produced. A bare
+/// digit press returns `None` so `press "1"` keeps typing the layout's digit
+/// (`1` on AZERTY) instead of the unshifted physical key (`&`).
+#[cfg(target_os = "linux")]
+fn physical_digit_keycode(key: Key, has_modifiers: bool) -> Option<u16> {
+    match key {
+        Key::Unicode(ch) if has_modifiers => linux_digit_keycode(ch),
+        _ => None,
+    }
+}
+
+/// Tap (press + release) the combo's main key, given whether any modifier is
+/// currently held.
+///
+/// On Linux a modified digit combo is injected as a raw physical keycode (see
+/// [`physical_digit_keycode`]) so it reaches the exact physical key that
 /// `global-hotkey` grabs. enigo's layout-aware [`Key::Unicode`] path resolves a
 /// digit's keysym only at shift-level 0; on layouts where the digit is shifted
 /// it fails to find it on the physical key and remaps it onto a spare keycode,
-/// which no physical-key grab can match. Every other key — and every key on
-/// macOS/Windows — goes through enigo's `Key` path unchanged.
-fn tap_main_key(enigo: &mut Enigo, key: Key) -> Result<(), KeyError> {
-    #[cfg(target_os = "linux")]
-    if let Key::Unicode(ch) = key
-        && let Some(keycode) = linux_digit_keycode(ch)
-    {
+/// which no physical-key grab can match. Bare digits and every other key — and
+/// every key on macOS/Windows — go through enigo's `Key` path unchanged.
+#[cfg(target_os = "linux")]
+fn tap_main_key(enigo: &mut Enigo, key: Key, has_modifiers: bool) -> Result<(), KeyError> {
+    if let Some(keycode) = physical_digit_keycode(key, has_modifiers) {
         return enigo
             .raw(keycode, Direction::Click)
             .map_err(|e| KeyError::EnigoInput(e.to_string()));
     }
+    enigo
+        .key(key, Direction::Click)
+        .map_err(|e| KeyError::EnigoInput(e.to_string()))
+}
+
+/// macOS and Windows have no layout-dependent digit-remapping problem, so every
+/// key goes through enigo's layout-aware [`Key`] path.
+#[cfg(not(target_os = "linux"))]
+fn tap_main_key(enigo: &mut Enigo, key: Key, _has_modifiers: bool) -> Result<(), KeyError> {
     enigo
         .key(key, Direction::Click)
         .map_err(|e| KeyError::EnigoInput(e.to_string()))
@@ -279,7 +306,7 @@ pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
                 .map_err(|e| KeyError::EnigoInput(e.to_string()))?;
             pressed.push(*m);
         }
-        tap_main_key(&mut enigo, parsed.key)
+        tap_main_key(&mut enigo, parsed.key, !parsed.modifiers.is_empty())
     })();
 
     // Always release the modifiers we actually pressed, in reverse order.
@@ -467,5 +494,33 @@ mod tests {
         for ch in ['a', 'A', 'p', '+', '-', ' ', 'é'] {
             assert_eq!(linux_digit_keycode(ch), None, "char: {ch}");
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_physical_digit_keycode_used_for_modified_digit_combos() {
+        // A modified digit combo (e.g. Control+1) targets a physical-key grab,
+        // so it is injected as the raw physical keycode global-hotkey grabbed.
+        assert_eq!(physical_digit_keycode(Key::Unicode('1'), true), Some(10));
+        assert_eq!(physical_digit_keycode(Key::Unicode('0'), true), Some(19));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_physical_digit_keycode_skips_bare_digit_for_character_entry() {
+        // A bare `press "1"` keeps the layout-aware Key::Unicode path so it
+        // types the layout's digit (`1` on AZERTY) rather than the unshifted
+        // physical key (`&`). Only modified combos divert to a raw keycode.
+        assert_eq!(physical_digit_keycode(Key::Unicode('1'), false), None);
+        assert_eq!(physical_digit_keycode(Key::Unicode('9'), false), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_physical_digit_keycode_skips_non_digit_keys() {
+        // Letters and named keys always use enigo's layout-aware path, even in
+        // a modified combo — they resolve correctly at shift-level 0.
+        assert_eq!(physical_digit_keycode(Key::Unicode('a'), true), None);
+        assert_eq!(physical_digit_keycode(Key::Return, true), None);
     }
 }

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -11,20 +11,30 @@
 //!       → Tauri accelerator handlers
 //! ```
 //!
-//! # Platform caveats
+//! # Platform caveats (X11 global shortcuts)
 //!
-//! On X11, [`simulate_press`] cannot reliably drive
-//! `tauri-plugin-global-shortcut` handlers. The upstream `global-hotkey` crate
-//! uses `XGrabKey` passive grabs on its Linux/X11 backend (Wayland is
-//! unsupported on Linux), and those grabs match against the X server's logical
-//! modifier state. `enigo`'s `XTestFakeKeyEvent` backend injects each modifier
-//! and keycode as a separate fake-input call, and the modifier state observed
-//! at the moment the main keycode is processed does not always match the
-//! grab's exact-modifier-mask, so the grab may not activate. DOM listeners
-//! and Tauri accelerators are unaffected and continue to receive
-//! `isTrusted=true` events.
+//! `tauri-plugin-global-shortcut` registers its accelerators through the
+//! `global-hotkey` crate, which on X11 uses `XGrabKey` passive grabs keyed on a
+//! *physical* keycode (e.g. `Code::Digit1` → keycode 10, derived from the evdev
+//! scancode and independent of the active layout).
 //!
-//! See issues #45 and #75.
+//! `enigo` injects a [`Key::Unicode`] character by looking its keysym up in the
+//! keymap, but only at shift-level 0. On a layout where the wanted character
+//! sits at a higher level — most importantly the digit row on AZERTY and
+//! similar layouts, where `1` is `Shift`+`&` — enigo cannot find it on the
+//! physical key and instead remaps it onto a spare keycode. That spare keycode
+//! never matches a physical-key grab, so `Control+1`-style global shortcuts
+//! silently fail to fire even though the same key still reaches DOM listeners
+//! as a trusted event. Letters live at level 0 on these layouts, which is why
+//! `Control+Shift+P` fires while `Control+1` did not (issue #114).
+//!
+//! To keep digit shortcuts working regardless of layout, [`simulate_press`]
+//! injects main-row digits as raw physical keycodes (see [`tap_main_key`])
+//! rather than as Unicode characters. Other characters that live above
+//! shift-level 0 on an exotic layout may still be remapped and miss a
+//! physical-key grab.
+//!
+//! See issues #45, #75 and #114.
 use enigo::{Direction, Enigo, Key, Keyboard, Settings};
 use std::sync::Mutex;
 use thiserror::Error;
@@ -187,6 +197,45 @@ fn single_char(token: &str) -> Option<char> {
     }
 }
 
+/// Physical X11/xkb keycodes for the main number-row digits.
+///
+/// These are layout-independent: X11 derives them from the Linux evdev
+/// scancodes (`KEY_1`..`KEY_0`) offset by 8, so `1` is always keycode 10 and
+/// `0` is keycode 19 — whether the active layout puts the digit on an unshifted
+/// (US QWERTY) or a shifted (e.g. French AZERTY) level. They are exactly the
+/// keycodes `global-hotkey` grabs for `Code::Digit1`..`Code::Digit0`.
+#[cfg(target_os = "linux")]
+fn linux_digit_keycode(ch: char) -> Option<u16> {
+    match ch {
+        '1'..='9' => Some(10 + (ch as u16 - '1' as u16)),
+        '0' => Some(19),
+        _ => None,
+    }
+}
+
+/// Tap (press + release) the combo's main key.
+///
+/// On Linux, main-row digits are injected as raw physical keycodes (see
+/// [`linux_digit_keycode`]) so they reach the exact physical key that
+/// `global-hotkey` grabs. enigo's layout-aware [`Key::Unicode`] path resolves a
+/// digit's keysym only at shift-level 0; on layouts where the digit is shifted
+/// it fails to find it on the physical key and remaps it onto a spare keycode,
+/// which no physical-key grab can match. Every other key — and every key on
+/// macOS/Windows — goes through enigo's `Key` path unchanged.
+fn tap_main_key(enigo: &mut Enigo, key: Key) -> Result<(), KeyError> {
+    #[cfg(target_os = "linux")]
+    if let Key::Unicode(ch) = key
+        && let Some(keycode) = linux_digit_keycode(ch)
+    {
+        return enigo
+            .raw(keycode, Direction::Click)
+            .map_err(|e| KeyError::EnigoInput(e.to_string()));
+    }
+    enigo
+        .key(key, Direction::Click)
+        .map_err(|e| KeyError::EnigoInput(e.to_string()))
+}
+
 /// Press `combo` at the OS level. Modifiers are pressed in order, then the
 /// main key is tapped (press+release), then modifiers are released in reverse
 /// order — the same pattern a human or Playwright would produce.
@@ -230,9 +279,7 @@ pub fn simulate_press(combo: &str) -> Result<(), KeyError> {
                 .map_err(|e| KeyError::EnigoInput(e.to_string()))?;
             pressed.push(*m);
         }
-        enigo
-            .key(parsed.key, Direction::Click)
-            .map_err(|e| KeyError::EnigoInput(e.to_string()))
+        tap_main_key(&mut enigo, parsed.key)
     })();
 
     // Always release the modifiers we actually pressed, in reverse order.
@@ -396,5 +443,29 @@ mod tests {
             parse_combo("Ctrl+NotAKey"),
             Err(KeyError::UnknownKey(_))
         ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_digit_keycode_maps_digits_to_physical_x11_keycodes() {
+        // evdev KEY_1..KEY_9 are X keycodes 10..18 and KEY_0 is 19 — the exact
+        // keycodes `global-hotkey` grabs for Code::Digit1..Digit9 / Digit0.
+        // Injecting these as raw keycodes is what fixes Control+digit global
+        // shortcuts on layouts (e.g. AZERTY) where the digit is shifted (#114).
+        assert_eq!(linux_digit_keycode('1'), Some(10));
+        assert_eq!(linux_digit_keycode('2'), Some(11));
+        assert_eq!(linux_digit_keycode('5'), Some(14));
+        assert_eq!(linux_digit_keycode('9'), Some(18));
+        assert_eq!(linux_digit_keycode('0'), Some(19));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_digit_keycode_returns_none_for_non_digits() {
+        // Letters and symbols keep enigo's layout-aware Key::Unicode path;
+        // only main-row digits are diverted to a raw physical keycode.
+        for ch in ['a', 'A', 'p', '+', '-', ' ', 'é'] {
+            assert_eq!(linux_digit_keycode(ch), None, "char: {ch}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #114. On X11, `tauri-pilot press "Control+1"` did **not** trigger a registered `Control+Digit1` global shortcut, while `Control+Shift+P` did — the asymmetry that #75 (closed as a blanket "X11 limitation") could not explain.

## Root cause

`tauri-plugin-global-shortcut` → `global-hotkey` grabs the **physical** keycode on X11: `Code::Digit1` → `XK_1` → `keysym_to_keycode` (scans **all** columns) → physical keycode `10` (evdev-derived, layout independent).

`enigo` injects a `Key::Unicode` digit by scanning the keymap **only at shift-level 0** (a documented `// TODO` in its source). On layouts where the digit row is shifted — e.g. **French AZERTY**, where `1` is `Shift`+`&` — `XK_1` is at column 1, so enigo cannot find it on the physical key and **remaps it onto a spare keycode**. That spare keycode never matches the physical-key `XGrabKey` grab, so the shortcut silently never fires. Letters live at level 0 on AZERTY too, which is why `Control+Shift+P` worked.

This also matched the issue's "control" observation: plain `press "1"` reached the DOM as a trusted `data-key="1"` (via the remapped keysym) while the *grab* on the physical keycode saw nothing.

## Fix

Inject main-row digits (`0`–`9`) as **raw physical keycodes** (`10`–`19`) via `enigo.raw()` on Linux, instead of `Key::Unicode`. This hits the exact physical key `global-hotkey` grabbed, regardless of layout, and aligns with Playwright's physical-`code` keyboard semantics. Every other key — and every key on macOS/Windows — keeps enigo's layout-aware `Key` path.

A documented residual caveat: other characters that sit above shift-level 0 on an exotic layout (e.g. shifted symbols) may still be remapped by enigo and miss a physical-key grab.

## Changes

- `key.rs`: add `linux_digit_keycode()` (digit → physical X keycode) and `tap_main_key()` (dispatch digits to `raw()`, everything else to `key()`); use it in `simulate_press`. Rewrite the platform-caveat module docs with the correct, refined diagnosis.
- `handler.rs`: refresh the now-inaccurate `#75` "doesn't fire" note.
- `CHANGELOG.md`: `[Unreleased]` → Fixed entry.

## Testing

- `cargo test --workspace` → 288 passed (incl. new `linux_digit_keycode` mapping tests).
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.

The live X11/AZERTY grab behaviour cannot be exercised in CI (needs a real X server + layout + a registered grab), so coverage is the keycode-mapping unit tests plus the verified keycode alignment against `global-hotkey 0.7` and `enigo 0.6.1` source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Control+digit global shortcuts on X11 by injecting digits as raw physical keycodes only for modified combos, so accelerators fire across layouts (e.g. AZERTY), while bare digit presses remain layout-aware; macOS/Windows unchanged. Fixes #114.

- **Bug Fixes**
  - On Linux/X11, `press "Control+<digit>"` now fires `Control+Digit*` by sending digits 0–9 via `enigo.raw()` as physical keycodes 10–19, matching `global-hotkey`’s `XGrabKey` grabs; the raw path runs only when modifiers are present, while a bare `press "1"` uses `enigo`’s `Key::Unicode`.
  - Documented the remaining caveat for symbols above shift-level 0 and added unit tests for the digit→keycode mapping and the modifier gate.

<sup>Written for commit 44f6f39d620135c9dbf0466555524aa2ebd98a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/117?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Control+digit shortcuts on X11 now reliably trigger the intended accelerator on non-standard layouts by sending the physical digit key, while plain digit typing behavior is preserved.

* **Documentation**
  * Changelog and docs updated to clarify X11/Linux global-shortcut behavior and how modified digit combos are handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->