### PR TITLE
fix(plugin): capture full document height in selector-less screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update two stale `EvalEngine` doc comments that still described the removed
   native eval callback model; eval results are now documented as delivered via
   the `__callback` IPC command on every platform. [#128]
+- Capture the full document height in `screenshot` without `--selector`.
+  html-to-image sized the render from the viewport and always started at the
+  document origin, so the PNG showed the top of the page regardless of scroll
+  position and silently dropped everything below the fold. [#129]
 
 ## [0.7.0] - 2026-05-30
 
@@ -522,3 +526,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#121]: https://github.com/mpiton/tauri-pilot/issues/121
 [#126]: https://github.com/mpiton/tauri-pilot/issues/126
 [#128]: https://github.com/mpiton/tauri-pilot/issues/128
+[#129]: https://github.com/mpiton/tauri-pilot/issues/129

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -111,7 +111,7 @@ pub(crate) enum Command {
         #[arg(long)]
         args: Option<String>,
     },
-    /// Capture a screenshot (PNG).
+    /// Capture a full-page screenshot (PNG).
     Screenshot {
         path: Option<PathBuf>,
         #[arg(long)]

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -877,7 +877,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "screenshot",
-            description: "Capture the WebView or an element selector as a PNG data URL.",
+            description: "Capture the full page or an element selector as a PNG data URL.",
             schema: selector_schema,
             read_only: true,
             destructive: false,

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1073,7 +1073,17 @@
     if (typeof htmlToImage === "undefined" || !htmlToImage.toPng) {
       throw new Error("html-to-image library not loaded. Bundle it into bridge.js for screenshot support.");
     }
-    var dataUrl = await htmlToImage.toPng(el, { pixelRatio: 1 });
+    var renderOptions = { pixelRatio: 1 };
+    if (!selector) {
+      // html-to-image sizes the capture from clientWidth/clientHeight, which
+      // for documentElement is the viewport — the render always starts at the
+      // document origin, so anything below the fold is silently cropped
+      // (#129). Pass the full scroll dimensions to capture the whole page.
+      var body = document.body;
+      renderOptions.width = Math.max(el.scrollWidth || 0, body ? body.scrollWidth || 0 : 0);
+      renderOptions.height = Math.max(el.scrollHeight || 0, body ? body.scrollHeight || 0 : 0);
+    }
+    var dataUrl = await htmlToImage.toPng(el, renderOptions);
     return dataUrl;
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
@@ -1,0 +1,119 @@
+// Dependency-free behavioural tests for the bridge `screenshot` action (#129).
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// *real* file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation. `htmlToImage.toPng` is mocked to capture the
+// node and options it receives: #129 is about the options (without explicit
+// width/height, html-to-image crops `document.documentElement` to the viewport
+// and silently loses everything below the fold).
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+// Real console methods, captured once so each bridge load re-wraps the
+// originals instead of stacking wrappers across tests.
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// Fresh globals + a fresh bridge instance for each test (the IIFE early-returns
+// if `window.__PILOT__` already exists, so `window` must be new every time).
+// Returns the pilot API plus the toPng calls captured by the mock.
+function loadBridge({ queryResult, documentElement, body } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+
+  const calls = [];
+  globalThis.htmlToImage = {
+    async toPng(node, options) {
+      calls.push({ node, options });
+      return "data:image/png;base64,AAAA";
+    },
+  };
+
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    documentElement: documentElement || {},
+    body: body || {},
+    querySelector(selector) {
+      if (queryResult === undefined) {
+        throw new Error("unexpected querySelector(" + selector + ")");
+      }
+      return queryResult;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+
+  // Indirect eval runs in global scope; the IIFE then resolves bare `window`,
+  // `document`, etc. against the globals set above.
+  (0, eval)(BRIDGE_SRC);
+  return { pilot: globalThis.window.__PILOT__, calls };
+}
+
+test("screenshot without selector captures the full document height", async () => {
+  // Document taller and wider than the viewport: scroll dimensions are the
+  // full layout size, client dimensions are the viewport crop we must avoid.
+  const documentElement = {
+    scrollWidth: 800,
+    scrollHeight: 2400,
+    clientWidth: 800,
+    clientHeight: 700,
+  };
+  const body = { scrollWidth: 820, scrollHeight: 2500 };
+  const { pilot, calls } = loadBridge({ documentElement, body });
+
+  await pilot.screenshot({});
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].node, documentElement);
+  // max(html, body) on both axes so nothing below the fold is lost.
+  assert.equal(calls[0].options.width, 820);
+  assert.equal(calls[0].options.height, 2500);
+  assert.equal(calls[0].options.pixelRatio, 1);
+});
+
+test("screenshot without selector tolerates a missing body", async () => {
+  const documentElement = { scrollWidth: 800, scrollHeight: 2400 };
+  const { pilot, calls } = loadBridge({ documentElement, body: null });
+
+  await pilot.screenshot({});
+
+  assert.equal(calls[0].options.width, 800);
+  assert.equal(calls[0].options.height, 2400);
+});
+
+test("screenshot with selector does not override element dimensions", async () => {
+  const el = { scrollWidth: 300, scrollHeight: 40 };
+  const { pilot, calls } = loadBridge({ queryResult: el });
+
+  await pilot.screenshot({ selector: "#panel" });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].node, el);
+  // html-to-image must size the capture from the element's own layout.
+  assert.equal("width" in calls[0].options, false);
+  assert.equal("height" in calls[0].options, false);
+  assert.equal(calls[0].options.pixelRatio, 1);
+});
+
+test("screenshot with unmatched selector throws element not found", async () => {
+  const { pilot } = loadBridge({ queryResult: null });
+
+  await assert.rejects(
+    () => pilot.screenshot({ selector: "#missing" }),
+    /Element not found: #missing/,
+  );
+});

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -820,11 +820,18 @@ tauri-pilot ipc create_pr --args '{"title":"Fix bug","branch":"fix/issue-42"}'
 
 ### `screenshot`
 
-Capture the current WebView as a PNG using the injected `html-to-image` bridge.
+Capture the full page as a PNG using the injected `html-to-image` bridge.
 
 ```bash
 tauri-pilot screenshot [path] [OPTIONS]
 ```
+
+Without `--selector`, the capture covers the whole document height, not just
+the visible viewport. The bridge serializes the DOM to render it, so the
+current scroll position is not reflected in the image — what you get is the
+entire page from the top. Use `--selector` to capture a single element
+(works for elements below the fold too). For a pixel-exact capture of the
+native window, use `screenshot_native`.
 
 **Arguments:**
 


### PR DESCRIPTION
Closes #129

## Why

`screenshot` without `--selector` returned a viewport-sized PNG that always showed the top of the document. html-to-image sizes the render from `clientWidth`/`clientHeight`, which for `documentElement` is the viewport, and the DOM-serialized render always starts at the document origin. So the output was neither a full-page capture nor the current view — anything below the fold was silently lost.

## Changes

- `bridge.js` `screenshot()`: when no selector is given, pass `width`/`height` = `max(documentElement, body)` scroll dimensions to `htmlToImage.toPng`. Selector captures are unchanged and keep sizing from the element's own layout.
- New `bridge.screenshot.test.mjs` (same harness pattern as the select/snapshot tests): full-dimension override without selector, no override with selector, missing-body tolerance, element-not-found error.
- Docs: `cli.md` screenshot section now describes the full-page behavior and states that scroll position can't be reflected in a DOM-serialized capture (use `--selector` or `screenshot_native` instead). MCP tool description and clap doc comment updated to match.
- CHANGELOG entry under Unreleased.

## Notes

- Scroll position is still not reflected — that's structural to html-to-image (DOM serialization carries no scroll state). The issue's option 3 (crop at scroll offset) remains possible later if needed.
- Very tall documents are bounded by html-to-image's built-in 16384px canvas clamp, which scales the image down proportionally instead of failing.
- Behavior change: selector-less screenshots are now full-page-sized instead of viewport-sized. Pre-1.0 and listed in the changelog.

## Testing

- `node --test crates/tauri-plugin-pilot/js/*.test.mjs` — 11/11 pass
- `cargo test --workspace` — 297 pass
- `cargo clippy --workspace -- -D warnings` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes selector-less `screenshot` to capture the full page instead of just the viewport, so content below the fold is included. Updates tests and docs to reflect the new default and its scroll-position caveat.

- **Bug Fixes**
  - In `bridge.js`, when no `--selector`, set `width`/`height` to the max scroll dimensions of `document.documentElement` and `document.body` before calling `html-to-image.toPng`.
  - Selector screenshots are unchanged and use the element’s layout.
  - Added `bridge.screenshot.test.mjs` for full-page sizing, selector behavior, missing-body tolerance, and element-not-found errors.
  - Updated CLI/MCP descriptions and `cli.md`; added CHANGELOG entry. Scroll position can’t be reflected in DOM-serialized captures.

<sup>Written for commit 16308cf163673ea0c570d5ec8495dc45fab8d53f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `screenshot` command to capture full document height when no selector is specified, preventing loss of content below the fold.

* **Documentation**
  * Enhanced CLI documentation with detailed explanation of screenshot behavior, clarifying full-page capture and selector options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->