### PR TITLE
fix(plugin): route macOS eval results via IPC callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore eval-based commands on macOS headless CI runners by delivering eval
+  results through the existing `__callback` IPC command on every platform instead
+  of relying on the native `WKWebView` completion handler, which may never fire
+  without an interactive GUI session. [#126]
+
 ## [0.7.0] - 2026-05-30
 
 ### Added

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -50,13 +50,9 @@ windows = { version = "0.61", features = [
 enigo = { version = "0.6.1", features = ["wayland"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-block2 = "0.6"
 core-foundation = "0.10"
 core-graphics = "0.24"
 image = { version = "0.25", default-features = false, features = ["png"] }
-objc2 = "0.6"
-objc2-foundation = "0.3"
-objc2-web-kit = "0.3"
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -223,21 +223,20 @@ mod tests {
         assert!(script.contains("catch"));
     }
 
-    // #110/#126: Native eval result callbacks are not reliable across WebView
-    // backends and macOS headless CI. The wrapped script must `await` the result
-    // and deliver it back through the `__callback` IPC command.
+    // #110/#126: The wrapped script must await the JavaScript result and send it
+    // through `__callback`, avoiding native eval result callbacks entirely.
     #[test]
-    fn test_wrap_script_delivers_via_ipc_callback() {
+    fn test_wrap_script_uses_ipc_callback_delivery() {
         let script = EvalEngine::wrap_script(7, "document.title");
         assert!(
             script.contains("__TAURI_INTERNALS__.invoke('plugin:pilot|__callback'"),
-            "wrap must deliver results via the __callback IPC command (#110/#126); got: {script}"
+            "wrapped script must send eval results through __callback IPC; got: {script}"
         );
         assert!(script.contains("{id:7,result:"));
         assert!(script.contains("{id:7,error:"));
         assert!(
             !script.contains("return {id:7,result:"),
-            "wrap must not depend on a native eval completion result; got: {script}"
+            "wrapped script must not return a native eval completion payload; got: {script}"
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -87,19 +87,16 @@ impl EvalEngine {
         }
     }
 
-    /// Wrap a user script in the ADR-001 callback pattern for Linux/Windows.
+    /// Wrap a user script in the ADR-001 callback pattern.
     ///
-    /// `WebKitGTK` and `WebView2` do not resolve a Promise returned from a webview
-    /// eval — the eval callback fires with the unresolved Promise object, so a
-    /// return-value delivery never lands and the eval times out (#110). Instead
-    /// the script `await`s the result and delivers it back through the
+    /// `WebView` eval result callbacks are not reliable across platforms and CI
+    /// modes, so the script `await`s the result and delivers it back through the
     /// `__callback` IPC command, which dispatches fine from eval-injected code.
     ///
     /// Normalizes `undefined` results to `null` (string `"null"`) so Tauri does
     /// not drop the `result` field — otherwise a void expression (e.g.,
     /// `element.click()`) would cause the handler to log a bogus "neither
     /// result nor error" warning (#48).
-    #[cfg(not(target_os = "macos"))]
     #[must_use]
     pub fn wrap_script(id: u64, script: &str) -> String {
         format!(
@@ -108,23 +105,6 @@ impl EvalEngine {
              {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}});\
              }}catch(__e){{await window.__TAURI_INTERNALS__.invoke('plugin:pilot|__callback',\
              {{id:{id},error:(__e&&__e.message)||String(__e)}});}}}})();"
-        )
-    }
-
-    /// Wrap a user script so the native macOS `WKWebView` completion handler
-    /// receives a tagged payload as the eval return value (#108).
-    ///
-    /// macOS reads the script's return value via `evaluateJavaScript`, so the
-    /// wrapper returns `{id, result}` directly rather than routing through IPC.
-    /// `undefined` is normalized to the string `"null"` for the same reason as
-    /// the non-macOS variant (#48).
-    #[cfg(target_os = "macos")]
-    #[must_use]
-    pub fn wrap_script(id: u64, script: &str) -> String {
-        format!(
-            "(async()=>{{try{{let __r=await({script});\
-             return {{id:{id},result:__r===undefined?'null':JSON.stringify(__r)}};\
-             }}catch(__e){{return {{id:{id},error:(__e&&__e.message)||String(__e)}};}}}})();"
         )
     }
 
@@ -243,36 +223,22 @@ mod tests {
         assert!(script.contains("catch"));
     }
 
-    // #110: Linux (WebKitGTK) and Windows (WebView2) do not resolve a Promise
-    // returned from a webview eval — the eval callback fires with the unresolved
-    // Promise, so a return-value delivery never lands and every eval times out.
-    // The wrapped script must therefore `await` the result and deliver it back
-    // through the `__callback` IPC command, which works from eval-injected code.
-    #[cfg(not(target_os = "macos"))]
+    // #110/#126: Native eval result callbacks are not reliable across WebView
+    // backends and macOS headless CI. The wrapped script must `await` the result
+    // and deliver it back through the `__callback` IPC command.
     #[test]
-    fn test_wrap_script_delivers_via_ipc_callback_on_non_macos() {
+    fn test_wrap_script_delivers_via_ipc_callback() {
         let script = EvalEngine::wrap_script(7, "document.title");
         assert!(
             script.contains("__TAURI_INTERNALS__.invoke('plugin:pilot|__callback'"),
-            "non-macOS wrap must deliver results via the __callback IPC command (#110); got: {script}"
+            "wrap must deliver results via the __callback IPC command (#110/#126); got: {script}"
         );
         assert!(script.contains("{id:7,result:"));
         assert!(script.contains("{id:7,error:"));
-    }
-
-    // macOS keeps the #108 native WKWebView completion-handler path, which reads
-    // the script's return value, so the wrapper returns the tagged payload and
-    // must not depend on the IPC bridge.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn test_wrap_script_returns_payload_for_native_callback_on_macos() {
-        let script = EvalEngine::wrap_script(7, "document.title");
         assert!(
-            script.contains("return {id:7,result:"),
-            "macOS wrap must return the tagged payload for the native callback; got: {script}"
+            !script.contains("return {id:7,result:"),
+            "wrap must not depend on a native eval completion result; got: {script}"
         );
-        assert!(!script.contains("__callback"));
-        assert!(!script.contains("__TAURI_INTERNALS__"));
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -64,7 +64,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 let identifier = sanitize_identifier(&app.config().identifier);
                 let socket_path = server::socket_path(&identifier);
 
-                let eval_fn = make_eval_fn(app, engine.clone());
+                let eval_fn = make_eval_fn(app);
                 let list_fn = make_list_fn(app);
                 let focus_fn = make_focus_fn(app);
 
@@ -142,7 +142,7 @@ fn sanitize_identifier(raw: &str) -> String {
 /// If `window` is `Some(label)`, targets that specific window (error if not found).
 /// If `window` is `None`, tries "main" first then falls back to the first available window.
 #[cfg(all(any(unix, windows), debug_assertions))]
-fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>, engine: EvalEngine) -> EvalFn {
+fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
     let handle = app.clone();
     Arc::new(move |window: Option<&str>, script: String| {
         let target = if let Some(label) = window {
@@ -159,142 +159,11 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>, engine: EvalEngine
                 .cloned()
                 .ok_or_else(|| "No webview available".to_owned())?
         };
-        #[cfg(target_os = "macos")]
-        {
-            eval_with_webkit_callback(&target, script, engine.clone())
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            // Linux (WebKitGTK) and Windows (WebView2) do not resolve a Promise
-            // returned from eval, so results come back via the `__callback` IPC
-            // command (see EvalEngine::wrap_script). This eval is fire-and-forget;
-            // the IPC handler resolves the pending request, not this closure.
-            let _ = &engine;
-            target.eval(&script).map_err(|e| e.to_string())
-        }
+        // Results come back via the `__callback` IPC command (see
+        // EvalEngine::wrap_script). This eval is fire-and-forget; the IPC handler
+        // resolves the pending request, not this closure.
+        target.eval(&script).map_err(|e| e.to_string())
     })
-}
-
-#[cfg(all(target_os = "macos", debug_assertions))]
-fn eval_with_webkit_callback<R: tauri::Runtime>(
-    target: &tauri::WebviewWindow<R>,
-    script: String,
-    engine: EvalEngine,
-) -> Result<(), String> {
-    let eval_id = extract_eval_callback_id(&script);
-    target
-        // SAFETY: `platform.inner()` returns the WKWebView pointer owned by wry
-        // and valid for this `with_webview` closure. `RcBlock` allocates the
-        // completion block on the heap, and WebKit copies it so the callback
-        // stays alive after this scope returns.
-        .with_webview(move |platform| unsafe {
-            use objc2::{AnyThread, runtime::AnyObject};
-            use objc2_foundation::{
-                NSError, NSJSONSerialization, NSJSONWritingOptions, NSString, NSUTF8StringEncoding,
-            };
-            use objc2_web_kit::WKWebView;
-
-            let webview: &WKWebView = &*platform.inner().cast();
-            let handler =
-                block2::RcBlock::new(move |value: *mut AnyObject, error: *mut NSError| {
-                    if !error.is_null() {
-                        resolve_native_eval_error(
-                            &engine,
-                            eval_id,
-                            "native WebKit eval callback returned an error",
-                        );
-                        return;
-                    }
-
-                    if value.is_null() {
-                        resolve_native_eval_error(
-                            &engine,
-                            eval_id,
-                            "native WebKit eval callback returned no value",
-                        );
-                        return;
-                    }
-
-                    let Some(json) = NSJSONSerialization::dataWithJSONObject_options_error(
-                        &*value,
-                        NSJSONWritingOptions::FragmentsAllowed,
-                    )
-                    .ok()
-                    .and_then(|data| {
-                        NSString::initWithData_encoding(
-                            NSString::alloc(),
-                            &data,
-                            NSUTF8StringEncoding,
-                        )
-                    }) else {
-                        resolve_native_eval_error(
-                            &engine,
-                            eval_id,
-                            "native WebKit eval callback result was not JSON serializable",
-                        );
-                        return;
-                    };
-                    let payload = json.to_string();
-                    handle_eval_callback_payload(&engine, &payload);
-                });
-
-            webview
-                .evaluateJavaScript_completionHandler(&NSString::from_str(&script), Some(&handler));
-        })
-        .map_err(|e| e.to_string())
-}
-
-#[cfg(all(target_os = "macos", debug_assertions))]
-fn extract_eval_callback_id(script: &str) -> Option<u64> {
-    script
-        .split("return {id:")
-        .nth(1)?
-        .split_once(',')?
-        .0
-        .parse()
-        .ok()
-}
-
-#[cfg(all(target_os = "macos", debug_assertions))]
-fn resolve_native_eval_error(engine: &EvalEngine, id: Option<u64>, message: &str) {
-    if let Some(id) = id {
-        handler::handle_callback(engine, id, None, Some(message.to_owned()));
-    } else {
-        tracing::warn!(
-            message,
-            "native WebKit eval callback failed before resolving an id"
-        );
-    }
-}
-
-#[cfg(all(target_os = "macos", debug_assertions))]
-fn handle_eval_callback_payload(engine: &EvalEngine, payload: &str) {
-    let parsed = serde_json::from_str::<serde_json::Value>(payload)
-        .ok()
-        .and_then(|value| {
-            if let Some(inner) = value.as_str() {
-                serde_json::from_str::<serde_json::Value>(inner).ok()
-            } else {
-                Some(value)
-            }
-        });
-    let Some(value) = parsed else {
-        tracing::warn!(payload, "eval callback returned non-json payload");
-        return;
-    };
-    let Some(id) = value.get("id").and_then(serde_json::Value::as_u64) else {
-        tracing::warn!(payload = %value, "eval callback payload missing id");
-        return;
-    };
-    let result = value
-        .get("result")
-        .and_then(serde_json::Value::as_str)
-        .map(ToOwned::to_owned);
-    let error = value
-        .get("error")
-        .and_then(serde_json::Value::as_str)
-        .map(ToOwned::to_owned);
-    handler::handle_callback(engine, id, result, error);
 }
 
 /// Create a focus function that requests OS focus for a webview window.

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -90,9 +90,9 @@ The `windows.list` method enumerates all open windows (label, URL, title), sorte
 
 `webview.eval()` in Tauri v2 is **fire-and-forget** — it dispatches JS into the WebView but provides no return value. All methods that read from the page require a response, so a callback pattern is used:
 
-1. The plugin wraps the target JS in a `try/catch` block that returns `{id, result}` or `{id, error}`
-2. The WebView eval completion callback receives that payload
-3. The callback handler looks up the matching `oneshot::Sender` and resolves it
+1. The plugin wraps the target JS in a `try/catch` block that awaits the result
+2. The wrapper sends `{id, result}` or `{id, error}` through the internal `__callback` IPC command
+3. The IPC callback handler looks up the matching `oneshot::Sender` and resolves it
 4. Rust awaits the oneshot channel with a 10-second timeout
 
 The `EvalEngine` maintains:


### PR DESCRIPTION
## Summary

• Route eval result delivery through `__callback` IPC on every platform
• Remove macOS WKWebView completion-handler eval path and unused ObjC deps
• Update regression coverage, changelog, and architecture docs

## Type

fix

## Testing

• `cargo check --workspace`
• `cargo fmt --all -- --check`
• `cargo test --workspace`
• `cargo clippy --workspace -- -D warnings`

Closes #126

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes eval results through the `__callback` IPC on all platforms to fix stalled macOS evals in headless CI and unify behavior. Removes the native WKWebView completion-handler path; simplifies the eval flow and updates docs/tests. (#126)

- **Bug Fixes**
  - All evals now await in JS and return via `__callback` IPC; native callbacks are no longer used, preventing macOS headless CI timeouts.

- **Dependencies**
  - Removed `block2`, `objc2`, `objc2-foundation`, `objc2-web-kit` from macOS builds.

<sup>Written for commit 3293332ac93574449540f02c6277a6f3ba36174d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed eval-based command delivery on macOS headless CI runners by standardizing result delivery across all platforms so eval results reliably arrive via the internal callback mechanism.

* **Documentation**
  * Updated the architecture guide (ADR-001) to describe the unified "eval + callback" pattern and how eval results are routed and resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->