### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-05
+
 ### Fixed
 
 - Restore eval-based commands on macOS headless CI runners by delivering eval
@@ -487,7 +489,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/mpiton/tauri-pilot/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mpiton/tauri-pilot/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mpiton/tauri-pilot/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/mpiton/tauri-pilot/compare/v0.5.1...v0.5.2

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Patch release with the four fixes sitting in [Unreleased]:

- #126 — macOS eval results routed through the `__callback` IPC command (headless CI)
- #128 — stale `EvalEngine` doc comments updated to match
- #129 — `screenshot` without `--selector` now captures the full document height
- #130 — `drag --offset` scrolls the source into view before resolving the drop point

Both crates bumped to 0.7.1. CHANGELOG dated 2026-06-05 with compare links.

QA on main before this branch: full command sweep against pilot-test-app (fixes #129/#130 verified live), 297 workspace tests, clippy -D warnings clean, 19/19 bridge JS tests.

Tag v0.7.1 is intentionally not pushed — it gets created on main after merge, then pushed to trigger the release workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release v0.7.1 fixes headless macOS eval routing, full‑page screenshots, and drag offset scrolling. Also bumps `tauri-pilot-cli` and `tauri-plugin-pilot` to 0.7.1 and updates the changelog.

- **Bug Fixes**
  - Route macOS eval results through `__callback` for headless CI.
  - `screenshot` without `--selector` captures full document height.
  - `drag --offset` scrolls the source into view before resolving the drop point.

- **Refactors**
  - Update `EvalEngine` doc comments to match current behavior.

<sup>Written for commit cb0ba76f00de8cb616341e1823b23c0ae2d6146e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.7.1 with updated changelog and version declarations across project packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->