### PR TITLE
fix(plugin): bind Windows named pipe inside async task (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now injected as its raw physical keycode, matching the keycode
   `global-hotkey` grabs. A bare `press "1"` keeps the layout-aware path, so it
   still types the layout's digit rather than the unshifted physical key. [#114]
+- Fix a startup panic on Windows ("there is no reactor running, must be called
+  from the context of a Tokio 1.x runtime") that aborted the host app before its
+  window opened. tokio's `NamedPipeServer` registers with the reactor the moment
+  it is created, but the plugin bound the pipe in its synchronous `setup` hook —
+  outside any tokio runtime. The Windows pipe is now bound inside the spawned
+  server task, which runs on the runtime. The Unix socket path is unchanged: it
+  binds with the std `UnixListener`, which needs no runtime. [#115]
 
 ### Security
 
@@ -477,3 +484,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#110]: https://github.com/mpiton/tauri-pilot/issues/110
 [#113]: https://github.com/mpiton/tauri-pilot/issues/113
 [#114]: https://github.com/mpiton/tauri-pilot/issues/114
+[#115]: https://github.com/mpiton/tauri-pilot/issues/115

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -68,16 +68,37 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 let list_fn = make_list_fn(app);
                 let focus_fn = make_focus_fn(app);
 
-                let (listener, guard) = server::bind(&socket_path).map_err(|e| {
-                    tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
-                    e
-                })?;
-
                 let recorder = Recorder::new();
 
+                // Unix binds with the std (sync) `UnixListener`, which needs no
+                // tokio runtime, so binding stays here in `setup` where a failure
+                // surfaces as a hard plugin error. `run` only upgrades the
+                // listener to tokio once it is already on the runtime.
+                #[cfg(unix)]
+                {
+                    let (listener, guard) = server::bind(&socket_path).map_err(|e| {
+                        tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
+                        e
+                    })?;
+                    tauri::async_runtime::spawn(server::run(
+                        listener,
+                        guard,
+                        engine,
+                        Some(eval_fn),
+                        Some(list_fn),
+                        Some(focus_fn),
+                        recorder,
+                    ));
+                }
+
+                // Windows' tokio `NamedPipeServer` registers with the reactor the
+                // instant it is created, so the bind must run inside the spawned
+                // task (which lives on the tokio runtime). Binding here in `setup`
+                // panics with "there is no reactor running, must be called from
+                // the context of a Tokio 1.x runtime" (#115).
+                #[cfg(windows)]
                 tauri::async_runtime::spawn(server::run(
-                    listener,
-                    guard,
+                    socket_path,
                     engine,
                     Some(eval_fn),
                     Some(list_fn),

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -123,5 +123,7 @@ pub mod windows;
 
 #[cfg(unix)]
 pub use unix::{bind, run, socket_path};
+// Windows binds inside `run` (#115), so `bind` is internal to the windows module
+// and is not re-exported — only `run` and `socket_path` are used by plugin setup.
 #[cfg(windows)]
-pub use windows::{bind, run, socket_path};
+pub use windows::{run, socket_path};

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -421,15 +421,29 @@ pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error>
     Ok((server, guard))
 }
 
+/// Bind the named pipe, then run the accept loop.
+///
+/// Unlike the Unix server, the bind happens here — inside the spawned task —
+/// rather than in the plugin `setup`. tokio's `NamedPipeServer` registers with
+/// the reactor the moment it is created, so creating it outside a running tokio
+/// runtime panics with "there is no reactor running, must be called from the
+/// context of a Tokio 1.x runtime" (#115). A bind failure is logged and ends the
+/// task instead of taking down the host app.
 pub async fn run(
-    first_server: NamedPipeServer,
-    guard: RegistryGuard,
+    pipe_path: PathBuf,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
     list_fn: Option<ListWindowsFn>,
     focus_fn: Option<FocusFn>,
     recorder: Recorder,
 ) {
+    let (first_server, guard) = match bind(&pipe_path) {
+        Ok(bound) => bound,
+        Err(e) => {
+            tracing::error!(path = %pipe_path.display(), "failed to bind named pipe: {e}");
+            return;
+        }
+    };
     let identifier = guard.identifier.clone();
     if let Err(e) = accept_loop(
         first_server,
@@ -544,10 +558,10 @@ mod tests {
     }
 
     async fn start_test_server(path: &Path) -> tokio::task::JoinHandle<()> {
-        let (listener, guard) = bind(path).expect("bind test pipe");
         let engine = EvalEngine::new();
+        let path = path.to_path_buf();
         let handle = tokio::spawn(async move {
-            run(listener, guard, engine, None, None, None, Recorder::new()).await;
+            run(path, engine, None, None, None, Recorder::new()).await;
         });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
@@ -635,6 +649,43 @@ mod tests {
 
         handle.abort();
         let _ = handle.await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[cfg(windows)]
+    async fn test_run_returns_when_bind_fails_instead_of_panicking() {
+        // #115: the named pipe is now bound inside `run` (on the tokio runtime),
+        // not in the plugin `setup`. A bind failure must end the task gracefully
+        // — never panic or hang. Hold the first pipe instance, then race a second
+        // `run` on the same path: `first_pipe_instance(true)` rejects the
+        // duplicate, so the second task must log the error and return on its own.
+        let pipe = unique_pipe_path();
+        let holder = start_test_server(&pipe).await; // owns the first instance
+
+        let dup_path = pipe.clone();
+        let dup = tokio::spawn(async move {
+            run(
+                dup_path,
+                EvalEngine::new(),
+                None,
+                None,
+                None,
+                Recorder::new(),
+            )
+            .await;
+        });
+
+        let joined = tokio::time::timeout(Duration::from_secs(5), dup)
+            .await
+            .expect("run must return after a failed bind (#115), not hang");
+        assert!(
+            joined.is_ok(),
+            "run must not panic when binding fails (#115)"
+        );
+
+        holder.abort();
+        let _ = holder.await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

On Windows, `pnpm tauri dev` aborts at startup before the window opens:

```
thread 'main' panicked at tokio-1.52.3/src/net/windows/named_pipe.rs:132:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Closes #115.

## Root cause

The plugin bound the IPC transport synchronously in the Tauri plugin `setup` hook. On Windows, `bind()` creates a tokio `NamedPipeServer` via `ServerOptions::create_with_security_attributes_raw`, which registers with the tokio reactor **the instant it is created**. `setup` runs outside any tokio runtime, so that registration panics and takes the host app down.

Unix was never affected: its `bind()` uses the **std (sync)** `UnixListener`, which needs no runtime — `run` only upgrades it to tokio later, inside the spawned task.

## Fix

- **Windows**: `server::run` now takes the pipe `PathBuf` and binds **inside the spawned task** (which lives on the tokio runtime). A bind failure is logged and ends the task instead of aborting the app.
- **Unix**: unchanged — still binds in `setup` with the std listener and surfaces a bind failure as a hard plugin error. The `setup` closure is split per platform with `#[cfg(unix)]` / `#[cfg(windows)]`.
- `bind` is no longer re-exported from `server` on Windows (it is now internal to the server task).

> Note: the reporter's suggested patch in the issue only touched the shared `lib.rs` + `windows.rs`, which would have failed to compile on Unix (the Unix `run` still takes a pre-bound listener). This PR keeps the Unix signature intact and only diverges the Windows path.

## Testing

- `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` → **291 passed** (Linux).
- Windows path can't run on the Linux dev box, so it was cross-validated:
  - `cargo check --target x86_64-pc-windows-gnu -p tauri-plugin-pilot --tests` → clean
  - `cargo clippy --target x86_64-pc-windows-gnu -p tauri-plugin-pilot --tests -- -D warnings` → clean
- Added a Windows regression test (`test_run_returns_when_bind_fails_instead_of_panicking`) asserting a failed bind ends the task without panicking or hanging. It runs on the `windows-latest` CI matrix leg.

## Changelog

Added a `Fixed` entry under `[Unreleased]` referencing #115.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows startup panic by binding the IPC named pipe inside the async server task instead of the sync plugin setup. This removes the `tokio` reactor error at launch and keeps Unix behavior unchanged.

- **Bug Fixes**
  - Windows: `server::run` now takes the pipe `PathBuf` and binds inside the spawned task on the runtime; on bind failure, log and exit the task instead of crashing.
  - Unix: unchanged — still binds with the std `UnixListener` in `setup`.
  - API/tests: stop re-exporting `server::bind` on Windows and add a regression test ensuring `run` returns on bind failure without panicking or hanging.

<sup>Written for commit 42a00debf5857efc82d3f91b4d6e804e966f5c29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/119?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows startup panic that occurred during plugin initialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->