### PR TITLE
fix(plugin): tap base physical key for uppercase-letter Shift combos on X11 (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now injected as its raw physical keycode, matching the keycode
   `global-hotkey` grabs. A bare `press "1"` keeps the layout-aware path, so it
   still types the layout's digit rather than the unshifted physical key. [#114]
+- Fire `Shift`+uppercase-letter global shortcuts via `press` on non-US layouts.
+  `press "Control+Shift+P"` — the conventional uppercase spelling — silently
+  failed to fire its accelerator on AZERTY while exiting `0`; only the lowercase
+  `Control+Shift+p` worked. #114 fixed the symmetric digit case but left
+  uppercase letters broken: `parse_combo` keeps the literal `'P'`, whose keysym
+  lives at shift-level 1, so `enigo` could not place it on the physical key and
+  remapped it onto a spare keycode no `XGrabKey` grab matched. An uppercase
+  letter in a modified combo is now lowered to its base key for injection, and
+  the explicitly held `Shift` produces the uppercase character — matching the
+  grab at level 0. A bare `press "P"` keeps `Key::Unicode('P')`, so it still
+  types an uppercase `P`. [#121]
 - Fix a startup panic on Windows ("there is no reactor running, must be called
   from the context of a Tokio 1.x runtime") that aborted the host app before its
   window opened. tokio's `NamedPipeServer` registers with the reactor the moment
@@ -493,3 +504,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#113]: https://github.com/mpiton/tauri-pilot/issues/113
 [#114]: https://github.com/mpiton/tauri-pilot/issues/114
 [#115]: https://github.com/mpiton/tauri-pilot/issues/115
+[#120]: https://github.com/mpiton/tauri-pilot/issues/120
+[#121]: https://github.com/mpiton/tauri-pilot/issues/121

--- a/crates/tauri-plugin-pilot/src/key.rs
+++ b/crates/tauri-plugin-pilot/src/key.rs
@@ -25,19 +25,31 @@
 //! physical key and instead remaps it onto a spare keycode. That spare keycode
 //! never matches a physical-key grab, so `Control+1`-style global shortcuts
 //! silently fail to fire even though the same key still reaches DOM listeners
-//! as a trusted event. Letters live at level 0 on these layouts, which is why
-//! `Control+Shift+P` fires while `Control+1` did not (issue #114).
+//! as a trusted event.
 //!
-//! To keep digit shortcuts working regardless of layout, [`simulate_press`]
-//! injects a digit as a raw physical keycode (see [`tap_main_key`]) when it is
-//! part of a modified combo such as `Control+1` — the case that targets a
-//! physical-key grab. A bare `press "1"` keeps enigo's layout-aware
-//! `Key::Unicode` path, so it still types the layout's digit rather than the
-//! unshifted physical key (`&` on AZERTY); reach for `fill` to set input text.
-//! Other characters that live above shift-level 0 on an exotic layout may still
-//! be remapped and miss a physical-key grab.
+//! The same trap catches an uppercase *letter* written into a `Shift` combo.
+//! `Control+Shift+P` parses to the pre-shifted character `'P'`, whose keysym
+//! lives at shift-level 1; on AZERTY enigo cannot place it on the physical key
+//! and remaps it onto a spare keycode, so the grab never fires (issue #121).
+//! Lowercase `p` sits at level 0, which is why `Control+Shift+p` works.
 //!
-//! See issues #45, #75 and #114.
+//! Two injection-path normalisations keep modified combos hitting the grab
+//! regardless of layout:
+//!
+//! - A digit in a modified combo (e.g. `Control+1`) is injected as a raw
+//!   physical keycode (see [`physical_digit_keycode`] / [`tap_main_key`]) — the
+//!   exact keycode `global-hotkey` grabbed.
+//! - An ASCII-uppercase letter in a modified combo is lowered to its base key
+//!   (see [`normalize_main_key`]); the explicitly held `Shift` then yields the
+//!   uppercase character, matching the grab at level 0.
+//!
+//! A bare `press "1"` or `press "P"` keeps enigo's layout-aware `Key::Unicode`
+//! path, so it still types the layout's character rather than the unshifted
+//! physical key (`&` on AZERTY); reach for `fill` to set input text. Other
+//! characters that live above shift-level 0 on an exotic layout may still be
+//! remapped and miss a physical-key grab.
+//!
+//! See issues #45, #75, #114 and #121.
 use enigo::{Direction, Enigo, Key, Keyboard, Settings};
 use std::sync::Mutex;
 use thiserror::Error;
@@ -232,6 +244,37 @@ fn physical_digit_keycode(key: Key, has_modifiers: bool) -> Option<u16> {
     }
 }
 
+/// Normalise the combo's main key for injection under any currently-held
+/// modifiers.
+///
+/// When a modifier is held, an ASCII-uppercase letter main key (e.g. `'P'` from
+/// `Control+Shift+P`) is lowered to its base form so enigo resolves it at
+/// shift-level 0 — the physical key the X11 grab is keyed on. The explicitly
+/// held `Shift` then produces the uppercase character, exactly as a human
+/// pressing the key would. Without this, enigo looks the uppercase keysym up at
+/// shift-level 1, fails to place it on the physical key on layouts like AZERTY,
+/// and remaps it onto a spare keycode that matches no grab — the press is lost
+/// even though the exit status is `0` (issue #121).
+///
+/// A bare `press "P"` (no modifiers) keeps `Key::Unicode('P')` so enigo applies
+/// its own shift and types an uppercase `P`, mirroring how a bare digit keeps
+/// the layout-aware path rather than a raw physical keycode. Non-ASCII
+/// uppercase letters are left untouched — only `A`–`Z` are handled.
+///
+/// Linux-only, like the digit raw-keycode path: macOS and Windows resolve a
+/// `Key::Unicode` character through their own keymap lookups that already land
+/// on the physical key regardless of letter case, so they keep enigo's plain
+/// `Key` path unchanged.
+#[cfg(target_os = "linux")]
+fn normalize_main_key(key: Key, has_modifiers: bool) -> Key {
+    match key {
+        Key::Unicode(ch) if has_modifiers && ch.is_ascii_uppercase() => {
+            Key::Unicode(ch.to_ascii_lowercase())
+        }
+        _ => key,
+    }
+}
+
 /// Tap (press + release) the combo's main key, given whether any modifier is
 /// currently held.
 ///
@@ -250,12 +293,14 @@ fn tap_main_key(enigo: &mut Enigo, key: Key, has_modifiers: bool) -> Result<(), 
             .map_err(|e| KeyError::EnigoInput(e.to_string()));
     }
     enigo
-        .key(key, Direction::Click)
+        .key(normalize_main_key(key, has_modifiers), Direction::Click)
         .map_err(|e| KeyError::EnigoInput(e.to_string()))
 }
 
-/// macOS and Windows have no layout-dependent digit-remapping problem, so every
-/// key goes through enigo's layout-aware [`Key`] path.
+/// macOS and Windows have no layout-dependent key-remapping problem (their
+/// keymap lookups resolve a `Key::Unicode` character to the physical key
+/// regardless of case or shift level), so every key goes through enigo's
+/// layout-aware [`Key`] path.
 #[cfg(not(target_os = "linux"))]
 fn tap_main_key(enigo: &mut Enigo, key: Key, _has_modifiers: bool) -> Result<(), KeyError> {
     enigo
@@ -522,5 +567,71 @@ mod tests {
         // a modified combo — they resolve correctly at shift-level 0.
         assert_eq!(physical_digit_keycode(Key::Unicode('a'), true), None);
         assert_eq!(physical_digit_keycode(Key::Return, true), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_normalize_main_key_lowercases_modified_uppercase_letter() {
+        // `Control+Shift+P` parses to Key::Unicode('P'); enigo resolves the
+        // uppercase keysym only at shift-level 1, so on AZERTY it remaps to a
+        // spare keycode no XGrabKey grab matches (#121). Tapping the base
+        // physical key ('p', level 0) under the held Shift hits the grab.
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('P'), true),
+            Key::Unicode('p')
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_normalize_main_key_keeps_bare_uppercase_letter() {
+        // A bare `press "P"` (no modifiers) means "type uppercase P" — keep the
+        // pre-shifted character so enigo applies its own shift, mirroring how a
+        // bare digit keeps the layout-aware Key::Unicode path.
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('P'), false),
+            Key::Unicode('P')
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_normalize_main_key_keeps_lowercase_letter() {
+        // Lowercase already resolves at shift-level 0 — untouched in either case.
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('p'), true),
+            Key::Unicode('p')
+        ));
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('p'), false),
+            Key::Unicode('p')
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_normalize_main_key_keeps_non_letter_keys() {
+        // Digits and named keys are not ASCII-uppercase letters, so they pass
+        // through unchanged — digits go through the raw-keycode path instead.
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('1'), true),
+            Key::Unicode('1')
+        ));
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('+'), true),
+            Key::Unicode('+')
+        ));
+        assert!(key_eq(normalize_main_key(Key::Return, true), Key::Return));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_normalize_main_key_keeps_non_ascii_uppercase() {
+        // Only ASCII A–Z are handled (the case enigo can resolve from the held
+        // Shift). A non-ASCII uppercase letter is left as-is rather than guessed.
+        assert!(key_eq(
+            normalize_main_key(Key::Unicode('É'), true),
+            Key::Unicode('É')
+        ));
     }
 }


