### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-10
+
 ### Added
 
 - `tauri-pilot --version` prints the CLI version. The flag was missing, so a
@@ -502,7 +504,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/mpiton/tauri-pilot/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/mpiton/tauri-pilot/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mpiton/tauri-pilot/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mpiton/tauri-pilot/compare/v0.5.2...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,3 +550,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#128]: https://github.com/mpiton/tauri-pilot/issues/128
 [#129]: https://github.com/mpiton/tauri-pilot/issues/129
 [#130]: https://github.com/mpiton/tauri-pilot/issues/130
+[#135]: https://github.com/mpiton/tauri-pilot/issues/135

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Release v0.7.2. Bundles #135 (version introspection) shipped via #136, bumps both crates to `0.7.2`, finalizes the changelog.

## Changes

- `tauri-pilot --version` prints the CLI version (#135)
- `ping` reports plugin + CLI versions side by side and warns when they drift; a missing `plugin_version` field flags a plugin <= 0.7.0 and points at an upgrade (#135)
- `state` output includes `plugin_version` (#135)
- plugin logs its version when the socket / named pipe starts listening (#135)
- both crates bumped `0.7.1` -> `0.7.2`
- CHANGELOG: dated `[0.7.2]`, added the `[#135]` reference link

## Testing

`./scripts/release.sh 0.7.2` ran `cargo check`, `cargo clippy -- -D warnings`, `cargo test --workspace` (146 passed), `cargo fmt`.

## Publish

After merge, push the tag to trigger the release workflow (crates.io + GitHub Release):

    git push origin v0.7.2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.7.2 adds version introspection across the CLI and plugin. Versions are now visible in commands and logs, with drift warnings to keep installs in sync.

- **New Features**
  - `tauri-pilot --version` prints the CLI version.
  - `ping` and `state` include plugin + CLI versions; warn when they differ or when the plugin is <= 0.7.0.
  - Plugin logs its version when the socket/named pipe starts listening.

- **Dependencies**
  - Bump `tauri-pilot-cli` and `tauri-plugin-pilot` to `0.7.2`; update the CHANGELOG and comparison links.

<sup>Written for commit 7bae4af85167e3594107dda036850133b394e6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.2 across packages

* **Documentation**
  * Changelog updated with 0.7.2 release information and reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->