### PR TITLE
fix(plugin): coerce snapshot value to string so diff handles <li> (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside any tokio runtime. The Windows pipe is now bound inside the spawned
   server task, which runs on the runtime. The Unix socket path is unchanged: it
   binds with the std `UnixListener`, which needs no runtime. [#115]
+- Stop `diff` aborting on any page containing `<li>` elements. The bridge
+  captured an element's `value` IDL property verbatim, but for `<li>`,
+  `<progress>`, and `<meter>` that property is a number (an `<li>`'s ordinal,
+  defaulting to `0`), so snapshots serialised `"value": 0` while the plugin
+  types `SnapshotElement.value` as `Option<String>`. Parsing such a reference
+  snapshot failed with `invalid type: integer 0, expected a string` (`-32602`),
+  making `diff` unusable on most real apps. The bridge now coerces `value` to a
+  string at capture, matching the wire contract. [#120]
 
 ### Security
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -386,7 +386,11 @@
         const entry = { ref: ref, role: role, depth: currentDepth };
         const name = getName(node);
         if (name) entry.name = name;
-        if (node.value !== undefined && node.value !== "") entry.value = node.value;
+        // `value` is an IDL property whose type varies by element: a string for
+        // form controls, but a number for `<li>` (ordinal), `<progress>`, and
+        // `<meter>`. Coerce to string so the wire format matches the plugin's
+        // `SnapshotElement.value: Option<String>` contract (#120).
+        if (node.value !== undefined && node.value !== "") entry.value = String(node.value);
         if (node.tagName === "INPUT") {
           var inputType = (node.getAttribute("type") || "text").toLowerCase();
           if (inputType === "checkbox" || inputType === "radio") {

--- a/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
@@ -1,0 +1,125 @@
+// Dependency-free behavioural tests for the bridge `snapshot` value capture (#120).
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// *real* file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation. The mock reproduces the DOM quirk behind #120:
+// `HTMLLIElement.value` is an IDL `long` (a number, the item's ordinal, default
+// `0`), so every `<li>` makes the bridge capture a JSON integer while the plugin
+// types `SnapshotElement.value` as `Option<String>` — `diff` then aborts with
+// `invalid type: integer 0, expected a string`.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+// Real console methods, captured once so each bridge load re-wraps the
+// originals instead of stacking wrappers across tests.
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// Minimal element mock. Only the surface `snapshot`/`getRole`/`getName` read:
+// tagName, nodeType, children, attributes, textContent, and the `value` IDL
+// property (which the test sets explicitly, mirroring real DOM types).
+function makeEl(tag, props = {}) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    nodeType: 1, // Node.ELEMENT_NODE
+    children: props.children || [],
+    textContent: props.text || "",
+    _attrs: props.attrs || {},
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this._attrs, name)
+        ? this._attrs[name]
+        : null;
+    },
+    hasAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(this._attrs, name);
+    },
+  };
+  if ("value" in props) el.value = props.value;
+  if ("disabled" in props) el.disabled = props.disabled;
+  return el;
+}
+
+// Fresh globals + a fresh bridge instance for each test (the IIFE early-returns
+// if `window.__PILOT__` already exists, so `window` must be new every time).
+function loadBridge(body) {
+  Object.assign(console, REAL_CONSOLE);
+
+  globalThis.Node = { ELEMENT_NODE: 1, TEXT_NODE: 3 };
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    body,
+    getElementById() {
+      return null;
+    },
+    querySelector() {
+      return null;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("snapshot never emits a numeric value for <li> items (#120)", () => {
+  // Every <li> outside an <ol> reports `.value === 0` (a number) per the DOM spec.
+  const li = (text) => makeEl("li", { text, value: 0 });
+  const list = makeEl("ul", { children: [li("a"), li("b"), li("c"), li("d")] });
+  const body = makeEl("body", { children: [list] });
+  const pilot = loadBridge(body);
+
+  const { elements } = pilot.snapshot();
+  const items = elements.filter((e) => e.role === "listitem");
+
+  assert.equal(items.length, 4, "all four <li> should be captured");
+  for (const item of items) {
+    assert.notEqual(
+      typeof item.value,
+      "number",
+      "value must serialise as a string, never a JSON number",
+    );
+    if (item.value !== undefined) {
+      assert.equal(typeof item.value, "string");
+    }
+  }
+});
+
+test("snapshot coerces a numeric ordinal (<ol> <li value>) to a string", () => {
+  const li = makeEl("li", { text: "second", value: 2 });
+  const list = makeEl("ol", { children: [li] });
+  const body = makeEl("body", { children: [list] });
+  const pilot = loadBridge(body);
+
+  const { elements } = pilot.snapshot();
+  const item = elements.find((e) => e.role === "listitem");
+
+  assert.equal(item.value, "2");
+});
+
+test("snapshot preserves a genuine string value unchanged", () => {
+  const input = makeEl("input", { value: "hello", attrs: { type: "text" } });
+  const body = makeEl("body", { children: [input] });
+  const pilot = loadBridge(body);
+
+  const { elements } = pilot.snapshot();
+  const field = elements.find((e) => e.value === "hello");
+
+  assert.ok(field, "the input value should still be captured");
+  assert.equal(field.value, "hello");
+});

--- a/crates/tauri-plugin-pilot/src/diff.rs
+++ b/crates/tauri-plugin-pilot/src/diff.rs
@@ -166,6 +166,17 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_element_deserializes_string_value() {
+        // Regression for #120: the bridge emits `value` as a string ("0" for a
+        // bare <li>), and the reference-snapshot parse in `diff` must accept it.
+        let json =
+            r#"{"ref":"e31","role":"listitem","depth":3,"name":"single hyphen value","value":"0"}"#;
+        let el: SnapshotElement =
+            serde_json::from_str(json).expect("string value should deserialize");
+        assert_eq!(el.value, Some("0".to_owned()));
+    }
+
+    #[test]
     fn test_diff_identical_snapshots() {
         let snapshot = vec![el("e1", "button", 1), el("e2", "input", 2)];
         let result = compute_diff(&snapshot, &snapshot);


### PR DESCRIPTION
Closes #120.

## Problem

`diff` aborted on any page containing `<li>` elements:

```
Error: RPC error (-32602): Failed to parse reference snapshot elements:
       invalid type: integer `0`, expected a string
```

The bridge captured an element's `value` IDL property verbatim. For `<li>`,
`<progress>`, and `<meter>` that property is a **number** — an `<li>`'s ordinal,
which defaults to `0` outside an `<ol>`. So every `<li>` made the snapshot
serialise `"value": 0`, while the plugin types `SnapshotElement.value` as
`Option<String>`. serde rejected the integer, and the `snapshot --save` →
`diff --ref` round-trip couldn't parse its own output. Lists are everywhere, so
`diff` was unusable on most real apps.

## Fix

Coerce `value` to a string at the point of capture in `bridge.js`:

```js
if (node.value !== undefined && node.value !== "") entry.value = String(node.value);
```

One line, at the boundary that owns DOM→JSON typing. It matches the existing
`String(params.value)` precedent in the `select` handler and aligns the bridge
output with the `Option<String>` contract. Identical coercion on both sides of a
diff means no spurious changes; an `<ol>` ordinal that genuinely changes is still
reported (now as `"1"` → `"2"`).

The form-`state` path was checked too — it only reads `input/select/textarea`
values (always strings), so no other sink needed coercing.

## Tests

- `crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs` (new) loads the real
  bridge into a DOM mock and asserts a `<li>` whose `.value === 0` never emits a
  numeric `value`, an `<ol>` ordinal coerces to `"2"`, and a real string value is
  preserved. RED before the fix, GREEN after.
- `diff.rs`: a round-trip guard that a snapshot element with `"value": "0"`
  deserialises into `Option<String>`.

```
node --test crates/tauri-plugin-pilot/js/*.test.mjs   # 7 pass
cargo test --workspace                                # 292 pass
cargo clippy --workspace -- -D warnings               # clean
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes diff aborts on pages with list items by coercing captured DOM value to a string during snapshot. Aligns bridge output with the `Option<String>` type so snapshots parse and round-trip correctly.

- **Bug Fixes**
  - Coerced `node.value` to `String(node.value)` in `bridge.js` for elements with numeric values (`<li>`, `<progress>`, `<meter>`).
  - Added JS tests to ensure `<li>` never emits a numeric value and ordinals coerce to strings; added a Rust test to deserialize `"value":"0"`.
  - Updated CHANGELOG; ordinal changes still show as string diffs.

<sup>Written for commit 8bd73ccab68d0ee7dfbc4cf083b67bb5bd7db8fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `diff` would abort when processing pages containing `<li>` elements by normalizing how element values are serialized.

* **Tests**
  * Added behavioral test suite to verify snapshot value capture behavior across element types.
  * Added regression test ensuring value field deserialization compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpiton/tauri-pilot/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->