### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-30
+
 ### Added
 
 - Add a `screenshot_native` CLI subcommand to capture a native window PNG by
@@ -465,7 +467,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mpiton/tauri-pilot/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mpiton/tauri-pilot/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/mpiton/tauri-pilot/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/mpiton/tauri-pilot/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,6 +499,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#105]: https://github.com/mpiton/tauri-pilot/pull/105
 [#106]: https://github.com/mpiton/tauri-pilot/pull/106
 [#107]: https://github.com/mpiton/tauri-pilot/pull/107
+[#108]: https://github.com/mpiton/tauri-pilot/issues/108
 [#109]: https://github.com/mpiton/tauri-pilot/issues/109
 [#110]: https://github.com/mpiton/tauri-pilot/issues/110
 [#113]: https://github.com/mpiton/tauri-pilot/issues/113

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Release v0.7.0 — 16 fix PRs since v0.6.0. No code changes in this PR beyond the release mechanics (version bumps, CHANGELOG finalize).

## Changes

- Bump workspace crates to `0.7.0` (`tauri-plugin-pilot`, `tauri-pilot-cli`)
- CHANGELOG: move `[Unreleased]` → `[0.7.0] - 2026-05-30`, add missing `[#108]` link reference
- `chore: release v0.7.0` commit + annotated tag `v0.7.0`

## What's in 0.7.0

**Added**
- `screenshot_native` CLI subcommand (native window PNG by window id) [#108]
- Idempotent bridge bootstrap [#108]

**Fixed**
- Restore eval delivery on Tauri 2.11 / wry 0.55 — macOS native callback [#108], Linux/Windows `__callback` IPC [#110]
- `windows.list` no longer panics when wry can't report a URL [#108]
- `<p>` paragraph text in snapshots [#109]
- `select` matches by label, errors on no-match [#113]
- X11 `Control`+digit global shortcuts on AZERTY [#114]
- X11 `Shift`+uppercase-letter global shortcuts on non-US layouts [#121]
- Windows startup panic (Tokio reactor) [#115]
- `diff` no longer aborts on pages with `<li>` [#120]

**Security**
- Block `javascript:` URLs in `pilot.navigate` MCP tool [#107]
- Harden release workflow against token exfiltration [#106]
- Shell-escape `ref` in `replay --export sh` [#105]
- Gate dangerous MCP tools behind opt-in env var [#104]

## Verification

- `cargo test --workspace` — 297 pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt` applied
- Live QA on pilot-test-app: eval, snapshot, screenshot (html-to-image), select-by-label, X11 Control+1 / Control+Shift+P all verified on this commit

## Post-merge

CI on tag push verifies tag==Cargo.toml versions + CHANGELOG entry, then publishes plugin → CLI to crates.io and creates the GitHub Release. Push the tag (`git push --tags`) after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v0.7.0 release: bump `tauri-plugin-pilot` and `tauri-pilot-cli` to 0.7.0 and finalize the CHANGELOG (add 0.7.0 section dated 2026-05-30, update `[Unreleased]` compare link, add `[#108]` link). No code changes.

<sup>Written for commit 885fa1b6e6d27eba0ea93a668e15a3dc23dc66e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

