### PR TITLE
feat(plugin): support Android via ADB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-v2-
 
+      - name: Check Android plugin
+        if: runner.os == 'Linux'
+        run: |
+          rustup target add aarch64-linux-android
+          cargo check -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features
+          cargo clippy -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features -- -D warnings
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
           fi
           echo "CHANGELOG.md contains entry for $TAG_VERSION"
 
+      - name: Check Android plugin
+        run: |
+          rustup target add aarch64-linux-android
+          cargo check -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features
+          cargo clippy -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features -- -D warnings
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Android device and emulator support via ADB from Linux or macOS. Each plugin
+  instance uses an abstract socket named `tauri-pilot-{identifier}-{random}.sock`,
+  forwarded with `adb forward localfilesystem:... localabstract:...`. Connections
+  require matching UID/GID pairs for the app, root or ADB shell. [#145]
+
 ## [0.7.3] - 2026-08-30
 
 ### Changed
@@ -604,3 +611,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#140]: https://github.com/mpiton/tauri-pilot/pull/140
 [#142]: https://github.com/mpiton/tauri-pilot/pull/142
 [#143]: https://github.com/mpiton/tauri-pilot/pull/143
+[#145]: https://github.com/mpiton/tauri-pilot/pull/145

--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ Use global flags before `mcp` to pin a specific app socket or window:
 ## Requirements
 
 - **Linux** (WebKitGTK), **macOS** (WebKit), or **Windows** (WebView2)
-- **Android** via [ADB](https://mpiton.github.io/tauri-pilot/guides/plugin-setup/#android-via-adb)
+- **Android** via [ADB from Linux or macOS](https://mpiton.github.io/tauri-pilot/guides/plugin-setup/#android-via-adb)
 - **Tauri v2** (v1 not supported)
 - **Rust 1.95.0+** (edition 2024)
 
 ## Known limitations
+
+- **Android from Windows hosts** — the Windows CLI uses named pipes and cannot connect through the Unix socket forwarding used by this Android setup.
 
 - **`press` and global shortcuts on X11** — synthetic key events from `press` (via `enigo`'s `XTestFakeKeyEvent` backend) frequently fail to trigger handlers registered with `tauri-plugin-global-shortcut`.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Use global flags before `mcp` to pin a specific app socket or window:
 ## Requirements
 
 - **Linux** (WebKitGTK), **macOS** (WebKit), or **Windows** (WebView2)
+- **Android** via [ADB](https://mpiton.github.io/tauri-pilot/guides/plugin-setup/#android-via-adb)
 - **Tauri v2** (v1 not supported)
 - **Rust 1.95.0+** (edition 2024)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,9 @@
 
 ## Scope
 
-tauri-pilot is a **debug-only** tool. The plugin runs exclusively under `#[cfg(debug_assertions)]` and should never be included in production builds. The Unix socket is local-only (`/tmp/`) with user-level permissions.
+tauri-pilot is a **debug-only** tool. The plugin runs exclusively under `#[cfg(debug_assertions)]` and should never be included in production builds. Desktop Unix sockets are local files with owner-only permissions.
+
+Android uses the abstract Unix namespace, which has no filesystem permissions. Each instance gets an OS-random socket name, reported in the app's info-level logs, to prevent predictable name pre-binding. Connections are authorized using kernel peer credentials (`SO_PEERCRED`): matching UID/GID pairs for the app, root (0) or ADB shell (2000). Access also depends on the device's SELinux policy. ADB and access to the app's startup logs are trusted; the protocol does not perform a separate server-authentication handshake.
 
 ## Reporting a Vulnerability
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) const BRIDGE_JS: &str = concat!(
 /// On non-Unix, non-Windows platforms or in release builds, returns a no-op plugin.
 /// In debug builds on Unix, injects the JS bridge, stores an `EvalEngine`,
 /// and starts a Unix socket server at `$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock` (falls back to `/tmp` if unavailable).
+/// Android uses the abstract Unix socket `tauri-pilot-{identifier}.sock`, reachable via ADB forwarding.
 /// In debug builds on Windows, starts a Named Pipe server at
 /// `\\.\pipe\tauri-pilot-{identifier}` and registers the instance under `%LOCALAPPDATA%\tauri-pilot\instances\`.
 #[must_use]
@@ -62,7 +63,6 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 app.manage(engine.clone());
 
                 let identifier = sanitize_identifier(&app.config().identifier);
-                let socket_path = server::socket_path(&identifier);
 
                 let eval_fn = make_eval_fn(app);
                 let list_fn = make_list_fn(app);
@@ -76,8 +76,9 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 // listener to tokio once it is already on the runtime.
                 #[cfg(unix)]
                 {
-                    let (listener, guard) = server::bind(&socket_path).map_err(|e| {
-                        tracing::error!(path = %socket_path.display(), "failed to bind socket: {e}");
+                    let address = server::socket_address(&identifier)?;
+                    let (listener, guard) = server::bind(&address).map_err(|e| {
+                        tracing::error!(?address, "failed to bind socket: {e}");
                         e
                     })?;
                     tauri::async_runtime::spawn(server::run(
@@ -98,7 +99,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 // the context of a Tokio 1.x runtime" (#115).
                 #[cfg(windows)]
                 tauri::async_runtime::spawn(server::run(
-                    socket_path,
+                    server::socket_path(&identifier),
                     engine,
                     Some(eval_fn),
                     Some(list_fn),

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -37,9 +37,10 @@ pub(crate) const BRIDGE_JS: &str = concat!(
 /// Initialize the tauri-pilot plugin.
 ///
 /// On non-Unix, non-Windows platforms or in release builds, returns a no-op plugin.
-/// In debug builds on Unix, injects the JS bridge, stores an `EvalEngine`,
+/// In debug builds on Unix other than Android, injects the JS bridge, stores an `EvalEngine`,
 /// and starts a Unix socket server at `$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock` (falls back to `/tmp` if unavailable).
-/// Android uses the abstract Unix socket `tauri-pilot-{identifier}.sock`, reachable via ADB forwarding.
+/// Android uses `tauri-pilot-{identifier}-{random}.sock` in the abstract namespace,
+/// reachable via ADB forwarding. The per-instance address is logged at info level.
 /// In debug builds on Windows, starts a Named Pipe server at
 /// `\\.\pipe\tauri-pilot-{identifier}` and registers the instance under `%LOCALAPPDATA%\tauri-pilot\instances\`.
 #[must_use]
@@ -76,7 +77,9 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 // listener to tokio once it is already on the runtime.
                 #[cfg(unix)]
                 {
-                    let address = server::socket_address(&identifier)?;
+                    let address = server::socket_address(&identifier).inspect_err(|e| {
+                        tracing::error!(identifier, "failed to build tauri-pilot socket address: {e}");
+                    })?;
                     let (listener, guard) = server::bind(&address).map_err(|e| {
                         tracing::error!(?address, "failed to bind socket: {e}");
                         e

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -122,7 +122,7 @@ pub mod unix;
 pub mod windows;
 
 #[cfg(unix)]
-pub use unix::{bind, run, socket_path};
+pub use unix::{bind, run, socket_address};
 // Windows binds inside `run` (#115), so `bind` is internal to the windows module
 // and is not re-exported — only `run` and `socket_path` are used by plugin setup.
 #[cfg(windows)]

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -6,6 +6,7 @@ use crate::recorder::Recorder;
 
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
+use std::os::unix::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::UnixListener;
 
@@ -45,6 +46,7 @@ fn inode_from_raw_fd(fd: std::os::unix::io::RawFd) -> u64 {
 }
 
 /// Returns true if `path` is a directory owned by the current user with no group/world permissions.
+#[cfg(not(target_os = "android"))]
 fn is_private_dir(path: &std::path::Path) -> bool {
     use std::os::unix::fs::MetadataExt;
     match std::fs::metadata(path) {
@@ -59,6 +61,7 @@ fn is_private_dir(path: &std::path::Path) -> bool {
 
 /// Core implementation — accepts the XDG value directly so tests can call it without mutating
 /// the process environment.
+#[cfg(not(target_os = "android"))]
 fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
     if let Some(val) = xdg.filter(|v| !v.is_empty()) {
         let path = std::path::PathBuf::from(&val);
@@ -76,13 +79,21 @@ fn socket_dir_from(xdg: Option<std::ffi::OsString>) -> std::path::PathBuf {
 /// Returns the directory for the socket file.
 /// Prefers `$XDG_RUNTIME_DIR` when it is a private directory (owned by current user, no
 /// group/world access). Falls back to `/tmp` with a warning if the directory is not private.
+#[cfg(not(target_os = "android"))]
 fn socket_dir() -> std::path::PathBuf {
     socket_dir_from(std::env::var_os("XDG_RUNTIME_DIR"))
 }
 
-/// Build the full socket path for the given app identifier.
-pub fn socket_path(identifier: &str) -> std::path::PathBuf {
-    socket_dir().join(format!("tauri-pilot-{identifier}.sock"))
+/// Android uses an abstract address; other Unix platforms use a filesystem path.
+pub fn socket_address(identifier: &str) -> std::io::Result<SocketAddr> {
+    let name = format!("tauri-pilot-{identifier}.sock");
+    #[cfg(target_os = "android")]
+    {
+        use std::os::android::net::SocketAddrExt;
+        SocketAddr::from_abstract_name(name)
+    }
+    #[cfg(not(target_os = "android"))]
+    SocketAddr::from_pathname(socket_dir().join(name))
 }
 
 /// Bind the socket using the **std** (sync) listener so this can be called
@@ -90,10 +101,20 @@ pub fn socket_path(identifier: &str) -> std::path::PathBuf {
 ///
 /// Tries bind first; only removes stale files on `AddrInUse` after verifying
 /// no live server is listening.
-/// Returns a std listener and a [`SocketGuard`] that cleans up on drop.
+/// Abstract sockets are released by the kernel; only filesystem sockets need a guard.
 pub fn bind(
-    socket_path: &std::path::Path,
-) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
+    address: &SocketAddr,
+) -> Result<(std::os::unix::net::UnixListener, Option<SocketGuard>), Error> {
+    let Some(socket_path) = address.as_pathname() else {
+        let listener = std::os::unix::net::UnixListener::bind_addr(address)?;
+        listener.set_nonblocking(true)?;
+        tracing::info!(
+            version = env!("CARGO_PKG_VERSION"),
+            ?address,
+            "tauri-pilot socket listening"
+        );
+        return Ok((listener, None));
+    };
     // SAFETY: umask is always safe to call; we restore the old mask immediately.
     let old_mask = unsafe { libc::umask(0o177) };
     let first_bind = std::os::unix::net::UnixListener::bind(socket_path);
@@ -142,10 +163,10 @@ pub fn bind(
 
     Ok((
         listener,
-        SocketGuard {
+        Some(SocketGuard {
             path: socket_path.to_path_buf(),
             inode,
-        },
+        }),
     ))
 }
 
@@ -153,7 +174,7 @@ pub fn bind(
 /// The `_guard` is held for its `Drop` cleanup.
 pub async fn run(
     listener: std::os::unix::net::UnixListener,
-    _guard: SocketGuard,
+    _guard: Option<SocketGuard>,
     engine: EvalEngine,
     eval_fn: Option<EvalFn>,
     list_fn: Option<ListWindowsFn>,
@@ -191,16 +212,21 @@ async fn accept_loop(
             }
         };
 
-        // Verify the connecting process belongs to the same user.
+        // Authenticate kernel-provided credentials before reading requests.
         match stream.peer_cred() {
             Ok(cred) => {
                 // SAFETY: getuid() is always safe to call; it has no preconditions.
                 let my_uid = unsafe { libc::getuid() };
-                if cred.uid() != my_uid {
+                #[cfg(target_os = "android")]
+                let authorized = android_peer_allowed(cred.uid(), cred.gid(), my_uid);
+                #[cfg(not(target_os = "android"))]
+                let authorized = cred.uid() == my_uid;
+                if !authorized {
                     tracing::warn!(
                         peer_uid = cred.uid(),
-                        expected_uid = my_uid,
-                        "rejected connection from different user"
+                        peer_gid = cred.gid(),
+                        app_uid = my_uid,
+                        "rejected unauthorized Unix peer"
                     );
                     continue;
                 }
@@ -228,7 +254,14 @@ async fn accept_loop(
     }
 }
 
-#[cfg(test)]
+// Android reserves UID 0 for root and 2000 for the ADB shell. This matches
+// Chromium Android DevTools: same UID/GID, and only the app, shell or root.
+#[cfg(target_os = "android")]
+fn android_peer_allowed(uid: u32, gid: u32, app_uid: u32) -> bool {
+    uid == gid && (uid == app_uid || uid == 0 || uid == 2000)
+}
+
+#[cfg(all(test, not(target_os = "android")))]
 mod tests {
     use super::*;
     use crate::protocol::Response;
@@ -249,7 +282,8 @@ mod tests {
     }
 
     async fn start_test_server(path: &Path) -> tokio::task::JoinHandle<()> {
-        let (listener, guard) = bind(path).expect("bind test socket");
+        let address = SocketAddr::from_pathname(path).expect("test socket address");
+        let (listener, guard) = bind(&address).expect("bind test socket");
         let engine = EvalEngine::new();
         let handle = tokio::spawn(async move {
             run(listener, guard, engine, None, None, None, Recorder::new()).await;
@@ -379,7 +413,8 @@ mod tests {
     async fn test_bind_socket_has_mode_0o600() {
         use std::os::unix::fs::PermissionsExt;
         let socket = unique_socket_path();
-        let (listener, guard) = bind(&socket).expect("bind test socket");
+        let address = SocketAddr::from_pathname(&socket).expect("test socket address");
+        let (listener, guard) = bind(&address).expect("bind test socket");
         let meta = std::fs::metadata(&socket).expect("socket metadata");
         let mode = meta.permissions().mode() & 0o777;
         assert_eq!(

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -84,37 +84,69 @@ fn socket_dir() -> std::path::PathBuf {
     socket_dir_from(std::env::var_os("XDG_RUNTIME_DIR"))
 }
 
-/// Android uses an abstract address; other Unix platforms use a filesystem path.
+/// Android uses a random per-instance abstract name; other Unix platforms use a path.
+///
+/// # Errors
+/// Returns an error if OS randomness cannot be read or the address is invalid or too long.
 pub fn socket_address(identifier: &str) -> std::io::Result<SocketAddr> {
-    let name = format!("tauri-pilot-{identifier}.sock");
     #[cfg(target_os = "android")]
     {
+        use std::io::Read;
         use std::os::android::net::SocketAddrExt;
+
+        let mut random = [0_u8; 16];
+        std::fs::File::open("/dev/urandom")?.read_exact(&mut random)?;
+        let name = format!(
+            "tauri-pilot-{identifier}-{:032x}.sock",
+            u128::from_ne_bytes(random)
+        );
         SocketAddr::from_abstract_name(name)
     }
     #[cfg(not(target_os = "android"))]
-    SocketAddr::from_pathname(socket_dir().join(name))
+    SocketAddr::from_pathname(socket_dir().join(format!("tauri-pilot-{identifier}.sock")))
 }
 
 /// Bind the socket using the **std** (sync) listener so this can be called
 /// outside a tokio runtime (e.g. from Tauri plugin `setup`).
 ///
-/// Tries bind first; only removes stale files on `AddrInUse` after verifying
-/// no live server is listening.
-/// Abstract sockets are released by the kernel; only filesystem sockets need a guard.
+/// Returns the listener and a cleanup guard for pathname sockets. Abstract sockets
+/// have no guard because the kernel releases their names when the listener closes.
+///
+/// # Errors
+/// Rejects unnamed addresses and propagates socket binding or configuration errors.
 pub fn bind(
     address: &SocketAddr,
 ) -> Result<(std::os::unix::net::UnixListener, Option<SocketGuard>), Error> {
-    let Some(socket_path) = address.as_pathname() else {
-        let listener = std::os::unix::net::UnixListener::bind_addr(address)?;
-        listener.set_nonblocking(true)?;
-        tracing::info!(
-            version = env!("CARGO_PKG_VERSION"),
-            ?address,
-            "tauri-pilot socket listening"
-        );
-        return Ok((listener, None));
-    };
+    if address.is_unnamed() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "tauri-pilot requires a named Unix socket",
+        )
+        .into());
+    }
+    match address.as_pathname() {
+        Some(path) => bind_pathname(path).map(|(listener, guard)| (listener, Some(guard))),
+        None => bind_abstract(address).map(|listener| (listener, None)),
+    }
+}
+
+/// Abstract addresses use peer credentials, with no filesystem permissions or cleanup.
+fn bind_abstract(address: &SocketAddr) -> Result<std::os::unix::net::UnixListener, Error> {
+    let listener = std::os::unix::net::UnixListener::bind_addr(address)?;
+    listener.set_nonblocking(true)?;
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        ?address,
+        "tauri-pilot socket listening"
+    );
+    Ok(listener)
+}
+
+/// Applies owner-only permissions and removes stale pathname sockets only when
+/// connecting confirms that no live listener remains.
+fn bind_pathname(
+    socket_path: &std::path::Path,
+) -> Result<(std::os::unix::net::UnixListener, SocketGuard), Error> {
     // SAFETY: umask is always safe to call; we restore the old mask immediately.
     let old_mask = unsafe { libc::umask(0o177) };
     let first_bind = std::os::unix::net::UnixListener::bind(socket_path);
@@ -163,10 +195,10 @@ pub fn bind(
 
     Ok((
         listener,
-        Some(SocketGuard {
+        SocketGuard {
             path: socket_path.to_path_buf(),
             inode,
-        }),
+        },
     ))
 }
 
@@ -254,9 +286,10 @@ async fn accept_loop(
     }
 }
 
-// Android reserves UID 0 for root and 2000 for the ADB shell. This matches
-// Chromium Android DevTools: same UID/GID, and only the app, shell or root.
-#[cfg(target_os = "android")]
+/// Accepts the canonical app, root (0) and ADB shell (2000) UID/GID pairs.
+/// Peers with a different primary group are outside this policy, matching
+/// Chromium's Android `DevTools` credential check.
+#[cfg(any(target_os = "android", test))]
 fn android_peer_allowed(uid: u32, gid: u32, app_uid: u32) -> bool {
     uid == gid && (uid == app_uid || uid == 0 || uid == 2000)
 }
@@ -272,6 +305,49 @@ mod tests {
     use tokio::net::UnixStream;
 
     static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    #[test]
+    fn android_peer_credentials() {
+        let app_uid = 10123;
+        for (uid, gid, allowed) in [
+            (app_uid, app_uid, true),
+            (0, 0, true),
+            (2000, 2000, true),
+            (app_uid, 0, false),
+            (2000, 0, false),
+            (10124, 10124, false),
+        ] {
+            assert_eq!(
+                android_peer_allowed(uid, gid, app_uid),
+                allowed,
+                "{uid}:{gid}"
+            );
+        }
+    }
+
+    #[test]
+    fn bind_rejects_unnamed_address() {
+        let socket = std::os::unix::net::UnixDatagram::unbound().expect("unnamed socket");
+        let address = socket.local_addr().expect("socket address");
+        assert!(
+            matches!(bind(&address), Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::InvalidInput)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn abstract_listener_is_nonblocking_without_file_guard() {
+        use std::os::linux::net::SocketAddrExt;
+
+        let name = format!("tauri-pilot-abstract-test-{}", std::process::id());
+        let address = SocketAddr::from_abstract_name(name).expect("abstract address");
+        let (listener, guard) = bind(&address).expect("bind abstract socket");
+        assert!(guard.is_none());
+        // SAFETY: the listener owns a valid descriptor; F_GETFL only reads its flags.
+        let flags = unsafe { libc::fcntl(listener.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0, "read listener flags");
+        assert_ne!(flags & libc::O_NONBLOCK, 0);
+    }
 
     fn unique_socket_path() -> PathBuf {
         let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -91,19 +91,25 @@ fn socket_dir() -> std::path::PathBuf {
 pub fn socket_address(identifier: &str) -> std::io::Result<SocketAddr> {
     #[cfg(target_os = "android")]
     {
-        use std::io::Read;
         use std::os::android::net::SocketAddrExt;
 
-        let mut random = [0_u8; 16];
-        std::fs::File::open("/dev/urandom")?.read_exact(&mut random)?;
-        let name = format!(
-            "tauri-pilot-{identifier}-{:032x}.sock",
-            u128::from_ne_bytes(random)
-        );
-        SocketAddr::from_abstract_name(name)
+        SocketAddr::from_abstract_name(android_socket_name(identifier)?)
     }
     #[cfg(not(target_os = "android"))]
     SocketAddr::from_pathname(socket_dir().join(format!("tauri-pilot-{identifier}.sock")))
+}
+
+#[cfg(any(target_os = "android", test))]
+fn android_socket_name(identifier: &str) -> std::io::Result<String> {
+    use std::io::Read;
+
+    let mut random = [0_u8; 8];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut random)?;
+    // The identifier is only a readable label; cap it to leave room for the random suffix.
+    Ok(format!(
+        "tauri-pilot-{identifier:.16}-{:016x}.sock",
+        u64::from_ne_bytes(random)
+    ))
 }
 
 /// Bind the socket using the **std** (sync) listener so this can be called
@@ -305,6 +311,18 @@ mod tests {
     use tokio::net::UnixStream;
 
     static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    #[test]
+    fn android_socket_name_fits_with_long_identifier() {
+        let name = android_socket_name(&"a".repeat(200)).expect("socket name");
+        assert!(name.len() <= 107, "abstract socket name is too long");
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::net::SocketAddrExt;
+            let address = SocketAddr::from_abstract_name(name).expect("valid abstract address");
+            bind(&address).expect("bind abstract socket");
+        }
+    }
 
     #[test]
     fn android_peer_credentials() {

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -6,6 +6,7 @@ description: Install tauri-pilot and start testing your Tauri v2 app interactive
 ## Requirements
 
 - Linux (WebKitGTK) or macOS (WebKit) — Windows planned
+- Android via [ADB](/tauri-pilot/guides/plugin-setup/#android-via-adb)
 - Tauri v2 (v1 not supported)
 - Rust 1.95.0+ (edition 2024)
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -5,7 +5,7 @@ description: Install tauri-pilot and start testing your Tauri v2 app interactive
 
 ## Requirements
 
-- Linux (WebKitGTK) or macOS (WebKit) — Windows planned
+- Linux (WebKitGTK), macOS (WebKit), or Windows (WebView2)
 - Android via [ADB](/tauri-pilot/guides/plugin-setup/#android-via-adb)
 - Tauri v2 (v1 not supported)
 - Rust 1.95.0+ (edition 2024)

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -109,3 +109,24 @@ cargo update -p tauri-plugin-pilot
 # then rebuild
 cargo tauri dev
 ```
+
+## Android via ADB
+
+On macOS or Linux, follow the setup above with `default-features = false` (Android has no native `press`) and register the plugin in `src-tauri/src/lib.rs`. Start the app with `cargo tauri android dev`.
+
+Connect a device or emulator through ADB, then replace `com.example.app` below with the identifier from `tauri.conf.json`:
+
+```sh
+pilot_dir=$(mktemp -d /tmp/tauri-pilot.XXXXXX)
+adb forward "localfilesystem:$pilot_dir/pilot.sock" \
+  localabstract:tauri-pilot-com.example.app.sock
+tauri-pilot --socket "$pilot_dir/pilot.sock" snapshot
+```
+
+Remove the forwarding when finished:
+
+```sh
+adb forward --remove "localfilesystem:$pilot_dir/pilot.sock"
+rm -f "$pilot_dir/pilot.sock"
+rmdir "$pilot_dir"
+```

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -141,7 +141,7 @@ pilot_pid=$(adb -s "$pilot_device" shell pidof "$pilot_package")
 adb -s "$pilot_device" logcat -d --pid="$pilot_pid" | grep 'tauri-pilot socket listening'
 ```
 
-Copy the complete `tauri-pilot-{identifier}-{random}.sock` name into `pilot_name` below. It changes each time the app starts, so update the forwarding after a restart. Once the page has loaded:
+Copy the complete `tauri-pilot-{identifier}-{random}.sock` name into `pilot_name` below. The identifier is limited to 16 characters, followed by 16 random hexadecimal digits. The name changes each time the app starts, so update the forwarding after a restart. Once the page has loaded:
 
 ```sh
 pilot_name=NAME_FROM_STARTUP_LOG
@@ -159,7 +159,7 @@ Use the same `-s "$pilot_device"` for all ADB commands when multiple devices are
 
 If forwarding succeeds but the CLI cannot connect, check `adb -s "$pilot_device" shell cat /proc/net/unix | grep tauri-pilot` and compare the name with the current startup log. The plugin only listens in debug builds.
 
-Remove the forwarding when finished:
+Remove the forwarding created above when finished:
 
 ```sh
 adb -s "$pilot_device" forward --remove "localfilesystem:$TAURI_PILOT_SOCKET"
@@ -168,4 +168,11 @@ rmdir "$pilot_dir"
 unset TAURI_PILOT_SOCKET
 ```
 
-On Linux, forwarding to a socket named `tauri-pilot-{identifier}.sock` inside your private `$XDG_RUNTIME_DIR` also enables CLI auto-discovery. Keep the runtime directory when cleaning up. Use a private directory rather than a bare `/tmp` socket, since ADB creates the host socket with its own permissions.
+On Linux, forwarding to a socket named `tauri-pilot-{identifier}.sock` inside your private `$XDG_RUNTIME_DIR` also enables CLI auto-discovery without `TAURI_PILOT_SOCKET`. For this alternative, remove only the forward and socket when finished, keeping the runtime directory:
+
+```sh
+adb -s "$pilot_device" forward --remove "localfilesystem:$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock"
+rm -f "$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock"
+```
+
+Use a private directory rather than a bare `/tmp` socket, since ADB creates the host socket with its own permissions.

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -112,7 +112,7 @@ cargo tauri dev
 
 ## Android via ADB
 
-On macOS or Linux, follow the setup above with `default-features = false` (Android has no native `press`) and register the plugin in `src-tauri/src/lib.rs`. Start the app with `cargo tauri android dev`.
+On macOS or Linux, follow the setup above with `default-features = false` (Android has no native `press`) and register the plugin in the mobile `run()` entry point in `src-tauri/src/lib.rs`. Start the app with `cargo tauri android dev`.
 
 Connect a device or emulator through ADB, then replace `com.example.app` below with the identifier from `tauri.conf.json`:
 

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -112,21 +112,58 @@ cargo tauri dev
 
 ## Android via ADB
 
-On macOS or Linux, follow the setup above with `default-features = false` (Android has no native `press`) and register the plugin in the mobile `run()` entry point in `src-tauri/src/lib.rs`. Start the app with `cargo tauri android dev`.
+The computer running the CLI must use Linux or macOS. The Windows CLI uses named pipes and cannot use this Unix socket forwarding setup.
 
-Connect a device or emulator through ADB, then replace `com.example.app` below with the identifier from `tauri.conf.json`:
+Before connecting:
+
+- Complete [Tauri's Android prerequisites](https://v2.tauri.app/start/prerequisites/#android), including the SDK, NDK, `ANDROID_HOME` and `NDK_HOME`, and put `adb` on `PATH`.
+- Run `cargo tauri android init` once for the app. Use an emulator or a device with USB debugging enabled and the computer authorized.
+- Register the plugin in the mobile `run()` entry point in `src-tauri/src/lib.rs`, with the debug guard and `pilot:default` permission shown above.
+- Configure the app's logging to capture `tauri_plugin_pilot` tracing events at info level. The listening event contains the socket name needed for forwarding.
+
+Disabling the desktop `press` backend on Android is recommended. Replace the shared plugin dependency with target-specific entries so desktop builds keep it enabled:
+
+```toml
+[target.'cfg(target_os = "android")'.dependencies]
+tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", default-features = false }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
+```
+
+Start a debug build with `cargo tauri android dev`. Select the device and read the `tauri-pilot socket listening` event from the app's startup logs; for apps logging to Logcat:
 
 ```sh
-pilot_dir=$(mktemp -d /tmp/tauri-pilot.XXXXXX)
-adb forward "localfilesystem:$pilot_dir/pilot.sock" \
-  localabstract:tauri-pilot-com.example.app.sock
-tauri-pilot --socket "$pilot_dir/pilot.sock" snapshot
+adb devices -l
+pilot_device=YOUR_DEVICE_SERIAL
+adb -s "$pilot_device" logcat -d | grep 'tauri-pilot socket listening'
 ```
+
+Copy the complete `tauri-pilot-{identifier}-{random}.sock` name into `pilot_name` below. It changes each time the app starts, so update the forwarding after a restart. Once the page has loaded:
+
+```sh
+pilot_name=NAME_FROM_STARTUP_LOG
+pilot_dir=$(mktemp -d /tmp/tauri-pilot.XXXXXX)
+export TAURI_PILOT_SOCKET="$pilot_dir/pilot.sock"
+adb -s "$pilot_device" forward "localfilesystem:$TAURI_PILOT_SOCKET" \
+  "localabstract:$pilot_name"
+tauri-pilot ping
+tauri-pilot snapshot
+```
+
+Use the same `-s "$pilot_device"` for all ADB commands when multiple devices are connected. `TAURI_PILOT_SOCKET` also applies to subsequent CLI commands and MCP processes launched from this shell.
+
+`press` is unavailable on Android and `screenshot_native` is macOS-only. Use `fill` or `type` for text input. Window operations are limited to the mobile app's single window.
+
+If forwarding succeeds but the CLI cannot connect, check `adb -s "$pilot_device" shell cat /proc/net/unix | grep tauri-pilot` and compare the name with the current startup log. The plugin only listens in debug builds.
 
 Remove the forwarding when finished:
 
 ```sh
-adb forward --remove "localfilesystem:$pilot_dir/pilot.sock"
-rm -f "$pilot_dir/pilot.sock"
+adb -s "$pilot_device" forward --remove "localfilesystem:$TAURI_PILOT_SOCKET"
+rm -f "$TAURI_PILOT_SOCKET"
 rmdir "$pilot_dir"
+unset TAURI_PILOT_SOCKET
 ```
+
+On Linux, forwarding to a socket named `tauri-pilot-{identifier}.sock` inside your private `$XDG_RUNTIME_DIR` also enables CLI auto-discovery. Keep the runtime directory when cleaning up. Use a private directory rather than a bare `/tmp` socket, since ADB creates the host socket with its own permissions.

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -131,12 +131,14 @@ tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", default-fe
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
 ```
 
-Start a debug build with `cargo tauri android dev`. Select the device and read the `tauri-pilot socket listening` event from the app's startup logs; for apps logging to Logcat:
+Start a debug build with `cargo tauri android dev`. Select the device and read the `tauri-pilot socket listening` event from the intended app's startup logs. For apps logging to Logcat, use the Android application ID to select its process:
 
 ```sh
 adb devices -l
 pilot_device=YOUR_DEVICE_SERIAL
-adb -s "$pilot_device" logcat -d | grep 'tauri-pilot socket listening'
+pilot_package=YOUR_ANDROID_APPLICATION_ID
+pilot_pid=$(adb -s "$pilot_device" shell pidof "$pilot_package")
+adb -s "$pilot_device" logcat -d --pid="$pilot_pid" | grep 'tauri-pilot socket listening'
 ```
 
 Copy the complete `tauri-pilot-{identifier}-{random}.sock` name into `pilot_name` below. It changes each time the app starts, so update the forwarding after a restart. Once the page has loaded:

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -385,7 +385,8 @@ tauri-pilot type @e2 " additional text"
 
 Inject keyboard events at the OS level via [`enigo`](https://crates.io/crates/enigo).
 Events are `isTrusted=true` and reach DOM listeners and Tauri accelerators on
-all supported platforms.
+supported desktop platforms. Android has no native `press` backend; use `fill`
+or `type` for text input.
 
 :::caution[X11 global shortcuts]
 On X11, synthetic key events from `enigo`'s `XTestFakeKeyEvent` backend


### PR DESCRIPTION
## Summary

- Add Android device and emulator support via ADB from macOS or Linux, as a first step toward mobile support.

## Motivation

I would like to bring tauri-pilot to mobile Tauri apps. For projects such as [TauriTavern](https://github.com/Darkatse/TauriTavern) that run on both desktop and mobile, inspecting and testing the mobile WebView is an important part of development.

## Changes

The implementation uses an abstract Unix socket on Android, forwarded by ADB to a local Unix socket on the host. This lets the existing CLI, JSON-RPC handlers and JS bridge be reused. Most of the change is in socket address handling and peer authentication.

Windows hosts need a further step: the Windows CLI currently connects through named pipes, while this setup gives the host a Unix socket. One option would be to forward a loopback TCP port through ADB to the same Android socket and add TCP connection support to the CLI. Would you be open to that approach? If so, I can submit a separate PR for it.

I also plan to work on iOS support, starting with the simulator.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Tested manually with a Tauri app (if applicable)

To check the approach, I used a small Tauri v2 app with a counter and a text input, built with `default-features = false`. From macOS, I connected to an Android emulator and a physical Android 16 device through ADB, then checked `ping`, snapshots, clicks, text input and assertions. I also checked the existing macOS socket connection.

`cargo check -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features` also passes.

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android device and emulator support via ADB, letting tauri-pilot inspect and test mobile WebViews without changing the existing CLI, JSON-RPC handlers, or JS bridge. Android uses a randomized per-instance abstract socket name (identifier capped at 16 characters plus a 16-hex random suffix) discoverable from the app's startup logs, and connections are authorized via kernel peer credentials (app, root, or ADB shell).

**Notes**
- Windows hosts need a TCP forward; a separate PR will add that.
- iOS support is planned next, starting with the simulator.

<sup>Written for commit c758c6b9bb8c264cbde710c1ec1a7dd9ab86b10c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android device and emulator support through ADB socket forwarding.
  * Added secure connection authorization for Android app, root, and ADB shell access.

* **Documentation**
  * Added Android setup guidance, including configuration, socket forwarding, device selection, troubleshooting, and cleanup.
  * Documented Android limitations, including unsupported Windows hosts and keyboard injection; use text input commands instead.
  * Updated platform requirements and security information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->