### PR TITLE
docs(plugin): update stale EvalEngine doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   results through the existing `__callback` IPC command on every platform instead
   of relying on the native `WKWebView` completion handler, which may never fire
   without an interactive GUI session. [#126]
+- Update two stale `EvalEngine` doc comments that still described the removed
+  native eval callback model; eval results are now documented as delivered via
+  the `__callback` IPC command on every platform. [#128]
 
 ## [0.7.0] - 2026-05-30
 
@@ -517,3 +520,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#115]: https://github.com/mpiton/tauri-pilot/issues/115
 [#120]: https://github.com/mpiton/tauri-pilot/issues/120
 [#121]: https://github.com/mpiton/tauri-pilot/issues/121
+[#126]: https://github.com/mpiton/tauri-pilot/issues/126
+[#128]: https://github.com/mpiton/tauri-pilot/issues/128

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -18,7 +18,7 @@ pub(crate) enum EvalError {
 
 type PendingMap = HashMap<u64, oneshot::Sender<Result<serde_json::Value, String>>>;
 
-/// Engine for executing JS in a `WebView` and resolving native eval callback results.
+/// Engine for executing JS in a `WebView` and resolving eval results delivered via the `__callback` IPC command.
 ///
 /// The core ADR-001 pattern: wrap script in try/catch + return a callback payload,
 /// await the result on a oneshot channel with timeout.
@@ -69,7 +69,7 @@ impl EvalEngine {
         (id, rx)
     }
 
-    /// Resolve a pending eval by ID from a `WebView` eval callback payload.
+    /// Resolve a pending eval by ID from a `__callback` IPC payload.
     pub fn resolve(&self, id: u64, result: Result<serde_json::Value, String>) {
         let sender = self
             .pending


### PR DESCRIPTION
Closes #128.

#127 unified eval delivery through the `__callback` IPC command on every platform, but two doc comments in `eval.rs` still described the removed native WebView callback model:

- `eval.rs:21` — now says eval results are delivered via the `__callback` IPC command
- `eval.rs:72` — now says `resolve` takes a `__callback` IPC payload

Verified against the call sites: `resolve` is only reached from `handle_callback` and the eval_fn-failure cleanup paths. The remaining "native eval" mentions in `eval.rs` test comments describe what the code must *avoid*, so they stay as-is.

Also adds the missing `[#126]` reference link in CHANGELOG.md (dangling since the #127 entry) and the `[#128]` link for the new entry.

Documentation only, no behavior change. `cargo test --workspace` (297 passed) and `cargo clippy --workspace -- -D warnings` both clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `EvalEngine` doc comments to state that eval results are delivered via the `__callback` IPC command on all platforms, replacing references to the old native WebView callback. Add missing `[#126]` and new `[#128]` links in CHANGELOG; docs-only, no behavior change.

<sup>Written for commit db2ca184c4ac2ee0baf4fe487acb89980813a092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for eval result delivery mechanism.
  * Updated changelog with additional issue references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->