### PR TITLE
fix(plugin): scroll source into view before offset drag (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   html-to-image sized the render from the viewport and always started at the
   document origin, so the PNG showed the top of the page regardless of scroll
   position and silently dropped everything below the fold. [#129]
+- Scroll the source element into view before an offset drag. `drag --offset`
+  resolves the drop point with `elementFromPoint`, which is viewport-bound, so
+  a source outside the visible viewport failed with the misleading error
+  "No element at offset (x,y)". The bridge now centers the source in the
+  viewport first, and the residual errors name the actual cause (drop point
+  outside the viewport vs. no element at the computed point). [#130]
 
 ## [0.7.0] - 2026-05-30
 
@@ -527,3 +533,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#126]: https://github.com/mpiton/tauri-pilot/issues/126
 [#128]: https://github.com/mpiton/tauri-pilot/issues/128
 [#129]: https://github.com/mpiton/tauri-pilot/issues/129
+[#130]: https://github.com/mpiton/tauri-pilot/issues/130

--- a/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
@@ -107,8 +107,8 @@ function loadBridge({ elements = {}, elementFromPoint } = {}) {
 }
 
 test("drag with offset scrolls a below-fold source into view before resolving the drop point", () => {
-  // Source centre starts at (110,1510), far below the 700px viewport. After
-  // scrollIntoView the centre lands at (110,350); offset (130,0) puts the drop
+  // Source center starts at (110,1510), far below the 700px viewport. After
+  // scrollIntoView the center lands at (110,350); offset (130,0) puts the drop
   // point at (240,350).
   const source = makeElement(rect(100, 1500, 20, 20), {
     visibleRect: rect(100, 340, 20, 20),
@@ -142,7 +142,7 @@ test("drag with offset scrolls a below-fold source into view before resolving th
 });
 
 test("drag with offset scrolls an above-viewport source into view", () => {
-  // Source centre starts at (110,-40), above the fold.
+  // Source center starts at (110,-40), above the fold.
   const source = makeElement(rect(100, -50, 20, 20), {
     visibleRect: rect(100, 340, 20, 20),
   });
@@ -173,9 +173,9 @@ test("drag with offset does not scroll a fully visible source", () => {
   assert.deepEqual(fromPointCalls, [{ x: 240, y: 110 }]);
 });
 
-test("drag with offset does not scroll a source wider than the viewport when its centre is visible", () => {
+test("drag with offset does not scroll a source wider than the viewport when its center is visible", () => {
   // rect spills past both horizontal edges (canvas/timeline case) but the
-  // centre (400,110) — the actual start point — is inside the 800x700
+  // center (400,110) — the actual start point — is inside the 800x700
   // viewport, so scrolling would only move a usable start point around.
   const source = makeElement(rect(-100, 100, 1000, 20));
   const dropTarget = makeElement(rect(500, 80, 100, 100));

--- a/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
@@ -1,0 +1,256 @@
+// Dependency-free behavioural tests for the bridge `drag` action (#130).
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// *real* file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation. #130 is about the offset path: it resolves the
+// drop point with `elementFromPoint`, which is viewport-bound, so a source
+// element outside the viewport made the lookup fail with a misleading
+// "No element at offset" error. The bridge must scroll the source into view
+// first, like a user would, and name the viewport in the residual error.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+// Real console methods, captured once so each bridge load re-wraps the
+// originals instead of stacking wrappers across tests.
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// Viewport-relative rect helper, mirroring getBoundingClientRect().
+function rect(left, top, width, height) {
+  return { left, top, width, height, right: left + width, bottom: top + height };
+}
+
+// Element mock recording dispatched events and scrollIntoView calls. When
+// `visibleRect` is given, scrollIntoView swaps the rect to it, simulating the
+// element entering the viewport.
+function makeElement(initialRect, { visibleRect } = {}) {
+  return {
+    _rect: initialRect,
+    dispatched: [],
+    scrollCalls: [],
+    getBoundingClientRect() {
+      return this._rect;
+    },
+    scrollIntoView(options) {
+      this.scrollCalls.push(options);
+      if (visibleRect) this._rect = visibleRect;
+    },
+    dispatchEvent(event) {
+      this.dispatched.push(event);
+      return true;
+    },
+  };
+}
+
+// Fresh globals + a fresh bridge instance for each test (the IIFE early-returns
+// if `window.__PILOT__` already exists, so `window` must be new every time).
+// `elements` maps selectors to mocks; `elementFromPoint` resolves drop points.
+function loadBridge({ elements = {}, elementFromPoint } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+
+  globalThis.htmlToImage = {
+    async toPng() {
+      return "data:image/png;base64,AAAA";
+    },
+  };
+
+  const fromPointCalls = [];
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    documentElement: { clientWidth: 800, clientHeight: 700 },
+    body: {},
+    querySelector(selector) {
+      return elements[selector] || null;
+    },
+    elementFromPoint(x, y) {
+      fromPointCalls.push({ x, y });
+      return elementFromPoint ? elementFromPoint(x, y) : null;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+
+  // drag() constructs DataTransfer, MouseEvent, and DragEvent.
+  globalThis.DataTransfer = class DataTransfer {
+    constructor() {
+      this.items = { add() {} };
+    }
+  };
+  class FakeUIEvent {
+    constructor(type, init) {
+      this.type = type;
+      Object.assign(this, init || {});
+    }
+  }
+  globalThis.MouseEvent = class MouseEvent extends FakeUIEvent {};
+  globalThis.DragEvent = class DragEvent extends FakeUIEvent {};
+
+  // Indirect eval runs in global scope; the IIFE then resolves bare `window`,
+  // `document`, etc. against the globals set above.
+  (0, eval)(BRIDGE_SRC);
+  return { pilot: globalThis.window.__PILOT__, fromPointCalls };
+}
+
+test("drag with offset scrolls a below-fold source into view before resolving the drop point", () => {
+  // Source centre starts at (110,1510), far below the 700px viewport. After
+  // scrollIntoView the centre lands at (110,350); offset (130,0) puts the drop
+  // point at (240,350).
+  const source = makeElement(rect(100, 1500, 20, 20), {
+    visibleRect: rect(100, 340, 20, 20),
+  });
+  const dropTarget = makeElement(rect(200, 300, 100, 100));
+  const { pilot, fromPointCalls } = loadBridge({
+    elements: { "#slider-thumb": source },
+    elementFromPoint: (x, y) => (x === 240 && y === 350 ? dropTarget : null),
+  });
+
+  const result = pilot.drag({
+    source: { selector: "#slider-thumb" },
+    offset: { x: 130, y: 0 },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(source.scrollCalls.length, 1);
+  // "instant" so a page-level `scroll-behavior: smooth` cannot turn the scroll
+  // into an animation that outlives the synchronous rect recompute below.
+  assert.deepEqual(source.scrollCalls[0], {
+    behavior: "instant",
+    block: "center",
+    inline: "center",
+  });
+  // The drop point must come from the post-scroll rect, not the stale one.
+  assert.deepEqual(fromPointCalls, [{ x: 240, y: 350 }]);
+  const drop = dropTarget.dispatched.find((e) => e.type === "drop");
+  assert.ok(drop, "drop event dispatched on the resolved target");
+  assert.equal(drop.clientX, 240);
+  assert.equal(drop.clientY, 350);
+});
+
+test("drag with offset scrolls an above-viewport source into view", () => {
+  // Source centre starts at (110,-40), above the fold.
+  const source = makeElement(rect(100, -50, 20, 20), {
+    visibleRect: rect(100, 340, 20, 20),
+  });
+  const dropTarget = makeElement(rect(200, 300, 100, 100));
+  const { pilot } = loadBridge({
+    elements: { "#thumb": source },
+    elementFromPoint: () => dropTarget,
+  });
+
+  const result = pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } });
+
+  assert.equal(result.ok, true);
+  assert.equal(source.scrollCalls.length, 1);
+});
+
+test("drag with offset does not scroll a fully visible source", () => {
+  const source = makeElement(rect(100, 100, 20, 20));
+  const dropTarget = makeElement(rect(200, 80, 100, 100));
+  const { pilot, fromPointCalls } = loadBridge({
+    elements: { "#thumb": source },
+    elementFromPoint: () => dropTarget,
+  });
+
+  const result = pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } });
+
+  assert.equal(result.ok, true);
+  assert.equal(source.scrollCalls.length, 0);
+  assert.deepEqual(fromPointCalls, [{ x: 240, y: 110 }]);
+});
+
+test("drag with offset does not scroll a source wider than the viewport when its centre is visible", () => {
+  // rect spills past both horizontal edges (canvas/timeline case) but the
+  // centre (400,110) — the actual start point — is inside the 800x700
+  // viewport, so scrolling would only move a usable start point around.
+  const source = makeElement(rect(-100, 100, 1000, 20));
+  const dropTarget = makeElement(rect(500, 80, 100, 100));
+  const { pilot, fromPointCalls } = loadBridge({
+    elements: { "#timeline": source },
+    elementFromPoint: () => dropTarget,
+  });
+
+  const result = pilot.drag({ source: { selector: "#timeline" }, offset: { x: 130, y: 0 } });
+
+  assert.equal(result.ok, true);
+  assert.equal(source.scrollCalls.length, 0);
+  assert.deepEqual(fromPointCalls, [{ x: 530, y: 110 }]);
+});
+
+test("drag with offset names the viewport when the drop point lands outside it", () => {
+  // Offset pushes the drop point to x=5110, past the 800px-wide viewport.
+  const source = makeElement(rect(100, 100, 20, 20));
+  const { pilot } = loadBridge({
+    elements: { "#thumb": source },
+    elementFromPoint: () => null,
+  });
+
+  assert.throws(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 5000, y: 0 } }),
+    /outside the viewport \(800x700\)/,
+  );
+});
+
+test("drag with offset reports the computed drop point when nothing is there", () => {
+  // Drop point (240,110) is inside the viewport but hits no element.
+  const source = makeElement(rect(100, 100, 20, 20));
+  const { pilot } = loadBridge({
+    elements: { "#thumb": source },
+    elementFromPoint: () => null,
+  });
+
+  assert.throws(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } }),
+    /No element at drop point \(240,110\)/,
+  );
+});
+
+test("drag with offset echoes a defaulted axis as 0 in the error, not undefined", () => {
+  // MCP passes the offset object through unvalidated, so {x:130} without y is
+  // reachable. The computation defaults y to 0; the message must match.
+  const source = makeElement(rect(100, 100, 20, 20));
+  const { pilot } = loadBridge({
+    elements: { "#thumb": source },
+    elementFromPoint: () => null,
+  });
+
+  assert.throws(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130 } }),
+    /for offset \(130,0\)/,
+  );
+});
+
+test("drag to a target element never scrolls and skips elementFromPoint", () => {
+  // Both elements below the fold: the target path dispatches directly on the
+  // resolved elements, so it works without scrolling and must stay that way.
+  const source = makeElement(rect(100, 1500, 20, 20));
+  const target = makeElement(rect(400, 1600, 100, 100));
+  const { pilot, fromPointCalls } = loadBridge({
+    elements: { "#card": source, "#column": target },
+  });
+
+  const result = pilot.drag({
+    source: { selector: "#card" },
+    target: { selector: "#column" },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(source.scrollCalls.length, 0);
+  assert.equal(target.scrollCalls.length, 0);
+  assert.equal(fromPointCalls.length, 0);
+  assert.ok(target.dispatched.some((e) => e.type === "drop"));
+});

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -652,10 +652,34 @@
       endX = targetRect.left + targetRect.width / 2;
       endY = targetRect.top + targetRect.height / 2;
     } else if (params.offset) {
-      endX = startX + (params.offset.x || 0);
-      endY = startY + (params.offset.y || 0);
+      // elementFromPoint below is viewport-bound: a start point outside the
+      // viewport would make the lookup miss (#130). Scroll the source into
+      // view first, like a user would, then recompute the start point.
+      // "instant" so a page-level `scroll-behavior: smooth` cannot defer the
+      // scroll past the synchronous rect recompute.
+      var docEl = document.documentElement;
+      var viewportWidth = docEl.clientWidth;
+      var viewportHeight = docEl.clientHeight;
+      if (startX < 0 || startY < 0 || startX >= viewportWidth || startY >= viewportHeight) {
+        source.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+        sourceRect = source.getBoundingClientRect();
+        startX = sourceRect.left + sourceRect.width / 2;
+        startY = sourceRect.top + sourceRect.height / 2;
+      }
+      var offsetX = params.offset.x || 0;
+      var offsetY = params.offset.y || 0;
+      endX = startX + offsetX;
+      endY = startY + offsetY;
       dropTarget = document.elementFromPoint(endX, endY);
-      if (!dropTarget) throw new Error("No element at offset (" + params.offset.x + "," + params.offset.y + ")");
+      if (!dropTarget) {
+        var pointLabel = "(" + Math.round(endX) + "," + Math.round(endY) + ")";
+        if (endX < 0 || endY < 0 || endX >= viewportWidth || endY >= viewportHeight) {
+          throw new Error("Drop point " + pointLabel + " is outside the viewport (" +
+            viewportWidth + "x" + viewportHeight + ") — reduce the offset");
+        }
+        throw new Error("No element at drop point " + pointLabel +
+          " for offset (" + offsetX + "," + offsetY + ")");
+      }
     } else {
       throw new Error("drag requires target or offset");
     }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -521,6 +521,8 @@ tauri-pilot drag <source> [target] [OPTIONS]
 |--------|-------------|
 | `--offset <X,Y>` | Drag by pixel offset instead of to an element (mutually exclusive with `[target]`) |
 
+With `--offset`, the drop point is resolved with `elementFromPoint`, which only hits elements inside the visible viewport. If the source element's centre — the drag start point — is outside the viewport, the bridge scrolls the element into view (centered) before computing coordinates. The offset itself must still land inside the viewport — an offset larger than the visible area fails with a `Drop point ... is outside the viewport` error.
+
 **Examples:**
 
 ```bash

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -521,7 +521,7 @@ tauri-pilot drag <source> [target] [OPTIONS]
 |--------|-------------|
 | `--offset <X,Y>` | Drag by pixel offset instead of to an element (mutually exclusive with `[target]`) |
 
-With `--offset`, the drop point is resolved with `elementFromPoint`, which only hits elements inside the visible viewport. If the source element's centre — the drag start point — is outside the viewport, the bridge scrolls the element into view (centered) before computing coordinates. The offset itself must still land inside the viewport — an offset larger than the visible area fails with a `Drop point ... is outside the viewport` error.
+With `--offset`, the drop point is resolved with `elementFromPoint`, which only hits elements inside the visible viewport. If the source element's center — the drag start point — is outside the viewport, the bridge scrolls the element into view (centered) before computing coordinates. The offset itself must still land inside the viewport — an offset larger than the visible area fails with a `Drop point ... is outside the viewport` error.
 
 **Examples:**
 


### PR DESCRIPTION
Closes #130.

## Why

`drag --offset` resolves the drop point with `elementFromPoint`, which only hit-tests the visible viewport. With the source element below the fold, the computed coordinates landed outside the viewport, the lookup returned null, and the command failed with "No element at offset (130,0)" — which reads like nothing exists at the destination when the real cause is the source being off-screen.

## Changes

- `drag()` offset path in `bridge.js`: when the source centre (the drag start point) is outside the viewport, scroll the element into view (`behavior: "instant"`, centered) and recompute the start point before resolving the drop target. The predicate is centre-based on purpose: an element wider than the viewport with a visible centre must not be recentered on every call. `instant` so a page-level `scroll-behavior: smooth` can't defer the scroll past the synchronous rect recompute.
- Split the residual error: drop point outside the viewport (names the viewport dimensions, suggests reducing the offset) vs no element at the computed point (echoes the defaulted offset values, so `{x:130}` without `y` prints `(130,0)`, not `(130,undefined)`).
- Target path untouched: it dispatches directly on resolved elements and never used `elementFromPoint`, so it works off-viewport already (per the issue).
- Docs: `cli.md` drag section notes the scroll behavior and the offset-must-land-in-viewport constraint.

## Testing

- New `bridge.drag.test.mjs` (8 tests): loads the shipping `bridge.js` into a mocked DOM. Covers below-fold and above-viewport sources (scroll + post-scroll coordinates), visible source (no scroll), wider-than-viewport source with visible centre (no scroll), both error messages, defaulted-axis echo, and the unchanged target path.
- `node --test`: 19/19 bridge tests pass.
- `cargo test --workspace`: 297 passed. `cargo clippy -- -D warnings`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrolls the source element into view before resolving offset drags so off-screen sources work reliably. Also improves error messages, updates CLI docs, and standardizes "center" spelling.

- **Bug Fixes**
  - In `bridge.js`, when using `--offset`, if the source center is outside the viewport, call `scrollIntoView({ behavior: "instant", block: "center", inline: "center" })`, recompute the start point, then apply the offset.
  - Skip scrolling when the source center is visible (e.g., wide elements spanning the viewport). The target-element path is unchanged.
  - Improve errors: distinguish “drop point outside the viewport (WxH)” from “no element at drop point (x,y)” and echo the computed point/offset.
  - Add `bridge.drag.test.mjs` covering below/above-fold sources, no-scroll cases, both error paths, and the unchanged target path. Update CLI docs to explain the viewport constraint and standardize on American “center” spelling.

<sup>Written for commit 2d27c8cf2d51bc6d4226eddcf35f7a78284d7542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drag now scrolls source elements into view before offset drags, preventing failures for offscreen sources.
  * Error messages now distinguish "drop point outside viewport" from "no element at the computed point" and report relevant coordinates/viewport.

* **Documentation**
  * Clarified drag/--offset behavior and viewport-related errors in CLI docs.

* **Tests**
  * Added a dependency-free test suite validating offset drag, scrolling behavior, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->