### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-30
+
 ### Changed
 
 - Upgrade `rmcp` to 3.1.4 (from 1.7). The only break reaching this codebase is
@@ -548,7 +550,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/mpiton/tauri-pilot/issues/54
 [#62]: https://github.com/mpiton/tauri-pilot/pull/62
 [#63]: https://github.com/mpiton/tauri-pilot/pull/63
-[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/mpiton/tauri-pilot/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/mpiton/tauri-pilot/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/mpiton/tauri-pilot/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/mpiton/tauri-pilot/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/mpiton/tauri-pilot/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `rmcp` to 3.1.4 (from 1.7). The only break reaching this codebase is
+  SEP-2322: `ServerHandler::call_tool` now returns `CallToolResponse`, converted
+  at the trait boundary so the internal helpers keep returning `CallToolResult`.
+  The MCP tool surface is unchanged. `base64` 0.23, `windows` 0.62,
+  `core-graphics` 0.25 and `serial_test` 4 move with it. [#143]
+
 ### Fixed
 
 - `drag` now performs a real pointer gesture, so it drives JS drag libraries
@@ -26,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gesture they describe instead of a flat 10 s. The result echoes
   `from`/`to`/`steps` and adds `html5DropHandled` so a caller can see whether a
   native handler claimed the drop. `ok` still means only that the gesture was
-  delivered — assert the effect.
+  delivered — assert the effect. [#142]
 
 ### Security
 
@@ -35,7 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a host-header SSRF in the prerendered error page fetch; sharp inherited
   four libvips CVEs. Refreshing the lockfile also moved the transitive
   js-yaml (4.3.0), svgo (4.0.2), vite (8.1.5) and esbuild (0.28.1) onto patched
-  versions. Docs-only — the plugin and CLI crates are untouched.
+  versions. Docs-only — the plugin and CLI crates are untouched. [#140]
+
+- Upgrade `quick-xml` to 0.42, clearing RUSTSEC-2026-0194 (quadratic
+  duplicate-attribute check) and RUSTSEC-2026-0195 (unbounded namespace
+  allocation), both scored 7.5. The docs lockfile was refreshed again to drop
+  the vulnerable `js-yaml` and `nanoid` it still carried. `cargo audit` and
+  `npm audit` are both clean. [#143]
 
 ## [0.7.2] - 2026-06-10
 
@@ -584,3 +598,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#129]: https://github.com/mpiton/tauri-pilot/issues/129
 [#130]: https://github.com/mpiton/tauri-pilot/issues/130
 [#135]: https://github.com/mpiton/tauri-pilot/issues/135
+[#140]: https://github.com/mpiton/tauri-pilot/pull/140
+[#142]: https://github.com/mpiton/tauri-pilot/pull/142
+[#143]: https://github.com/mpiton/tauri-pilot/pull/143

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-pilot-cli"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-pilot"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -82,7 +82,7 @@ cargo tauri dev
 
 # Terminal 2 — verify the plugin is reachable
 tauri-pilot ping
-# Connected. Plugin and CLI both 0.7.1.
+# Connected. Plugin and CLI both 0.7.3.
 ```
 
 `ping` reports the plugin version compiled into your app alongside the CLI version. When they match, you're ready to start using the snapshot/action workflow.
@@ -93,8 +93,8 @@ The plugin is a Rust dependency compiled into your app. The CLI is a separate bi
 
 ```bash
 tauri-pilot ping
-# Connected. Plugin 0.7.0, CLI 0.7.1.
-# Plugin 0.7.0 and CLI 0.7.1 differ. Rebuild your app against tauri-plugin-pilot 0.7.1 ...
+# Connected. Plugin 0.7.2, CLI 0.7.3.
+# Plugin 0.7.2 and CLI 0.7.3 differ. Rebuild your app against tauri-plugin-pilot 0.7.3 ...
 ```
 
 If `ping` reports `Plugin <= 0.7.0`, or eval commands fail on macOS with `native WebKit eval callback returned an error`, the plugin baked into your app predates the unified eval path (removed in 0.7.1). Update it and rebuild:
@@ -104,7 +104,7 @@ If `ping` reports `Plugin <= 0.7.0`, or eval commands fail on macOS with `native
 cargo update -p tauri-plugin-pilot
 
 # or pin a released version in src-tauri/Cargo.toml:
-#   tauri-plugin-pilot = "0.7.1"
+#   tauri-plugin-pilot = "0.7.3"
 
 # then rebuild
 cargo tauri dev


### PR DESCRIPTION
## Summary

• Bump both crates to 0.7.3 and date the CHANGELOG section
• Record the missing entry for #143 — quick-xml 0.42 (RUSTSEC-2026-0194, RUSTSEC-2026-0195) under Security, rmcp 1.7 → 3.1.4 under Changed — and add the `[#140] [#142] [#143]` link definitions
• Refresh the stale 0.7.1 version examples in the plugin-setup guide

Release contents: the `drag` pointer-gesture fix (#142), the Astro 7 / sharp 0.35 docs upgrade (#140) and the rmcp 3.1 + quick-xml advisory patch (#143).

Verified locally: `cargo clippy --workspace -- -D warnings` clean, 156 Rust tests and 30 bridge JS tests green, `cargo audit` clean (the two remaining high-severity quick-xml hits came from stale `plist` / `wayland-scanner` entries in an untracked local lockfile; a fresh resolve picks the patched versions).

Tag `v0.7.3` will be pushed on the squash-merge commit, same as v0.7.2.

## Type

chore

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v0.7.3, packaging the drag pointer-gesture fix, the Astro 7 docs upgrade, and the `rmcp` 3.1.4 + `quick-xml` 0.42 security patch since 0.7.2. Both crates bump to 0.7.3, the changelog gains the missing entries for #140, #142, and #143, and the plugin-setup guide's stale 0.7.1 version examples are updated to 0.7.3.

The only breaking change is `rmcp`'s `ServerHandler::call_tool`, which now returns `CallToolResponse` instead of `CallToolResult`; the conversion happens at the trait boundary, so the MCP tool surface is unchanged. `quick-xml` 0.42 clears RUSTSEC-2026-0194 and RUSTSEC-2026-0195, and both `cargo audit` and `npm audit` are clean.

<sup>Written for commit 3298431b00c86d5d93121dc4dbe07f659d890f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