### PR DESCRIPTION
Closes #121.

## Problem

`press "Control+Shift+P"` — the conventional uppercase spelling — silently fails to fire a registered global shortcut on non-US layouts (reproduced on French AZERTY/X11). The command returns `✓ ok` (exit 0), but neither the Tauri accelerator nor the DOM `keydown` listener sees it. The lowercase `Control+Shift+p` works every time.

Same root-cause class as #114, but #114 only covered digits. `parse_combo` keeps the literal `'P'`, whose keysym lives at shift-level 1. enigo can't place it on the physical key on AZERTY, so it remaps it onto a spare keycode no `XGrabKey` grab matches — the press is lost while exit stays 0.

## Fix

Mirror the existing digit raw-keycode path. When a modified combo holds an ASCII-uppercase letter, lower it to its base key for injection (`normalize_main_key`) so enigo resolves it at shift-level 0 — the physical key the grab is keyed on. The explicitly-held `Shift` then produces the uppercase character and matches the grab.

A bare `press "P"` (no modifiers) keeps `Key::Unicode('P')`, so it still types an uppercase `P` — symmetric to how a bare digit keeps the layout-aware path.

`normalize_main_key` and its tests are gated to `#[cfg(target_os = "linux")]`, like the digit path: macOS and Windows resolve a `Key::Unicode` character to the physical key regardless of letter case, so they keep enigo's plain `Key` path unchanged.

