### PR TITLE
fix(bridge): make drag a real pointer gesture so it drives JS drag libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   libraries cannot activate on, while still returning `ok: true`. A drag against a
   dnd-kit app therefore reported success and did nothing, which is the worst
   outcome for an agent asserting on it. The gesture now presses the deepest node
-  under the start point (library listeners commonly sit on an inner handle, and
-  events only bubble upward), streams interpolated `mousemove`/`pointermove`
-  events on `document` to clear distance thresholds, emits the HTML5 sequence as
-  before, and releases with `mouseup`/`pointerup`. `steps`, `stepDelayMs` and
-  `settleMs` params tune it; the result echoes `from`/`to`/`steps` and adds
-  `html5DropHandled` so a caller can see whether a native handler claimed the
-  drop. `ok` still means only that the gesture was delivered — assert the effect.
+  under the start point when that node is inside the source (library listeners
+  commonly sit on an inner handle, and events only bubble upward; an overlay over
+  the source is ignored), streams interpolated `pointermove`/`mousemove` events
+  hit-tested at each step, emits the HTML5 sequence as before, and releases with
+  `pointerup`/`mouseup`. Every pointer event precedes its compatibility mouse
+  event, as a browser produces them. `steps`, `stepDelayMs` and `settleMs` params
+  tune it over JSON-RPC and MCP, and the Rust-side eval timeout now covers the
+  gesture they describe instead of a flat 10 s. The result echoes
+  `from`/`to`/`steps` and adds `html5DropHandled` so a caller can see whether a
+  native handler claimed the drop. `ok` still means only that the gesture was
+  delivered — assert the effect.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `drag` now performs a real pointer gesture, so it drives JS drag libraries
+  (dnd-kit, sortable.js, interact.js, react-dnd's mouse backend) instead of only
+  HTML5 `draggable="true"` handlers. Previously it dispatched HTML5 DragEvents
+  plus a single `mousedown` — no `mousemove` stream and no `mouseup` — which those
+  libraries cannot activate on, while still returning `ok: true`. A drag against a
+  dnd-kit app therefore reported success and did nothing, which is the worst
+  outcome for an agent asserting on it. The gesture now presses the deepest node
+  under the start point (library listeners commonly sit on an inner handle, and
+  events only bubble upward), streams interpolated `mousemove`/`pointermove`
+  events on `document` to clear distance thresholds, emits the HTML5 sequence as
+  before, and releases with `mouseup`/`pointerup`. `steps`, `stepDelayMs` and
+  `settleMs` params tune it; the result echoes `from`/`to`/`steps` and adds
+  `html5DropHandled` so a caller can see whether a native handler claimed the
+  drop. `ok` still means only that the gesture was delivered — assert the effect.
+
 ### Security
 
 - Upgrade the docs site to Astro 7.1.5 (from 6.3.2), Starlight 0.41.5 and sharp

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ the JavaScript do not need escaping.
 | `select` | Select a dropdown option |
 | `check` | Toggle a checkbox |
 | `scroll` | Scroll page or element |
-| `drag` | Drag element to element or by offset |
+| `drag` | Drag element to element or by offset (drives HTML5 *and* dnd-kit-style libraries) |
 | `drop` | Simulate file drop on element |
 | `text` | Get element text content |
 | `html` | Get element innerHTML |

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,7 +98,7 @@ Three target formats, auto-detected:
 | `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 
 `drag` emits an HTML5 drag sequence *and* a real press → interpolated
-`mousemove`/`pointermove` stream on `document` → release, so it drives both native
+`pointermove`/`mousemove` stream → release, so it drives both native
 `draggable="true"` handlers and libraries like dnd-kit or sortable.js. Its `ok`
 means the gesture was delivered, not that the app reacted — assert the expected
 effect afterwards.

--- a/SKILL.md
+++ b/SKILL.md
@@ -97,6 +97,12 @@ Three target formats, auto-detected:
 | `drag <source> [target] [--offset X,Y]` | `drag @e5 @e8` |
 | `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 
+`drag` emits an HTML5 drag sequence *and* a real press → interpolated
+`mousemove`/`pointermove` stream on `document` → release, so it drives both native
+`draggable="true"` handlers and libraries like dnd-kit or sortable.js. Its `ok`
+means the gesture was delivered, not that the app reacted — assert the expected
+effect afterwards.
+
 ### Assertions
 
 | Command | Example |

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -215,6 +215,13 @@ impl PilotMcpServer {
                         params["offset"] = offset;
                     }
                 }
+                // Gesture tunables are optional; the bridge applies its own
+                // defaults and clamps when they are absent.
+                for key in ["steps", "stepDelayMs", "settleMs"] {
+                    if let Some(value) = optional_i32(&args, key)? {
+                        params[key] = json!(value);
+                    }
+                }
                 self.call_app_tool("drag", Some(params), window).await
             }
             "drop" => self.call_drop_tool(args, window).await,
@@ -1423,6 +1430,20 @@ fn drag_schema() -> Arc<JsonObject> {
                 "offset",
                 any_prop("Optional offset object such as {\"x\": 0, \"y\": 100}."),
             ),
+            (
+                "steps",
+                integer_prop("Move events to emit, 1-60 (default 12)."),
+            ),
+            (
+                "stepDelayMs",
+                integer_prop("Pause between move events in ms (default 16)."),
+            ),
+            (
+                "settleMs",
+                integer_prop(
+                    "Wait after the release in ms, for async state updates to land (default 250).",
+                ),
+            ),
         ]),
         &["source"],
     )