## Changes

- `crates/tauri-plugin-pilot/src/key.rs` — add `normalize_main_key`, wire it into the Linux `tap_main_key` after the digit check, update the module docstring (it wrongly claimed `Control+Shift+P` fires).
- `CHANGELOG.md` — Fixed entry for #121 (and restore the missing `[#120]` link reference).

## Testing

- 5 new unit tests for `normalize_main_key`: modified uppercase → lowercase, bare uppercase kept, lowercase kept, digit/symbol/named keys unchanged, non-ASCII uppercase (`'É'`) kept.
- `cargo test --workspace` — 297 pass. `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

The injection itself can't be asserted in a headless unit test (needs a display + grab); the helper tests pin the case decision that was the bug.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uppercase-letter Shift combos on X11 non-US layouts so global shortcuts like Control+Shift+P fire reliably. On Linux, we tap the base physical key and let the held Shift produce the uppercase letter to match the grabbed key.

- **Bug Fixes**
  - Linux/X11: add `normalize_main_key` to lower ASCII uppercase main keys in modified combos before injection; wired into `tap_main_key`.
  - Mirrors the digit raw-keycode path from #114 and closes #121. Bare `press "P"` is unchanged; macOS/Windows unchanged.
  - Adds 5 unit tests and updates `CHANGELOG.md`.

<sup>Written for commit b8df3919d5c16fe93effae4255b8e0754a575050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