@@ -1948,6 +1969,64 @@ mod tests {
 
         server.await.expect("mock server task");
         let _ = std::fs::remove_file(&socket);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn drag_forwards_gesture_tunables_to_the_bridge() {
+        // The docs advertise steps/stepDelayMs/settleMs over MCP; they only work
+        // if the rebuilt params object carries them through to the bridge.
+        let socket = std::env::temp_dir().join(format!(
+            "tauri-pilot-mcp-drag-tunables-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read request");
+            let request: Request = serde_json::from_str(line.trim()).expect("parse request");
+            assert_eq!(request.method, "drag");
+            let params = request.params.expect("drag params present");
+            assert_eq!(params["steps"], json!(30));
+            assert_eq!(params["stepDelayMs"], json!(40));
+            assert_eq!(params["settleMs"], json!(1_500));
+            let response = Response::success(request.id, json!({"ok": true}));
+            let mut bytes = serde_json::to_vec(&response).expect("serialize response");
+            bytes.push(b'\n');
+            writer.write_all(&bytes).await.expect("write response");
+        });
+
+        let pilot = PilotMcpServer::new(Some(socket.clone()), None);
+        let mut args = Map::new();
+        args.insert("source".to_owned(), json!("@e5"));
+        args.insert("target".to_owned(), json!("@e8"));
+        args.insert("steps".to_owned(), json!(30));
+        args.insert("stepDelayMs".to_owned(), json!(40));
+        args.insert("settleMs".to_owned(), json!(1_500));
+        let result = pilot
+            .call_tool_by_name("drag", args)
+            .await
+            .expect("tool call succeeds");
+        assert_eq!(result.is_error, Some(false));
+
+        server.await.expect("mock server task");
+        let _ = std::fs::remove_file(&socket);
+    }
+
+    #[test]
+    fn drag_schema_declares_the_documented_tunables() {
+        let schema = drag_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema has properties");
+        for key in ["steps", "stepDelayMs", "settleMs"] {
+            assert!(properties.contains_key(key), "drag schema is missing {key}");
+        }
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
@@ -1,4 +1,4 @@
-// Dependency-free behavioural tests for the bridge `drag` action (#130, #141).
+// Dependency-free behavioural tests for the bridge `drag` action (#130).
 //
 // bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
 // *real* file into a minimal global mock so these tests exercise the shipping
@@ -10,7 +10,7 @@
 // The bridge must scroll the source into view first, like a user would, and name
 // the viewport in the residual error.
 //
-// #141 is about what the gesture actually contains. HTML5 DragEvents alone drive
+// The gesture's contents matter just as much. HTML5 DragEvents alone drive
 // only `draggable="true"` handlers; JS drag libraries (dnd-kit, sortable.js,
 // interact.js, react-dnd's mouse backend) activate on mousedown and then track
 // repeated mousemove/pointermove on `document` before committing on mouseup. The
@@ -50,11 +50,16 @@ function rect(left, top, width, height) {
 // Element mock recording dispatched events and scrollIntoView calls. When
 // `visibleRect` is given, scrollIntoView swaps the rect to it, simulating the
 // element entering the viewport.
-function makeElement(initialRect, { visibleRect, cancelDrop = false } = {}) {
+function makeElement(initialRect, { visibleRect, cancelDrop = false, descendants = [] } = {}) {
   return {
     _rect: initialRect,
     dispatched: [],
     scrollCalls: [],
+    // The press target is gated on containment, so the mock needs the real
+    // Node.contains() semantics: an element contains itself and its subtree.
+    contains(node) {
+      return node === this || descendants.includes(node);
+    },
     getBoundingClientRect() {
       return this._rect;
     },
@@ -165,7 +170,8 @@ test("drag with offset scrolls a below-fold source into view before resolving th
   });
   // The drop point must come from the post-scroll rect, not the stale one. The
   // second lookup is the press target (deepest node under the start point).
-  assert.deepEqual(fromPointCalls, [
+  // Moves hit-test too, so only the leading pair is the drop point + press target.
+  assert.deepEqual(fromPointCalls.slice(0, 2), [
     { x: 240, y: 350 },
     { x: 110, y: 350 },
   ]);
@@ -204,7 +210,7 @@ test("drag with offset does not scroll a fully visible source", async () => {
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
-  assert.deepEqual(fromPointCalls, [
+  assert.deepEqual(fromPointCalls.slice(0, 2), [
     { x: 240, y: 110 },
     { x: 110, y: 110 },
   ]);
@@ -225,7 +231,7 @@ test("drag with offset does not scroll a source wider than the viewport when its
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
-  assert.deepEqual(fromPointCalls, [
+  assert.deepEqual(fromPointCalls.slice(0, 2), [
     { x: 530, y: 110 },
     { x: 400, y: 110 },
   ]);
@@ -277,7 +283,8 @@ test("drag with offset echoes a defaulted axis as 0 in the error, not undefined"
 test("drag to a target element never scrolls and resolves only the press target", async () => {
   // Both elements below the fold: the target path dispatches directly on the
   // resolved elements, so it works without scrolling and must stay that way.
-  // The single elementFromPoint call is the press target, not the drop point.
+  // The first elementFromPoint call is the press target, not the drop point;
+  // the rest are the per-move hit tests.
   const source = makeElement(rect(100, 1500, 20, 20));
   const target = makeElement(rect(400, 1600, 100, 100));
   const { pilot, fromPointCalls } = loadBridge({
@@ -293,11 +300,11 @@ test("drag to a target element never scrolls and resolves only the press target"
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
   assert.equal(target.scrollCalls.length, 0);
-  assert.deepEqual(fromPointCalls, [{ x: 110, y: 1510 }]);
+  assert.deepEqual(fromPointCalls[0], { x: 110, y: 1510 });
   assert.ok(target.dispatched.some((e) => e.type === "drop"));
 });
 
-// ── #141: the gesture must also drive JS drag libraries ──────────────────────
+// ── the gesture must also drive JS drag libraries ────────────────────────────
 
 test("drag presses, streams moves on document, and releases", async () => {
   const source = makeElement(rect(0, 0, 100, 100));
@@ -313,8 +320,11 @@ test("drag presses, streams moves on document, and releases", async () => {
   const docTypes = types(doc);
   assert.deepEqual(docTypes.filter((t) => t === "mousemove").length, 4);
   assert.deepEqual(docTypes.filter((t) => t === "pointermove").length, 4);
-  assert.equal(docTypes.at(-2), "mouseup");
-  assert.equal(docTypes.at(-1), "pointerup");
+  // Pointer events lead, their compatibility mouse events follow — the order a
+  // browser produces, and the one `click()` already uses.
+  assert.deepEqual(docTypes.slice(0, 2), ["pointermove", "mousemove"]);
+  assert.equal(docTypes.at(-2), "pointerup");
+  assert.equal(docTypes.at(-1), "mouseup");
   assert.ok(
     docTypes.indexOf("mousemove") < docTypes.indexOf("mouseup"),
     "moves precede the release",
@@ -335,9 +345,9 @@ test("drag presses, streams moves on document, and releases", async () => {
 test("drag presses the deepest node under the point, not the resolved container", async () => {
   // dnd-kit and friends attach listeners to an inner handle/card; events only
   // bubble upward, so pressing the container never reaches them.
-  const source = makeElement(rect(0, 0, 100, 100));
-  const target = makeElement(rect(200, 200, 100, 100));
   const handle = makeElement(rect(40, 40, 20, 20));
+  const source = makeElement(rect(0, 0, 100, 100), { descendants: [handle] });
+  const target = makeElement(rect(200, 200, 100, 100));
   const { pilot } = loadBridge({
     elements: { "#a": source, "#b": target },
     elementFromPoint: () => handle,
@@ -345,10 +355,28 @@ test("drag presses the deepest node under the point, not the resolved container"
 
   await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
 
-  assert.deepEqual(types(handle), ["mousedown", "pointerdown"]);
+  assert.deepEqual(types(handle).slice(0, 2), ["pointerdown", "mousedown"]);
   assert.ok(!types(source).includes("mousedown"), "container is not pressed directly");
   // The HTML5 sequence still belongs to the resolved source element.
   assert.ok(types(source).includes("dragstart"));
+});
+
+test("drag ignores an overlay covering the start point and presses the source", async () => {
+  // A toast, backdrop or modal over the source is what elementFromPoint returns.
+  // Pressing it would send the gesture somewhere unrelated while `drag` still
+  // reported ok — the false green this action exists to remove.
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const overlay = makeElement(rect(0, 0, 800, 700));
+  const { pilot } = loadBridge({
+    elements: { "#a": source, "#b": target },
+    elementFromPoint: () => overlay,
+  });
+
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
+
+  assert.ok(!types(overlay).includes("pointerdown"), "overlay is not pressed");
+  assert.deepEqual(types(source).slice(0, 2), ["pointerdown", "mousedown"]);
 });
 
 test("drag falls back to the resolved source when nothing is hit-testable", async () => {
@@ -361,7 +389,7 @@ test("drag falls back to the resolved source when nothing is hit-testable", asyn
 
   await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
 
-  assert.ok(types(source).includes("mousedown"));
+  assert.deepEqual(types(source).slice(0, 2), ["pointerdown", "mousedown"]);
 });
 
 test("drag still emits the full HTML5 sequence in order", async () => {
@@ -405,7 +433,12 @@ test("drag reports whether an HTML5 handler claimed the drop", async () => {
   assert.equal(handled.html5DropHandled, true);
 });
 
-test("drag degrades to mouse-only events when PointerEvent is unavailable", async () => {
+test("drag still emits pointer-typed events when the PointerEvent constructor is missing", async () => {
+  // A WebView without `PointerEvent` must not silently lose the pointer stream:
+  // dnd-kit's default sensor is PointerSensor, so mouse events alone would leave
+  // the very libraries this gesture targets unable to activate. Listeners
+  // dispatch by type string, so a MouseEvent typed `pointermove` still reaches
+  // an addEventListener("pointermove", …).
   const source = makeElement(rect(0, 0, 100, 100));
   const target = makeElement(rect(200, 200, 100, 100));
   const { pilot, document: doc } = loadBridge({
@@ -421,8 +454,12 @@ test("drag degrades to mouse-only events when PointerEvent is unavailable", asyn
   });
 
   assert.equal(result.ok, true);
-  assert.ok(!types(doc).some((t) => t.startsWith("pointer")), "no pointer events emitted");
+  assert.equal(types(doc).filter((t) => t === "pointermove").length, 2);
   assert.equal(types(doc).filter((t) => t === "mousemove").length, 2);
+  const pointerMove = doc.dispatched.find((e) => e.type === "pointermove");
+  assert.ok(pointerMove instanceof MouseEvent, "falls back to a MouseEvent, not a throw");
+  assert.equal(pointerMove.pointerId, 1);
+  assert.equal(pointerMove.pointerType, "mouse");
 });
 
 test("drag clamps a hostile or missing step count", async () => {
@@ -467,6 +504,27 @@ test("drag reports the gesture endpoints it used", async () => {
 
   assert.deepEqual(result.from, { x: 50, y: 50 });
   assert.deepEqual(result.to, { x: 250, y: 350 });
+});
+
+test("drag does not pay a step delay after the last move", async () => {
+  // The delay spaces moves apart, so N moves need N-1 gaps. Sleeping after the
+  // last one only pushes the drop sequence back for nothing.
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot } = loadBridge({ elements: { "#a": source, "#b": target } });
+
+  const started = Date.now();
+  await pilot.drag({
+    source: { selector: "#a" },
+    target: { selector: "#b" },
+    steps: 3,
+    stepDelayMs: 100,
+    settleMs: 0,
+  });
+  const elapsed = Date.now() - started;
+
+  assert.ok(elapsed >= 200, `three moves need two gaps, got ${elapsed}ms`);
+  assert.ok(elapsed < 300, `a fourth gap was paid after the last move (${elapsed}ms)`);
 });
 
 test("drag waits between moves and settles after the release by default", async () => {

--- a/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
@@ -1,12 +1,21 @@
-// Dependency-free behavioural tests for the bridge `drag` action (#130).
+// Dependency-free behavioural tests for the bridge `drag` action (#130, #141).
 //
 // bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
 // *real* file into a minimal global mock so these tests exercise the shipping
-// code, not a re-implementation. #130 is about the offset path: it resolves the
-// drop point with `elementFromPoint`, which is viewport-bound, so a source
-// element outside the viewport made the lookup fail with a misleading
-// "No element at offset" error. The bridge must scroll the source into view
-// first, like a user would, and name the viewport in the residual error.
+// code, not a re-implementation.
+//
+// #130 is about the offset path: it resolves the drop point with
+// `elementFromPoint`, which is viewport-bound, so a source element outside the
+// viewport made the lookup fail with a misleading "No element at offset" error.
+// The bridge must scroll the source into view first, like a user would, and name
+// the viewport in the residual error.
+//
+// #141 is about what the gesture actually contains. HTML5 DragEvents alone drive
+// only `draggable="true"` handlers; JS drag libraries (dnd-kit, sortable.js,
+// interact.js, react-dnd's mouse backend) activate on mousedown and then track
+// repeated mousemove/pointermove on `document` before committing on mouseup. The
+// gesture must satisfy both, and must press the deepest node under the point
+// because library listeners commonly sit on an inner handle.
 //
 // Run: node --test crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
 
@@ -22,11 +31,16 @@ const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
 // Real console methods, captured once so each bridge load re-wraps the
 // originals instead of stacking wrappers across tests.
 const REAL_CONSOLE = {
-  log: console.log.bind(console),
-  warn: console.warn.bind(console),
-  error: console.error.bind(console),
-  info: console.info.bind(console),
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
 };
+
+// Keep the suite quick: the gesture's inter-step and settle delays are real
+// timers, and they are covered explicitly by their own tests.
+const FAST = { stepDelayMs: 0, settleMs: 0 };
 
 // Viewport-relative rect helper, mirroring getBoundingClientRect().
 function rect(left, top, width, height) {
@@ -36,7 +50,7 @@ function rect(left, top, width, height) {
 // Element mock recording dispatched events and scrollIntoView calls. When
 // `visibleRect` is given, scrollIntoView swaps the rect to it, simulating the
 // element entering the viewport.
-function makeElement(initialRect, { visibleRect } = {}) {
+function makeElement(initialRect, { visibleRect, cancelDrop = false } = {}) {
   return {
     _rect: initialRect,
     dispatched: [],
@@ -50,7 +64,8 @@ function makeElement(initialRect, { visibleRect } = {}) {
     },
     dispatchEvent(event) {
       this.dispatched.push(event);
-      return true;
+      // dispatchEvent returns false when a cancelable event was preventDefault-ed.
+      return !(cancelDrop && event.type === "drop");
     },
   };
 }
@@ -58,7 +73,7 @@ function makeElement(initialRect, { visibleRect } = {}) {
 // Fresh globals + a fresh bridge instance for each test (the IIFE early-returns
 // if `window.__PILOT__` already exists, so `window` must be new every time).
 // `elements` maps selectors to mocks; `elementFromPoint` resolves drop points.
-function loadBridge({ elements = {}, elementFromPoint } = {}) {
+function loadBridge({ elements = {}, elementFromPoint, pointerEvents = true } = {}) {
   Object.assign(console, REAL_CONSOLE);
 
   globalThis.htmlToImage = {
@@ -72,6 +87,13 @@ function loadBridge({ elements = {}, elementFromPoint } = {}) {
   globalThis.document = {
     documentElement: { clientWidth: 800, clientHeight: 700 },
     body: {},
+    // The gesture's move/release events go to `document`, so it needs to record
+    // them like any other node.
+    dispatched: [],
+    dispatchEvent(event) {
+      this.dispatched.push(event);
+      return true;
+    },
     querySelector(selector) {
       return elements[selector] || null;
     },
@@ -85,7 +107,7 @@ function loadBridge({ elements = {}, elementFromPoint } = {}) {
   XMLHttpRequestStub.prototype.send = function () {};
   globalThis.XMLHttpRequest = XMLHttpRequestStub;
 
-  // drag() constructs DataTransfer, MouseEvent, and DragEvent.
+  // drag() constructs DataTransfer, MouseEvent, PointerEvent, and DragEvent.
   globalThis.DataTransfer = class DataTransfer {
     constructor() {
       this.items = { add() {} };
@@ -99,14 +121,21 @@ function loadBridge({ elements = {}, elementFromPoint } = {}) {
   }
   globalThis.MouseEvent = class MouseEvent extends FakeUIEvent {};
   globalThis.DragEvent = class DragEvent extends FakeUIEvent {};
+  if (pointerEvents) {
+    globalThis.PointerEvent = class PointerEvent extends FakeUIEvent {};
+  } else {
+    delete globalThis.PointerEvent;
+  }
 
   // Indirect eval runs in global scope; the IIFE then resolves bare `window`,
   // `document`, etc. against the globals set above.
   (0, eval)(BRIDGE_SRC);
-  return { pilot: globalThis.window.__PILOT__, fromPointCalls };
+  return { pilot: globalThis.window.__PILOT__, fromPointCalls, document: globalThis.document };
 }
 
-test("drag with offset scrolls a below-fold source into view before resolving the drop point", () => {
+const types = (node) => node.dispatched.map((e) => e.type);
+
+test("drag with offset scrolls a below-fold source into view before resolving the drop point", async () => {
   // Source center starts at (110,1510), far below the 700px viewport. After
   // scrollIntoView the center lands at (110,350); offset (130,0) puts the drop
   // point at (240,350).
@@ -116,12 +145,13 @@ test("drag with offset scrolls a below-fold source into view before resolving th
   const dropTarget = makeElement(rect(200, 300, 100, 100));
   const { pilot, fromPointCalls } = loadBridge({
     elements: { "#slider-thumb": source },
-    elementFromPoint: (x, y) => (x === 240 && y === 350 ? dropTarget : null),
+    elementFromPoint: (x, y) => (x === 240 && y === 350 ? dropTarget : source),
   });
 
-  const result = pilot.drag({
+  const result = await pilot.drag({
     source: { selector: "#slider-thumb" },
     offset: { x: 130, y: 0 },
+    ...FAST,
   });
 
   assert.equal(result.ok, true);
@@ -133,15 +163,19 @@ test("drag with offset scrolls a below-fold source into view before resolving th
     block: "center",
     inline: "center",
   });
-  // The drop point must come from the post-scroll rect, not the stale one.
-  assert.deepEqual(fromPointCalls, [{ x: 240, y: 350 }]);
+  // The drop point must come from the post-scroll rect, not the stale one. The
+  // second lookup is the press target (deepest node under the start point).
+  assert.deepEqual(fromPointCalls, [
+    { x: 240, y: 350 },
+    { x: 110, y: 350 },
+  ]);
   const drop = dropTarget.dispatched.find((e) => e.type === "drop");
   assert.ok(drop, "drop event dispatched on the resolved target");
   assert.equal(drop.clientX, 240);
   assert.equal(drop.clientY, 350);
 });
 
-test("drag with offset scrolls an above-viewport source into view", () => {
+test("drag with offset scrolls an above-viewport source into view", async () => {
   // Source center starts at (110,-40), above the fold.
   const source = makeElement(rect(100, -50, 20, 20), {
     visibleRect: rect(100, 340, 20, 20),
@@ -152,13 +186,13 @@ test("drag with offset scrolls an above-viewport source into view", () => {
     elementFromPoint: () => dropTarget,
   });
 
-  const result = pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } });
+  const result = await pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 }, ...FAST });
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 1);
 });
 
-test("drag with offset does not scroll a fully visible source", () => {
+test("drag with offset does not scroll a fully visible source", async () => {
   const source = makeElement(rect(100, 100, 20, 20));
   const dropTarget = makeElement(rect(200, 80, 100, 100));
   const { pilot, fromPointCalls } = loadBridge({
@@ -166,14 +200,17 @@ test("drag with offset does not scroll a fully visible source", () => {
     elementFromPoint: () => dropTarget,
   });
 
-  const result = pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } });
+  const result = await pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 }, ...FAST });
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
-  assert.deepEqual(fromPointCalls, [{ x: 240, y: 110 }]);
+  assert.deepEqual(fromPointCalls, [
+    { x: 240, y: 110 },
+    { x: 110, y: 110 },
+  ]);
 });
 
-test("drag with offset does not scroll a source wider than the viewport when its center is visible", () => {
+test("drag with offset does not scroll a source wider than the viewport when its center is visible", async () => {
   // rect spills past both horizontal edges (canvas/timeline case) but the
   // center (400,110) — the actual start point — is inside the 800x700
   // viewport, so scrolling would only move a usable start point around.
@@ -184,14 +221,17 @@ test("drag with offset does not scroll a source wider than the viewport when its
     elementFromPoint: () => dropTarget,
   });
 
-  const result = pilot.drag({ source: { selector: "#timeline" }, offset: { x: 130, y: 0 } });
+  const result = await pilot.drag({ source: { selector: "#timeline" }, offset: { x: 130, y: 0 }, ...FAST });
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
-  assert.deepEqual(fromPointCalls, [{ x: 530, y: 110 }]);
+  assert.deepEqual(fromPointCalls, [
+    { x: 530, y: 110 },
+    { x: 400, y: 110 },
+  ]);
 });
 
-test("drag with offset names the viewport when the drop point lands outside it", () => {
+test("drag with offset names the viewport when the drop point lands outside it", async () => {
   // Offset pushes the drop point to x=5110, past the 800px-wide viewport.
   const source = makeElement(rect(100, 100, 20, 20));
   const { pilot } = loadBridge({
@@ -199,13 +239,13 @@ test("drag with offset names the viewport when the drop point lands outside it",
     elementFromPoint: () => null,
   });
 
-  assert.throws(
-    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 5000, y: 0 } }),
+  await assert.rejects(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 5000, y: 0 }, ...FAST }),
     /outside the viewport \(800x700\)/,
   );
 });
 
-test("drag with offset reports the computed drop point when nothing is there", () => {
+test("drag with offset reports the computed drop point when nothing is there", async () => {
   // Drop point (240,110) is inside the viewport but hits no element.
   const source = makeElement(rect(100, 100, 20, 20));
   const { pilot } = loadBridge({
@@ -213,13 +253,13 @@ test("drag with offset reports the computed drop point when nothing is there", (
     elementFromPoint: () => null,
   });
 
-  assert.throws(
-    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 } }),
+  await assert.rejects(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130, y: 0 }, ...FAST }),
     /No element at drop point \(240,110\)/,
   );
 });
 
-test("drag with offset echoes a defaulted axis as 0 in the error, not undefined", () => {
+test("drag with offset echoes a defaulted axis as 0 in the error, not undefined", async () => {
   // MCP passes the offset object through unvalidated, so {x:130} without y is
   // reachable. The computation defaults y to 0; the message must match.
   const source = makeElement(rect(100, 100, 20, 20));
@@ -228,29 +268,215 @@ test("drag with offset echoes a defaulted axis as 0 in the error, not undefined"
     elementFromPoint: () => null,
   });
 
-  assert.throws(
-    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130 } }),
+  await assert.rejects(
+    () => pilot.drag({ source: { selector: "#thumb" }, offset: { x: 130 }, ...FAST }),
     /for offset \(130,0\)/,
   );
 });
 
-test("drag to a target element never scrolls and skips elementFromPoint", () => {
+test("drag to a target element never scrolls and resolves only the press target", async () => {
   // Both elements below the fold: the target path dispatches directly on the
   // resolved elements, so it works without scrolling and must stay that way.
+  // The single elementFromPoint call is the press target, not the drop point.
   const source = makeElement(rect(100, 1500, 20, 20));
   const target = makeElement(rect(400, 1600, 100, 100));
   const { pilot, fromPointCalls } = loadBridge({
     elements: { "#card": source, "#column": target },
   });
 
-  const result = pilot.drag({
+  const result = await pilot.drag({
     source: { selector: "#card" },
     target: { selector: "#column" },
+    ...FAST,
   });
 
   assert.equal(result.ok, true);
   assert.equal(source.scrollCalls.length, 0);
   assert.equal(target.scrollCalls.length, 0);
-  assert.equal(fromPointCalls.length, 0);
+  assert.deepEqual(fromPointCalls, [{ x: 110, y: 1510 }]);
   assert.ok(target.dispatched.some((e) => e.type === "drop"));
+});
+
+// ── #141: the gesture must also drive JS drag libraries ──────────────────────
+
+test("drag presses, streams moves on document, and releases", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot, document: doc } = loadBridge({
+    elements: { "#a": source, "#b": target },
+  });
+
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, steps: 4, ...FAST });
+
+  // Library activation needs the press, then *several* moves past a distance
+  // threshold, then the release — in that order.
+  const docTypes = types(doc);
+  assert.deepEqual(docTypes.filter((t) => t === "mousemove").length, 4);
+  assert.deepEqual(docTypes.filter((t) => t === "pointermove").length, 4);
+  assert.equal(docTypes.at(-2), "mouseup");
+  assert.equal(docTypes.at(-1), "pointerup");
+  assert.ok(
+    docTypes.indexOf("mousemove") < docTypes.indexOf("mouseup"),
+    "moves precede the release",
+  );
+
+  // Moves interpolate from the source center to the target center so a
+  // threshold-based sensor sees real displacement.
+  const moves = doc.dispatched.filter((e) => e.type === "mousemove");
+  assert.deepEqual(
+    { x: moves.at(-1).clientX, y: moves.at(-1).clientY },
+    { x: 250, y: 250 },
+  );
+  assert.ok(moves[0].clientX > 50, "first move already left the start point");
+  // A held button must be reported, or listeners treat the move as a hover.
+  assert.equal(moves[0].buttons, 1);
+});
+
+test("drag presses the deepest node under the point, not the resolved container", async () => {
+  // dnd-kit and friends attach listeners to an inner handle/card; events only
+  // bubble upward, so pressing the container never reaches them.
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const handle = makeElement(rect(40, 40, 20, 20));
+  const { pilot } = loadBridge({
+    elements: { "#a": source, "#b": target },
+    elementFromPoint: () => handle,
+  });
+
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
+
+  assert.deepEqual(types(handle), ["mousedown", "pointerdown"]);
+  assert.ok(!types(source).includes("mousedown"), "container is not pressed directly");
+  // The HTML5 sequence still belongs to the resolved source element.
+  assert.ok(types(source).includes("dragstart"));
+});
+
+test("drag falls back to the resolved source when nothing is hit-testable", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot } = loadBridge({
+    elements: { "#a": source, "#b": target },
+    elementFromPoint: () => null,
+  });
+
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
+
+  assert.ok(types(source).includes("mousedown"));
+});
+
+test("drag still emits the full HTML5 sequence in order", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot } = loadBridge({
+    elements: { "#a": source, "#b": target },
+  });
+
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" }, ...FAST });
+
+  assert.deepEqual(
+    types(source).filter((t) => t.startsWith("drag")),
+    ["dragstart", "dragleave", "dragend"],
+  );
+  assert.deepEqual(types(target), ["dragenter", "dragover", "drop"]);
+});
+
+test("drag reports whether an HTML5 handler claimed the drop", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const plain = makeElement(rect(200, 200, 100, 100));
+  const claiming = makeElement(rect(200, 200, 100, 100), { cancelDrop: true });
+
+  const first = loadBridge({ elements: { "#a": source, "#b": plain } });
+  const ignored = await first.pilot.drag({
+    source: { selector: "#a" },
+    target: { selector: "#b" },
+    ...FAST,
+  });
+  assert.equal(ignored.html5DropHandled, false);
+
+  const second = loadBridge({ elements: { "#a": makeElement(rect(0, 0, 100, 100)), "#b": claiming } });
+  const handled = await second.pilot.drag({
+    source: { selector: "#a" },
+    target: { selector: "#b" },
+    ...FAST,
+  });
+  // `ok` only means the gesture was delivered; this flag is the one real signal
+  // the bridge can observe about whether anything reacted.
+  assert.equal(handled.ok, true);
+  assert.equal(handled.html5DropHandled, true);
+});
+
+test("drag degrades to mouse-only events when PointerEvent is unavailable", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot, document: doc } = loadBridge({
+    elements: { "#a": source, "#b": target },
+    pointerEvents: false,
+  });
+
+  const result = await pilot.drag({
+    source: { selector: "#a" },
+    target: { selector: "#b" },
+    steps: 2,
+    ...FAST,
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(!types(doc).some((t) => t.startsWith("pointer")), "no pointer events emitted");
+  assert.equal(types(doc).filter((t) => t === "mousemove").length, 2);
+});
+
+test("drag clamps a hostile or missing step count", async () => {
+  const cases = [
+    [undefined, 12],
+    [0, 12],
+    [-5, 12],
+    ["nonsense", 12],
+    [3.7, 3],
+    [500, 60],
+  ];
+
+  for (const [steps, expected] of cases) {
+    const source = makeElement(rect(0, 0, 100, 100));
+    const target = makeElement(rect(200, 200, 100, 100));
+    const { pilot, document: doc } = loadBridge({
+      elements: { "#a": source, "#b": target },
+    });
+
+    const result = await pilot.drag({
+      source: { selector: "#a" },
+      target: { selector: "#b" },
+      steps,
+      ...FAST,
+    });
+
+    assert.equal(result.steps, expected, `steps=${steps}`);
+    assert.equal(types(doc).filter((t) => t === "mousemove").length, expected);
+  }
+});
+
+test("drag reports the gesture endpoints it used", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 300, 100, 100));
+  const { pilot } = loadBridge({ elements: { "#a": source, "#b": target } });
+
+  const result = await pilot.drag({
+    source: { selector: "#a" },
+    target: { selector: "#b" },
+    ...FAST,
+  });
+
+  assert.deepEqual(result.from, { x: 50, y: 50 });
+  assert.deepEqual(result.to, { x: 250, y: 350 });
+});
+
+test("drag waits between moves and settles after the release by default", async () => {
+  const source = makeElement(rect(0, 0, 100, 100));
+  const target = makeElement(rect(200, 200, 100, 100));
+  const { pilot } = loadBridge({ elements: { "#a": source, "#b": target } });
+
+  // Defaults: 12 steps x 16ms plus a 250ms settle. Async framework work (state
+  // update, request, re-render) needs that beat before a caller asserts.
+  const started = Date.now();
+  await pilot.drag({ source: { selector: "#a" }, target: { selector: "#b" } });
+  assert.ok(Date.now() - started >= 250, "gesture did not wait for the app to settle");
 });

--- a/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.drag.test.mjs
@@ -513,18 +513,29 @@ test("drag does not pay a step delay after the last move", async () => {
   const target = makeElement(rect(200, 200, 100, 100));
   const { pilot } = loadBridge({ elements: { "#a": source, "#b": target } });
 
-  const started = Date.now();
-  await pilot.drag({
-    source: { selector: "#a" },
-    target: { selector: "#b" },
-    steps: 3,
-    stepDelayMs: 100,
-    settleMs: 0,
-  });
-  const elapsed = Date.now() - started;
+  // Record what the gesture schedules rather than how long it takes. A wall
+  // clock has no upper bound: a paused event loop would fail a correct run.
+  const realSetTimeout = globalThis.setTimeout;
+  const delays = [];
+  globalThis.setTimeout = (fn, ms) => {
+    delays.push(ms);
+    return realSetTimeout(fn, 0);
+  };
+  try {
+    await pilot.drag({
+      source: { selector: "#a" },
+      target: { selector: "#b" },
+      steps: 3,
+      stepDelayMs: 100,
+      settleMs: 40,
+    });
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+  }
 
-  assert.ok(elapsed >= 200, `three moves need two gaps, got ${elapsed}ms`);
-  assert.ok(elapsed < 300, `a fourth gap was paid after the last move (${elapsed}ms)`);
+  // Two gaps for three moves, then the settle. A third 100 would mean the loop
+  // slept after the last move.
+  assert.deepEqual(delays, [100, 100, 40]);
 });
 
 test("drag waits between moves and settles after the release by default", async () => {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -638,7 +638,39 @@
     return { ok: true };
   }
 
-  function drag(params) {
+  // Dispatch a mouse/pointer pair. Older WebViews without PointerEvent still get
+  // the MouseEvent, so a missing constructor degrades instead of throwing.
+  function dispatchPointerPair(node, mouseType, pointerType, x, y, buttons) {
+    var init = {
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      buttons: buttons,
+      view: typeof window === "undefined" ? undefined : window,
+    };
+    var accepted = node.dispatchEvent(new MouseEvent(mouseType, init));
+    if (pointerType && typeof PointerEvent === "function") {
+      var pointerInit = {};
+      for (var key in init) {
+        if (Object.prototype.hasOwnProperty.call(init, key)) pointerInit[key] = init[key];
+      }
+      pointerInit.pointerId = 1;
+      pointerInit.pointerType = "mouse";
+      pointerInit.isPrimary = true;
+      node.dispatchEvent(new PointerEvent(pointerType, pointerInit));
+    }
+    return accepted;
+  }
+
+  function pilotSleep(ms) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  async function drag(params) {
     var source = resolveTarget(params.source || params);
     var sourceRect = source.getBoundingClientRect();
     var startX = sourceRect.left + sourceRect.width / 2;
@@ -684,15 +716,73 @@
       throw new Error("drag requires target or offset");
     }
 
+    // Two families of drag implementation exist and they listen for different
+    // things, so a gesture that only satisfies one silently does nothing in the
+    // other:
+    //
+    //   * HTML5 native DnD (`draggable="true"`) wants dragstart/dragover/drop.
+    //   * JS libraries (dnd-kit, sortable.js, interact.js, react-dnd's mouse
+    //     backend) never see those. They activate on mousedown and then track
+    //     *repeated* mousemove/pointermove events on `document`, usually behind a
+    //     small distance threshold, and commit on mouseup. A single mousedown with
+    //     no movement and no release cannot activate them.
+    //
+    // So emit both: a real press-move-release stream plus the HTML5 sequence.
+    var steps = Number(params.steps);
+    if (!isFinite(steps) || steps < 1) steps = 12;
+    steps = Math.min(Math.floor(steps), 60);
+    var stepDelay = Number(params.stepDelayMs);
+    if (!isFinite(stepDelay) || stepDelay < 0) stepDelay = 16;
+    var settleMs = Number(params.settleMs);
+    if (!isFinite(settleMs) || settleMs < 0) settleMs = 250;
+
     var dt = typeof DataTransfer === "function" ? new DataTransfer() : new ClipboardEvent("").clipboardData;
-    source.dispatchEvent(new MouseEvent("mousedown", { clientX: startX, clientY: startY, bubbles: true }));
+
+    // Press on the deepest node under the point, not the resolved container: a
+    // library's listeners are commonly attached to an inner handle or card, and
+    // events only bubble upward, so pressing the ancestor never reaches them.
+    var pressTarget = source;
+    if (document.elementFromPoint) {
+      var atPoint = document.elementFromPoint(startX, startY);
+      if (atPoint) pressTarget = atPoint;
+    }
+
+    dispatchPointerPair(pressTarget, "mousedown", "pointerdown", startX, startY, 1);
     source.dispatchEvent(new DragEvent("dragstart", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
+
+    // Moves go to `document`: libraries attach their move listeners there once the
+    // press is seen, and a `position: fixed` ancestor can otherwise break capture.
+    for (var i = 1; i <= steps; i++) {
+      var moveX = startX + ((endX - startX) * i) / steps;
+      var moveY = startY + ((endY - startY) * i) / steps;
+      dispatchPointerPair(document, "mousemove", "pointermove", moveX, moveY, 1);
+      if (stepDelay > 0) await pilotSleep(stepDelay);
+    }
+
     source.dispatchEvent(new DragEvent("dragleave", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
     dropTarget.dispatchEvent(new DragEvent("dragenter", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
     dropTarget.dispatchEvent(new DragEvent("dragover", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
-    dropTarget.dispatchEvent(new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true }));
+    // A cancelled drop event means an HTML5 handler claimed it (preventDefault).
+    var html5DropHandled = !dropTarget.dispatchEvent(
+      new DragEvent("drop", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true, cancelable: true })
+    );
     source.dispatchEvent(new DragEvent("dragend", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
-    return { ok: true };
+
+    dispatchPointerPair(document, "mouseup", "pointerup", endX, endY, 0);
+
+    // Library drops commonly run async work (state update, request, re-render), so
+    // give it a beat before the caller asserts on the DOM.
+    if (settleMs > 0) await pilotSleep(settleMs);
+
+    // `ok` reports that the gesture was delivered — it cannot know whether the app
+    // acted on it. Assert the expected effect separately.
+    return {
+      ok: true,
+      from: { x: startX, y: startY },
+      to: { x: endX, y: endY },
+      steps: steps,
+      html5DropHandled: html5DropHandled,
+    };
   }
 
   function drop(params) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -638,30 +638,28 @@
     return { ok: true };
   }
 
-  // Dispatch a mouse/pointer pair. Older WebViews without PointerEvent still get
-  // the MouseEvent, so a missing constructor degrades instead of throwing.
-  function dispatchPointerPair(node, mouseType, pointerType, x, y, buttons) {
-    var init = {
-      clientX: x,
-      clientY: y,
+  // A pointer event followed by the compatibility mouse event a browser would
+  // synthesise from it — same order and same preventDefault gate as `click()`,
+  // since a cancelled pointer event suppresses its mouse counterpart. Goes
+  // through `dispatchPointerEvent`, so a WebView without the `PointerEvent`
+  // constructor still gets a pointer-typed event (a MouseEvent with
+  // pointerId/pointerType patched on) rather than nothing at all — dnd-kit's
+  // default sensor is `PointerSensor`, so that fallback is the whole point.
+  function dispatchGesturePair(node, pointerType, mouseType, x, y, buttons) {
+    var init = { clientX: x, clientY: y, buttons: buttons, view: window };
+    if (!dispatchPointerEvent(node, pointerType, init)) return false;
+    return node.dispatchEvent(new MouseEvent(mouseType, Object.assign({
       bubbles: true,
       cancelable: true,
+      composed: true,
       button: 0,
-      buttons: buttons,
-      view: typeof window === "undefined" ? undefined : window,
-    };
-    var accepted = node.dispatchEvent(new MouseEvent(mouseType, init));
-    if (pointerType && typeof PointerEvent === "function") {
-      var pointerInit = {};
-      for (var key in init) {
-        if (Object.prototype.hasOwnProperty.call(init, key)) pointerInit[key] = init[key];
-      }
-      pointerInit.pointerId = 1;
-      pointerInit.pointerType = "mouse";
-      pointerInit.isPrimary = true;
-      node.dispatchEvent(new PointerEvent(pointerType, pointerInit));
-    }
-    return accepted;
+    }, init)));
+  }
+
+  // Deepest node under a viewport point, like a real pointer. Falls back to
+  // `document` when nothing is hit-testable there.
+  function nodeAtPoint(x, y) {
+    return (document.elementFromPoint && document.elementFromPoint(x, y)) || document;
   }
 
   function pilotSleep(ms) {
@@ -744,19 +742,29 @@
     var pressTarget = source;
     if (document.elementFromPoint) {
       var atPoint = document.elementFromPoint(startX, startY);
-      if (atPoint) pressTarget = atPoint;
+      // Only a hit inside the source counts. A toast, backdrop or any overlay
+      // covering the start point would otherwise take the press, the source
+      // would never move, and `drag` would still report ok — the exact false
+      // green this action exists to remove.
+      if (atPoint && (atPoint === source || source.contains(atPoint))) pressTarget = atPoint;
     }
 
-    dispatchPointerPair(pressTarget, "mousedown", "pointerdown", startX, startY, 1);
+    dispatchGesturePair(pressTarget, "pointerdown", "mousedown", startX, startY, 1);
     source.dispatchEvent(new DragEvent("dragstart", { clientX: startX, clientY: startY, dataTransfer: dt, bubbles: true }));
 
-    // Moves go to `document`: libraries attach their move listeners there once the
-    // press is seen, and a `position: fixed` ancestor can otherwise break capture.
+    // Each move targets the node under the point. Dispatching on `document`
+    // instead would give the event a propagation path of `[window, document]`
+    // and nothing else, so any listener on an element between the pressed node
+    // and the document never fires — React 17+ delegates on its root container,
+    // not on `document`. Hit-testing costs one lookup per step and still reaches
+    // the document-level listeners libraries install, because these bubble.
     for (var i = 1; i <= steps; i++) {
       var moveX = startX + ((endX - startX) * i) / steps;
       var moveY = startY + ((endY - startY) * i) / steps;
-      dispatchPointerPair(document, "mousemove", "pointermove", moveX, moveY, 1);
-      if (stepDelay > 0) await pilotSleep(stepDelay);
+      dispatchGesturePair(nodeAtPoint(moveX, moveY), "pointermove", "mousemove", moveX, moveY, 1);
+      // The delay spaces the moves apart, so after the last one it separates
+      // nothing and only pushes the drop sequence back.
+      if (stepDelay > 0 && i < steps) await pilotSleep(stepDelay);
     }
 
     source.dispatchEvent(new DragEvent("dragleave", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
@@ -768,7 +776,7 @@
     );
     source.dispatchEvent(new DragEvent("dragend", { clientX: endX, clientY: endY, dataTransfer: dt, bubbles: true }));
 
-    dispatchPointerPair(document, "mouseup", "pointerup", endX, endY, 0);
+    dispatchGesturePair(nodeAtPoint(endX, endY), "pointerup", "mouseup", endX, endY, 0);
 
     // Library drops commonly run async work (state update, request, re-render), so
     // give it a beat before the caller asserts on the DOM.

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -57,6 +57,30 @@ fn bridge_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
     Duration::from_millis(timeout_ms.saturating_add(BRIDGE_TIMEOUT_BUFFER_MS))
 }
 
+/// Compute the Rust-side eval timeout for `drag`, whose JS implementation
+/// awaits its own timers: `steps` moves spaced by `stepDelayMs`, then a
+/// `settleMs` pause after the release. Defaults and the `steps` clamp mirror
+/// `drag()` in `bridge.js`. Without this, a caller tuning the gesture past
+/// [`DEFAULT_TIMEOUT`] gets an RPC timeout while the bridge is still mid-drag,
+/// and the pending result is dropped.
+fn drag_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
+    // Anything that isn't a non-negative integer (string, float, negative)
+    // falls back to the bridge default: over-estimating the budget only costs
+    // headroom the caller never pays unless JS is genuinely stuck.
+    let field = |key: &str, default: u64| {
+        params
+            .and_then(|p| p.get(key))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(default)
+    };
+    let steps = field("steps", 12).clamp(1, 60);
+    let gesture_ms = steps
+        .saturating_mul(field("stepDelayMs", 16))
+        .saturating_add(field("settleMs", 250))
+        .saturating_add(BRIDGE_TIMEOUT_BUFFER_MS);
+    Duration::from_millis(gesture_ms).max(DEFAULT_TIMEOUT)
+}
+
 /// Extract and remove the optional `"window"` key from params.
 ///
 /// Returns `(window_label, cleaned_params)`:
@@ -151,10 +175,24 @@ pub(crate) async fn dispatch(
                 .to_owned(),
             data: None,
         }),
-        "click" | "fill" | "type" | "select" | "check" | "scroll" | "drag" | "drop" | "text"
-        | "html" | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title"
-        | "visible" | "count" | "checked" => {
+        "click" | "fill" | "type" | "select" | "check" | "scroll" | "drop" | "text" | "html"
+        | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "visible"
+        | "count" | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+        }
+        // `drag` spends `steps × stepDelayMs + settleMs` in JS timers before it
+        // resolves, so the channel timeout has to cover the gesture the caller
+        // asked for.
+        "drag" => {
+            handle_eval_method(
+                method,
+                params,
+                engine,
+                eval_fn,
+                win,
+                drag_eval_timeout(params),
+            )
+            .await
         }
         // `state` is a bridge-derived method (url/title/ready), but the dispatch
         // merges the plugin's compile-time version into the result so a single
@@ -1356,6 +1394,50 @@ mod tests {
             got,
             Duration::from_millis(DEFAULT_BRIDGE_TIMEOUT_MS + BRIDGE_TIMEOUT_BUFFER_MS)
         );
+    }
+
+    // ─── drag_eval_timeout ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_drag_eval_timeout_covers_a_tuned_gesture() {
+        // 60 moves 500 ms apart plus a 5 s settle is 35 s of JS timers. The old
+        // flat 10 s channel expired mid-drag and dropped the pending result.
+        let params = json!({"steps": 60, "stepDelayMs": 500, "settleMs": 5_000});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60 * 500 + 5_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_keeps_the_default_floor() {
+        // A default or fast gesture computes well under DEFAULT_TIMEOUT; the
+        // channel must not shrink below it, since the bridge still has to
+        // resolve elements and dispatch before the timers even start.
+        assert_eq!(drag_eval_timeout(None), DEFAULT_TIMEOUT);
+        let fast = json!({"steps": 2, "stepDelayMs": 0, "settleMs": 0});
+        assert_eq!(drag_eval_timeout(Some(&fast)), DEFAULT_TIMEOUT);
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_clamps_steps_like_the_bridge() {
+        // The bridge clamps steps to 1..=60, so a hostile count must not inflate
+        // the channel timeout past what the gesture can actually take.
+        let params = json!({"steps": 100_000, "stepDelayMs": 1_000, "settleMs": 0});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_ignores_hostile_values() {
+        // Non-numeric or negative tunables fall back to the bridge defaults
+        // instead of panicking or coercing to something absurd.
+        let params = json!({"steps": "lots", "stepDelayMs": -5, "settleMs": null});
+        assert_eq!(drag_eval_timeout(Some(&params)), DEFAULT_TIMEOUT);
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -65,10 +65,10 @@ fn bridge_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
 /// and the pending result is dropped.
 fn drag_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
     // Values `bridge.js` itself rejects (NaN, negative) fall back to its own
-    // default here too, as do the shapes `Number()` maps to 0 where Rust
-    // doesn't (`null`, `true`, `""`). Those last ones over-estimate the
-    // budget, which costs nothing but headroom the caller never pays unless
-    // JS is genuinely stuck.
+    // default here too. The shapes `Number()` accepts and Rust doesn't —
+    // `null` and `""` give 0, `true` gives 1 — land on a default larger than
+    // what the bridge computes, so they over-estimate the budget. That costs
+    // nothing but headroom the caller never pays unless JS is genuinely stuck.
     let field = |key: &str, default: f64| {
         params
             .and_then(|p| p.get(key))
@@ -95,13 +95,25 @@ fn drag_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
 
 /// Mirror the `Number()` coercion `bridge.js` applies to each drag tunable
 /// before validating it. A numeric string is a real value over there
-/// (`Number("1000")` is `1000`), so reading one as "absent" here would
-/// under-budget the gesture by three orders of magnitude.
+/// (`Number("1000")` is `1000`, and so is `Number("0x3e8")`), so reading one
+/// as "absent" here would under-budget the gesture by three orders of
+/// magnitude.
 fn coerce_number(value: &serde_json::Value) -> Option<f64> {
-    match value {
-        serde_json::Value::String(s) => s.trim().parse().ok(),
-        other => other.as_f64(),
+    let serde_json::Value::String(text) = value else {
+        return value.as_f64();
+    };
+    let text = text.trim();
+    // Radix-prefixed integer literals are the one string form `Number()`
+    // accepts and `f64::from_str` rejects. Capped at `u32` because
+    // `setTimeout` fires immediately past its own 32-bit delay limit, so a
+    // larger literal describes a wait no browser performs anyway.
+    let lowered = text.to_ascii_lowercase();
+    for (prefix, radix) in [("0x", 16), ("0o", 8), ("0b", 2)] {
+        if let Some(digits) = lowered.strip_prefix(prefix) {
+            return u32::from_str_radix(digits, radix).ok().map(f64::from);
+        }
     }
+    text.parse().ok()
 }
 
 /// Extract and remove the optional `"window"` key from params.
@@ -1477,6 +1489,19 @@ mod tests {
         assert_eq!(
             got,
             Duration::from_millis(60 * 1_000 + 500 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_coerces_radix_prefixed_strings() {
+        // `Number("0x3e8")` is 1000, so the bridge really does wait a second
+        // between moves here. Rejecting the literal would put the channel back
+        // on its 10 s floor against a 60 s gesture.
+        let params = json!({"steps": "0x3c", "stepDelayMs": "0X3E8", "settleMs": "0b0"});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -59,32 +59,49 @@ fn bridge_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
 
 /// Compute the Rust-side eval timeout for `drag`, whose JS implementation
 /// awaits its own timers: `steps` moves spaced by `stepDelayMs`, then a
-/// `settleMs` pause after the release. Defaults and the `steps` clamp mirror
-/// `drag()` in `bridge.js`. Without this, a caller tuning the gesture past
+/// `settleMs` pause after the release. Coercion, defaults and the `steps`
+/// clamp mirror `drag()` in `bridge.js`. Without this, a caller tuning the gesture past
 /// [`DEFAULT_TIMEOUT`] gets an RPC timeout while the bridge is still mid-drag,
 /// and the pending result is dropped.
 fn drag_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
-    // Anything that isn't a non-negative integer (string, float, negative)
-    // falls back to the bridge default: over-estimating the budget only costs
-    // headroom the caller never pays unless JS is genuinely stuck.
-    let field = |key: &str, default: u64| {
+    // Values `bridge.js` itself rejects (NaN, negative) fall back to its own
+    // default here too, as do the shapes `Number()` maps to 0 where Rust
+    // doesn't (`null`, `true`, `""`). Those last ones over-estimate the
+    // budget, which costs nothing but headroom the caller never pays unless
+    // JS is genuinely stuck.
+    let field = |key: &str, default: f64| {
         params
             .and_then(|p| p.get(key))
-            .and_then(serde_json::Value::as_u64)
+            .and_then(coerce_number)
+            .filter(|v| v.is_finite() && *v >= 0.0)
             .unwrap_or(default)
     };
-    // `bridge.js` sends anything below 1 back to its default of 12, so a
-    // clamp to 1 here would under-budget a `steps: 0` call by an order of
-    // magnitude.
-    let steps = match field("steps", 12) {
-        0 => 12,
-        steps => steps.min(60),
+    // `bridge.js` floors `steps` and sends anything below 1 back to its default
+    // of 12, so a clamp to 1 here would under-budget a `steps: 0` call by an
+    // order of magnitude.
+    let steps = match field("steps", 12.0).floor() {
+        s if s < 1.0 => 12.0,
+        s => s.min(60.0),
     };
-    let gesture_ms = steps
-        .saturating_mul(field("stepDelayMs", 16))
-        .saturating_add(field("settleMs", 250))
-        .saturating_add(BRIDGE_TIMEOUT_BUFFER_MS);
-    Duration::from_millis(gesture_ms).max(DEFAULT_TIMEOUT)
+    let gesture_ms = steps * field("stepDelayMs", 16.0) + field("settleMs", 250.0);
+    // Only a value near f64::MAX can overflow the conversion, and a caller
+    // asking for a gesture longer than the heat death of the universe gets the
+    // floor rather than a panic.
+    Duration::try_from_secs_f64(gesture_ms / 1000.0)
+        .unwrap_or(DEFAULT_TIMEOUT)
+        .saturating_add(Duration::from_millis(BRIDGE_TIMEOUT_BUFFER_MS))
+        .max(DEFAULT_TIMEOUT)
+}
+
+/// Mirror the `Number()` coercion `bridge.js` applies to each drag tunable
+/// before validating it. A numeric string is a real value over there
+/// (`Number("1000")` is `1000`), so reading one as "absent" here would
+/// under-budget the gesture by three orders of magnitude.
+fn coerce_number(value: &serde_json::Value) -> Option<f64> {
+    match value {
+        serde_json::Value::String(s) => s.trim().parse().ok(),
+        other => other.as_f64(),
+    }
 }
 
 /// Extract and remove the optional `"window"` key from params.
@@ -1447,6 +1464,33 @@ mod tests {
         assert_eq!(
             got,
             Duration::from_millis(12 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_coerces_numeric_strings_like_the_bridge() {
+        // `bridge.js` runs every tunable through `Number()`, so "1000" is a real
+        // 1 s step delay over there. Reading it as absent here budgeted 10 s
+        // against a 60 s gesture and timed the channel out mid-drag.
+        let params = json!({"steps": "60", "stepDelayMs": "1000", "settleMs": "500"});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60 * 1_000 + 500 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_honors_fractional_delays() {
+        // Fractional delays are legal in JS and only `steps` gets floored, so
+        // the budget has to follow the same rules or a `stepDelayMs: 900.5`
+        // gesture outlives its channel.
+        let params = json!({"steps": 60.7, "stepDelayMs": 900.5, "settleMs": 0});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            // 60 steps of 900.5 ms.
+            Duration::from_millis(54_030 + BRIDGE_TIMEOUT_BUFFER_MS)
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -104,13 +104,22 @@ fn coerce_number(value: &serde_json::Value) -> Option<f64> {
     };
     let text = text.trim();
     // Radix-prefixed integer literals are the one string form `Number()`
-    // accepts and `f64::from_str` rejects. Capped at `u32` because
-    // `setTimeout` fires immediately past its own 32-bit delay limit, so a
-    // larger literal describes a wait no browser performs anyway.
+    // accepts and `f64::from_str` rejects. Accumulated in `f64` rather than an
+    // integer type because `Number()` puts no width limit on them and `steps`
+    // clamps to 60 afterwards, so a capped parse would send a huge count back
+    // to the default of 12 instead of to the clamp.
     let lowered = text.to_ascii_lowercase();
-    for (prefix, radix) in [("0x", 16), ("0o", 8), ("0b", 2)] {
+    for (prefix, radix) in [("0x", 16_u32), ("0o", 8), ("0b", 2)] {
         if let Some(digits) = lowered.strip_prefix(prefix) {
-            return u32::from_str_radix(digits, radix).ok().map(f64::from);
+            // `Number("0x")` is NaN, and `try_fold` would call it 0.
+            if digits.is_empty() {
+                return None;
+            }
+            return digits.chars().try_fold(0.0_f64, |acc, digit| {
+                digit
+                    .to_digit(radix)
+                    .map(|d| acc.mul_add(f64::from(radix), f64::from(d)))
+            });
         }
     }
     text.parse().ok()
@@ -1503,6 +1512,27 @@ mod tests {
             got,
             Duration::from_millis(60 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
         );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_clamps_a_wide_radix_step_count() {
+        // A literal past any integer width still floors to the bridge's 60-step
+        // clamp, not back to its default of 12 — the difference is 60 s of
+        // gesture against a 12 s budget.
+        let params = json!({"steps": "0xFFFFFFFFFF", "stepDelayMs": 1_000, "settleMs": 0});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(60 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_rejects_a_bare_radix_prefix() {
+        // `Number("0x")` is NaN, so the bridge uses its default and so must the
+        // budget.
+        let params = json!({"steps": "0x", "stepDelayMs": "0b2", "settleMs": 0});
+        assert_eq!(drag_eval_timeout(Some(&params)), DEFAULT_TIMEOUT);
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -73,7 +73,13 @@ fn drag_eval_timeout(params: Option<&serde_json::Value>) -> Duration {
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(default)
     };
-    let steps = field("steps", 12).clamp(1, 60);
+    // `bridge.js` sends anything below 1 back to its default of 12, so a
+    // clamp to 1 here would under-budget a `steps: 0` call by an order of
+    // magnitude.
+    let steps = match field("steps", 12) {
+        0 => 12,
+        steps => steps.min(60),
+    };
     let gesture_ms = steps
         .saturating_mul(field("stepDelayMs", 16))
         .saturating_add(field("settleMs", 250))
@@ -1429,6 +1435,18 @@ mod tests {
         assert_eq!(
             got,
             Duration::from_millis(60 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
+        );
+    }
+
+    #[test]
+    fn test_drag_eval_timeout_treats_zero_steps_as_the_bridge_default() {
+        // `bridge.js` maps steps < 1 to 12, so zero is 12 s of move delays here,
+        // not one. Clamping to 1 would expire the channel mid-gesture.
+        let params = json!({"steps": 0, "stepDelayMs": 1_000, "settleMs": 0});
+        let got = drag_eval_timeout(Some(&params));
+        assert_eq!(
+            got,
+            Duration::from_millis(12 * 1_000 + BRIDGE_TIMEOUT_BUFFER_MS)
         );
     }
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -511,13 +511,18 @@ things, so `drag` emits both:
   `dragstart` → `dragleave` → `dragenter` → `dragover` → `drop` → `dragend`.
 - **JS drag libraries** (dnd-kit, sortable.js, interact.js, react-dnd's mouse
   backend) never see those events. They activate on `mousedown`, then track
-  *repeated* `mousemove`/`pointermove` events on `document` — usually behind a
-  small distance threshold — and commit on `mouseup`. So `drag` presses, streams
-  interpolated moves from the source to the drop point, and releases.
+  *repeated* `mousemove`/`pointermove` events — usually behind a small distance
+  threshold — and commit on `mouseup`. So `drag` presses, streams interpolated
+  moves from the source to the drop point, and releases. Each pointer event is
+  followed by its compatibility mouse event, the order a browser produces.
 
 The press targets the deepest node under the start point (`elementFromPoint`)
 rather than the resolved element, because library listeners are commonly attached
-to an inner handle or card and events only bubble upward.
+to an inner handle or card and events only bubble upward. That node must be the
+source or inside it — when an overlay, toast or backdrop covers the start point,
+`drag` presses the resolved source instead of the thing on top of it. Moves are
+hit-tested the same way at each step, so listeners on elements between the pressed
+node and the document see them too.
 
 ```bash
 tauri-pilot drag <source> [target] [OPTIONS]
@@ -538,11 +543,12 @@ tauri-pilot drag <source> [target] [OPTIONS]
 
 With `--offset`, the drop point is resolved with `elementFromPoint`, which only hits elements inside the visible viewport. If the source element's center — the drag start point — is outside the viewport, the bridge scrolls the element into view (centered) before computing coordinates. The offset itself must still land inside the viewport — an offset larger than the visible area fails with a `Drop point ... is outside the viewport` error.
 
-The gesture's shape is tunable over JSON-RPC/MCP (the CLI uses the defaults):
+The gesture's shape is tunable over JSON-RPC and MCP (the CLI uses the defaults):
 `steps` (default 12, clamped to 1–60) is how many move events are emitted,
 `stepDelayMs` (default 16) is the pause between them, and `settleMs` (default 250)
 is how long the bridge waits after the release so an async state update, request,
-or re-render can land before you assert.
+or re-render can land before you assert. The plugin sizes its eval timeout from
+these, so a long gesture is not cut short by the default 10-second budget.
 
 `ok` reports that the gesture was **delivered**, not that the app reacted to it —
 nothing observable from outside can prove a library handled a drop. Always assert

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -502,7 +502,22 @@ tauri-pilot scroll bottom --ref @e4
 
 ### `drag`
 
-Drag an element to another element or by a pixel offset. Dispatches the full HTML5 drag event sequence: `mousedown` → `dragstart` → `dragleave` → `dragenter` → `dragover` → `drop` → `dragend`.
+Drag an element to another element or by a pixel offset.
+
+Two unrelated kinds of drag implementation exist, and they listen for different
+things, so `drag` emits both:
+
+- **HTML5 native drag** (`draggable="true"`) reacts to the drag event sequence:
+  `dragstart` → `dragleave` → `dragenter` → `dragover` → `drop` → `dragend`.
+- **JS drag libraries** (dnd-kit, sortable.js, interact.js, react-dnd's mouse
+  backend) never see those events. They activate on `mousedown`, then track
+  *repeated* `mousemove`/`pointermove` events on `document` — usually behind a
+  small distance threshold — and commit on `mouseup`. So `drag` presses, streams
+  interpolated moves from the source to the drop point, and releases.
+
+The press targets the deepest node under the start point (`elementFromPoint`)
+rather than the resolved element, because library listeners are commonly attached
+to an inner handle or card and events only bubble upward.
 
 ```bash
 tauri-pilot drag <source> [target] [OPTIONS]
@@ -522,6 +537,18 @@ tauri-pilot drag <source> [target] [OPTIONS]
 | `--offset <X,Y>` | Drag by pixel offset instead of to an element (mutually exclusive with `[target]`) |
 
 With `--offset`, the drop point is resolved with `elementFromPoint`, which only hits elements inside the visible viewport. If the source element's center — the drag start point — is outside the viewport, the bridge scrolls the element into view (centered) before computing coordinates. The offset itself must still land inside the viewport — an offset larger than the visible area fails with a `Drop point ... is outside the viewport` error.
+
+The gesture's shape is tunable over JSON-RPC/MCP (the CLI uses the defaults):
+`steps` (default 12, clamped to 1–60) is how many move events are emitted,
+`stepDelayMs` (default 16) is the pause between them, and `settleMs` (default 250)
+is how long the bridge waits after the release so an async state update, request,
+or re-render can land before you assert.
+
+`ok` reports that the gesture was **delivered**, not that the app reacted to it —
+nothing observable from outside can prove a library handled a drop. Always assert
+the expected effect afterwards. The one signal the bridge can observe is
+`html5DropHandled`, which is true when a handler called `preventDefault()` on the
+`drop` event. The result also echoes the `from`/`to` points and `steps` used.
 
 **Examples:**
 


### PR DESCRIPTION
## Problem

`drag` dispatches the HTML5 DragEvent sequence plus a single `mousedown` — no `mousemove` stream, no `mouseup` — and then returns `ok: true` unconditionally.

That works for `draggable="true"` handlers. It cannot work for the other family of drag implementation: **dnd-kit, sortable.js, interact.js and react-dnd's mouse backend never receive DragEvents**. They activate on `mousedown`, then track *repeated* `mousemove`/`pointermove` events on `document` behind a small distance threshold, and commit on `mouseup`. A press with no movement and no release cannot activate them.

So on a React app using dnd-kit, `tauri-pilot drag @e5 @e8` printed `ok` and changed nothing. For an agent — the primary audience for this tool — a false green is worse than an error, because the assertion that follows is written against a UI that never moved.

## What changed

`bridge.js` `drag()` now emits a gesture both families can see:

- **Presses the deepest node under the start point** (`document.elementFromPoint`) instead of the resolved element. Library listeners commonly sit on an inner handle or card, and DOM events only bubble upward, so pressing the resolved container never reaches them. This was the difference between "no events fire" and "drag activates" in my testing.
- **Streams interpolated `mousemove`/`pointermove` events on `document`** with `buttons: 1`, so distance thresholds clear and listeners do not treat the move as a hover. `document` because a `position: fixed` ancestor can otherwise break pointer capture in WKWebView.
- **Keeps the HTML5 sequence byte-for-byte** (`dragstart` → `dragleave` → `dragenter` → `dragover` → `drop` → `dragend`) on the same elements as before, so native handlers do not regress.
- **Releases with `mouseup`/`pointerup`**, then waits `settleMs` before returning, because a library drop commonly kicks off async state/network work before the DOM reflects it.

New optional params: `steps` (1–60, default 12), `stepDelayMs` (default 16), `settleMs` (default 250). The CLI surface is unchanged and uses the defaults.

`drag` is now `async`. `EvalEngine::wrap_script` already does `await (script)`, and `screenshot` is async already, so the protocol and Rust side are untouched.

## Honesty about the return value

`ok` now documents what it actually means: **the gesture was delivered**. Nothing observable from outside the app can prove a library handled a drop, so the docs tell callers to assert the effect instead of trusting `ok`.

The one signal the bridge *can* observe is added: `html5DropHandled` is true when a handler called `preventDefault()` on the `drop` event. The result also echoes `from`, `to` and `steps`.

## Compatibility

- `PointerEvent` is only constructed when the global exists, so a WebView without it degrades to mouse-only events instead of throwing.
- Existing offset behaviour (#130: scroll-into-view, viewport error messages) is unchanged and still covered.
- One observable change for the target path: it now calls `elementFromPoint` once to find the press target, where before it made no such call. The existing test that asserted "skips elementFromPoint" was updated to assert the press-target lookup instead.

## Tests

`bridge.drag.test.mjs` goes from 8 to 17 tests, all against the real `bridge.js`:

- press → move stream → release ordering, move count, interpolation endpoints, and `buttons: 1`
- press targets the deepest node, not the container; falls back to the resolved source when nothing is hit-testable
- the full HTML5 sequence still fires, in order, on the same elements
- `html5DropHandled` true/false
- graceful degradation with no `PointerEvent`
- `steps` clamping for missing/zero/negative/non-numeric/fractional/oversized input
- reported `from`/`to`
- default timing actually waits for the app to settle

```
node --test crates/tauri-plugin-pilot/js/bridge.drag.test.mjs   # 17 pass
cargo fmt --all --check                                         # clean
cargo test --workspace                                          # 138 pass
cargo clippy --workspace -- -D warnings                         # clean
```

## Live verification

Tested against a real Tauri v2 + React desktop app on macOS (WKWebView), `@dnd-kit/core` 6.3.1 with `MouseSensor` and a 6px activation distance, dragging a card from a `position: fixed` drawer into a drop zone:

- **Before:** `tauri-pilot drag '[aria-roledescription="draggable"]' '.hb-slot.is-empty'` → `ok`, zero rows written, UI unchanged.
- **After (same command, same app):** the item lands in the slot, and the corresponding row is present in the app's SQLite database.

Also confirmed via the app's own drag instrumentation that the drop route received a valid pointer position, which it did not before.

## Docs

`docs/reference/cli.md` explains both event families, the press-target rule, the tuning params, and what `ok` does and does not mean. `README.md`, `SKILL.md` and `CHANGELOG.md` updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `drag` a real pointer gesture so it drives JS drag libraries (dnd-kit, sortable.js, interact.js, react-dnd) as well as HTML5 native drag. Previously `drag` emitted only the HTML5 DragEvent sequence plus one `mousedown` and returned `ok: true` even when nothing moved.

- Presses the deepest node under the start point, gated on containment so inner handles get the press and overlays over the source are ignored.
- Streams interpolated `pointermove`/`mousemove` with `buttons: 1`, each hit-tested at its own point, then releases; pointer events precede their mouse counterparts and the HTML5 sequence is unchanged.
- Adds tunables `steps` (1–60, default 12), `stepDelayMs` (default 16), and `settleMs` (default 250) via JSON-RPC and MCP; `drag` is now async and the Rust eval timeout is sized from the tunables, mirroring the bridge's coercion and clamping so tuned gestures aren't cut short.
- The result adds `from`, `to`, `steps`, and `html5DropHandled`; `ok` means the gesture was delivered, so assert the effect separately.
- Falls back to pointer-typed `MouseEvent`s when `PointerEvent` is unavailable; offset and scroll-into-view behavior are unchanged.

**Migration**
- Direct `window.__PILOT__.drag` callers must await it; set `settleMs` or `stepDelayMs` in tests to control timing.

<sup>Written for commit 97e1a8e711ac7d70a7939ac5ba01009d67d973fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced drag operations with realistic pointer gestures, interpolated movement, and release events.
  - Added configurable movement steps and timing options.
  - Drag results now report gesture coordinates, step count, and HTML5 drop handling.

- **Bug Fixes**
  - Improved dragging for JavaScript-based drag-and-drop libraries and deeply nested targets.
  - Improved event targeting, pointer/mouse event ordering, and handling of overlays at the starting point.

- **Documentation**
  - Clarified drag behavior, configuration options, and the distinction between event delivery and application response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->