### PR TITLE
fix(bridge): curate the style properties screenshot copies onto the clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dangerous_mcp_tools_enabled`; it reads `.is_ok_and(...)` now, same
   behaviour.
 
+- `screenshot` no longer pins the webview for minutes on style-variable-heavy
+  pages. html-to-image copies computed styles onto the clone, and whenever
+  `getComputedStyle(el).cssText` is empty — WebKit and Blink both — it falls
+  back to one `setProperty` per name in `getComputedStyle(documentElement)`.
+  On a Tailwind v4 page that is ~2200 names, ~1760 of them custom properties,
+  applied to every cloned element; macOS WebKit re-serializes the whole style
+  attribute on each call, making the clone quadratic (~370 s and 100 % CPU on a
+  648-node page, with every later bridge call timing out until it finished).
+  The bridge now passes a curated `includeStyleProperties` list of the
+  properties a page actually paints, so the copy drops from ~2240 to 158
+  `setProperty` calls per element (28x faster end-to-end on a Chromium repro of
+  that page, pixel-identical output). Custom properties are dropped on purpose:
+  computed values already arrive with their `var()` resolved. [#146]
+
 ## [0.7.3] - 2026-08-30
 
 ### Changed
@@ -619,3 +633,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#142]: https://github.com/mpiton/tauri-pilot/pull/142
 [#143]: https://github.com/mpiton/tauri-pilot/pull/143
 [#145]: https://github.com/mpiton/tauri-pilot/pull/145
+[#146]: https://github.com/mpiton/tauri-pilot/issues/146

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repro of that page at the original 156-name cut, pixel-identical output).
   Custom properties are dropped on purpose: computed values already arrive with
   their `var()` resolved. The list is an allowlist, though, so a standard
-  painted property that is not on it is missing from the capture as well —
-  `screenshot_native` remains the pixel-exact escape hatch. [#146]
+  painted property that is not on it is missing from the capture as well;
+  on macOS `screenshot_native` remains the pixel-exact escape hatch. [#146]
 
 ## [0.7.3] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attribute on each call, making the clone quadratic (~370 s and 100 % CPU on a
   648-node page, with every later bridge call timing out until it finished).
   The bridge now passes a curated `includeStyleProperties` list of the
-  properties a page actually paints, so the copy drops from ~2240 to 158
-  `setProperty` calls per element (28x faster end-to-end on a Chromium repro of
-  that page, pixel-identical output). Custom properties are dropped on purpose:
-  computed values already arrive with their `var()` resolved. [#146]
+  properties a page actually paints, so the copy drops from ~2200 to 187
+  `setProperty` calls per element (measured 28x faster end-to-end on a Chromium
+  repro of that page at the original 156-name cut, pixel-identical output).
+  Custom properties are dropped on purpose: computed values already arrive with
+  their `var()` resolved. The list is an allowlist, though, so a standard
+  painted property that is not on it is missing from the capture as well —
+  `screenshot_native` remains the pixel-exact escape hatch. [#146]
 
 ## [0.7.3] - 2026-08-30
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1205,7 +1205,7 @@
     "max-height", "box-sizing", "aspect-ratio", "margin-top", "margin-right",
     "margin-bottom", "margin-left", "padding-top", "padding-right",
     "padding-bottom", "padding-left", "overflow-x", "overflow-y", "visibility",
-    "opacity", "vertical-align",
+    "opacity", "vertical-align", "content-visibility", "clip",
     // Flex + grid
     "flex-direction", "flex-wrap", "flex-grow", "flex-shrink", "flex-basis",
     "justify-content", "justify-items", "justify-self", "align-content",
@@ -1213,7 +1213,7 @@
     "grid-template-columns", "grid-template-rows", "grid-template-areas",
     "grid-auto-flow", "grid-auto-columns", "grid-auto-rows",
     "grid-column-start", "grid-column-end", "grid-row-start", "grid-row-end",
-    "column-count",
+    "column-count", "column-width",
     // Background + border
     "background-color", "background-image", "background-position",
     "background-size", "background-repeat", "background-clip",
@@ -1226,10 +1226,14 @@
     "border-bottom-right-radius", "border-bottom-left-radius",
     "border-collapse", "border-spacing", "table-layout", "outline-color",
     "outline-style", "outline-width", "outline-offset", "box-shadow",
+    "border-image-source", "border-image-slice", "border-image-width",
+    "border-image-outset", "border-image-repeat",
     // Paint effects
-    "filter", "backdrop-filter", "mix-blend-mode", "clip-path", "mask-image",
-    "transform", "transform-origin", "transform-style", "translate", "rotate",
-    "scale", "perspective",
+    "filter", "backdrop-filter", "mix-blend-mode", "background-blend-mode",
+    "isolation", "clip-path", "mask-image", "mask-size", "mask-position",
+    "mask-repeat", "mask-mode", "mask-composite", "transform",
+    "transform-origin", "transform-style", "translate", "rotate", "scale",
+    "perspective", "perspective-origin", "backface-visibility",
     // Text
     "color", "font-family", "font-size", "font-weight", "font-style",
     "font-variant", "font-stretch", "font-feature-settings",
@@ -1237,16 +1241,21 @@
     "text-align", "text-indent", "text-transform", "text-shadow",
     "text-overflow", "text-decoration-line", "text-decoration-color",
     "text-decoration-style", "text-decoration-thickness",
-    "text-underline-offset", "-webkit-text-fill-color", "-webkit-text-stroke",
+    "text-underline-offset", "-webkit-text-fill-color",
+    "-webkit-text-stroke-width", "-webkit-text-stroke-color",
+    "-webkit-text-security", "-webkit-font-smoothing",
     "-webkit-line-clamp", "-webkit-box-orient", "white-space", "word-break",
     "overflow-wrap", "hyphens", "direction", "unicode-bidi", "writing-mode",
     "text-orientation", "tab-size", "list-style-type", "list-style-position",
-    "list-style-image", "content",
+    "list-style-image", "content", "counter-reset", "counter-increment",
     // Replaced content + SVG
     "object-fit", "object-position", "image-rendering", "fill", "fill-opacity",
     "fill-rule", "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
     "stroke-linejoin", "stroke-dasharray", "stroke-dashoffset", "clip-rule",
-    "stop-color", "stop-opacity", "d",
+    "stop-color", "stop-opacity", "d", "text-anchor", "dominant-baseline",
+    "paint-order", "marker-start", "marker-mid", "marker-end",
+    // Form controls
+    "appearance", "-webkit-appearance", "accent-color",
   ];
 
   async function screenshot(options) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1248,6 +1248,7 @@
     "overflow-wrap", "hyphens", "direction", "unicode-bidi", "writing-mode",
     "text-orientation", "tab-size", "list-style-type", "list-style-position",
     "list-style-image", "content", "counter-reset", "counter-increment",
+    "counter-set",
     // Replaced content + SVG
     "object-fit", "object-position", "image-rendering", "fill", "fill-opacity",
     "fill-rule", "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1188,6 +1188,67 @@
     });
   }
 
+  // html-to-image copies computed styles onto the clone. When
+  // `getComputedStyle(el).cssText` is empty — WebKit and Blink both — it falls
+  // back to one `setProperty` per name in `getComputedStyle(documentElement)`,
+  // which on a Tailwind v4 page is ~2200 names (~1760 of them custom
+  // properties). WebKit re-serializes the whole style attribute on every
+  // `setProperty`, so that copy is quadratic: minutes of 100% CPU on a few
+  // hundred nodes, and the webview stays wedged past the RPC timeout (#146).
+  // Custom properties are dead weight here — computed values arrive with their
+  // `var()` already resolved — so we hand html-to-image the painted properties
+  // only. Anything not in this list is lost from the capture.
+  var STYLE_PROPERTIES = [
+    // Box + layout
+    "display", "position", "top", "right", "bottom", "left", "float", "clear",
+    "z-index", "width", "height", "min-width", "min-height", "max-width",
+    "max-height", "box-sizing", "aspect-ratio", "margin-top", "margin-right",
+    "margin-bottom", "margin-left", "padding-top", "padding-right",
+    "padding-bottom", "padding-left", "overflow-x", "overflow-y", "visibility",
+    "opacity", "vertical-align",
+    // Flex + grid
+    "flex-direction", "flex-wrap", "flex-grow", "flex-shrink", "flex-basis",
+    "justify-content", "justify-items", "justify-self", "align-content",
+    "align-items", "align-self", "order", "row-gap", "column-gap",
+    "grid-template-columns", "grid-template-rows", "grid-template-areas",
+    "grid-auto-flow", "grid-auto-columns", "grid-auto-rows",
+    "grid-column-start", "grid-column-end", "grid-row-start", "grid-row-end",
+    "column-count",
+    // Background + border
+    "background-color", "background-image", "background-position",
+    "background-size", "background-repeat", "background-clip",
+    "background-origin", "background-attachment", "-webkit-background-clip",
+    "border-top-width", "border-right-width", "border-bottom-width",
+    "border-left-width", "border-top-style", "border-right-style",
+    "border-bottom-style", "border-left-style", "border-top-color",
+    "border-right-color", "border-bottom-color", "border-left-color",
+    "border-top-left-radius", "border-top-right-radius",
+    "border-bottom-right-radius", "border-bottom-left-radius",
+    "border-collapse", "border-spacing", "table-layout", "outline-color",
+    "outline-style", "outline-width", "outline-offset", "box-shadow",
+    // Paint effects
+    "filter", "backdrop-filter", "mix-blend-mode", "clip-path", "mask-image",
+    "transform", "transform-origin", "transform-style", "translate", "rotate",
+    "scale", "perspective",
+    // Text
+    "color", "font-family", "font-size", "font-weight", "font-style",
+    "font-variant", "font-stretch", "font-feature-settings",
+    "font-variation-settings", "line-height", "letter-spacing", "word-spacing",
+    "text-align", "text-indent", "text-transform", "text-shadow",
+    "text-overflow", "text-decoration-line", "text-decoration-color",
+    "text-decoration-style", "text-decoration-thickness",
+    "text-underline-offset", "-webkit-text-fill-color", "-webkit-text-stroke",
+    "-webkit-line-clamp", "-webkit-box-orient", "white-space", "word-break",
+    "overflow-wrap", "hyphens", "direction", "unicode-bidi", "writing-mode",
+    "text-orientation", "tab-size", "list-style-type", "list-style-position",
+    "list-style-image", "content",
+    // Replaced content + SVG
+    "object-fit", "object-position", "image-rendering", "fill", "fill-opacity",
+    "fill-rule", "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
+    "stroke-linejoin", "stroke-dasharray", "stroke-dashoffset", "clip-rule",
+    "stop-color", "stop-opacity", "d",
+  ];
+
   async function screenshot(options) {
     var selector = options && options.selector;
     var el = selector ? document.querySelector(selector) : document.documentElement;
@@ -1195,7 +1256,7 @@
     if (typeof htmlToImage === "undefined" || !htmlToImage.toPng) {
       throw new Error("html-to-image library not loaded. Bundle it into bridge.js for screenshot support.");
     }
-    var renderOptions = { pixelRatio: 1 };
+    var renderOptions = { pixelRatio: 1, includeStyleProperties: STYLE_PROPERTIES };
     if (!selector) {
       // html-to-image sizes the capture from clientWidth/clientHeight, which
       // for documentElement is the viewport — the render always starts at the

--- a/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
@@ -117,3 +117,37 @@ test("screenshot with unmatched selector throws element not found", async () => 
     /Element not found: #missing/,
   );
 });
+
+// #146: html-to-image's per-property clone path (taken whenever
+// `getComputedStyle(el).cssText` is empty — WebKit and Blink both) copies every
+// name returned by `getComputedStyle(document.documentElement)` onto every
+// cloned element. On a Tailwind v4 page that list is ~2200 names, ~1760 of them
+// custom properties, and WebKit re-serializes the whole style attribute on each
+// `setProperty` — quadratic, minutes of wedged webview. The bridge must hand
+// html-to-image a curated list instead.
+test("screenshot restricts the style properties html-to-image copies", async () => {
+  const documentElement = { scrollWidth: 800, scrollHeight: 600 };
+  const { pilot, calls } = loadBridge({ documentElement, body: null });
+
+  await pilot.screenshot({});
+
+  const props = calls[0].options.includeStyleProperties;
+  assert.ok(Array.isArray(props), "includeStyleProperties must be passed");
+  // A few hundred names is already quadratic pain on WebKit; keep it small.
+  assert.ok(props.length < 200, `expected a curated list, got ${props.length}`);
+  assert.equal(props.filter((p) => p.startsWith("--")).length, 0);
+  // Anything the page actually paints has to survive the clone.
+  for (const required of [
+    "color",
+    "background-color",
+    "font-family",
+    "border-top-width",
+    "transform",
+    "transform-origin",
+    "content",
+    "fill",
+  ]) {
+    assert.ok(props.includes(required), `missing ${required}`);
+  }
+  assert.equal(new Set(props).size, props.length, "duplicate property names");
+});

--- a/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
@@ -107,6 +107,9 @@ test("screenshot with selector does not override element dimensions", async () =
   assert.equal("width" in calls[0].options, false);
   assert.equal("height" in calls[0].options, false);
   assert.equal(calls[0].options.pixelRatio, 1);
+  // #146 hits element captures too — the CLI and the MCP tool both take this
+  // path for `--selector`, so the curated list must be passed here as well.
+  assert.ok(Array.isArray(calls[0].options.includeStyleProperties));
 });
 
 test("screenshot with unmatched selector throws element not found", async () => {
@@ -136,18 +139,46 @@ test("screenshot restricts the style properties html-to-image copies", async () 
   // A few hundred names is already quadratic pain on WebKit; keep it small.
   assert.ok(props.length < 200, `expected a curated list, got ${props.length}`);
   assert.equal(props.filter((p) => p.startsWith("--")).length, 0);
-  // Anything the page actually paints has to survive the clone.
+  // Anything the page actually paints has to survive the clone. At least one
+  // name per block of STYLE_PROPERTIES, so deleting a whole category fails
+  // here instead of silently flattening every capture.
   for (const required of [
-    "color",
-    "background-color",
-    "font-family",
+    "display", // box + layout
+    "content-visibility", // ... and the two that hide a subtree
+    "clip",
+    "flex-direction", // flex + grid
+    "background-color", // background + border
     "border-top-width",
-    "transform",
+    "border-image-source",
+    "transform", // paint effects
     "transform-origin",
+    "mask-size",
+    "color", // text
+    "font-family",
     "content",
-    "fill",
+    "-webkit-text-security", // author-masked fields must stay masked
+    "fill", // replaced content + SVG
+    "text-anchor",
+    "appearance", // form controls
   ]) {
     assert.ok(props.includes(required), `missing ${required}`);
   }
   assert.equal(new Set(props).size, props.length, "duplicate property names");
+});
+
+// The whole fix rests on one expression in the vendored bundle:
+// `t.includeStyleProperties ? ... : f(getComputedStyle(documentElement))`.
+// html-to-image silently ignores options it does not know, so a version bump
+// that renames or drops it would put the ~2200-name enumeration back on every
+// cloned element with the suite still green. Pin the option to the artifact.
+test("the vendored html-to-image still reads includeStyleProperties", () => {
+  const vendor = readFileSync(
+    join(here, "vendor", "html-to-image.iife.js"),
+    "utf8",
+  );
+  assert.ok(
+    vendor.includes("includeStyleProperties"),
+    "vendored html-to-image dropped includeStyleProperties: re-check " +
+      "scripts/build-html-to-image.sh against the upstream pin (#146)",
+  );
 });

--- a/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.screenshot.test.mjs
@@ -176,9 +176,15 @@ test("the vendored html-to-image still reads includeStyleProperties", () => {
     join(here, "vendor", "html-to-image.iife.js"),
     "utf8",
   );
+  // `includeStyleProperties?` rather than the bare name: the option has to be
+  // *read as a condition*, which is the shape of the expression that picks it
+  // over the full enumeration. The minifier renames the parameter, never the
+  // property, so this survives a rebuild of the same upstream code and fails
+  // if a version bump drops the branch.
   assert.ok(
-    vendor.includes("includeStyleProperties"),
-    "vendored html-to-image dropped includeStyleProperties: re-check " +
-      "scripts/build-html-to-image.sh against the upstream pin (#146)",
+    vendor.includes("includeStyleProperties?"),
+    "vendored html-to-image no longer reads includeStyleProperties as a " +
+      "condition: re-check scripts/build-html-to-image.sh against the " +
+      "upstream pin (#146)",
   );
 });

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -869,6 +869,13 @@ entire page from the top. Use `--selector` to capture a single element
 (works for elements below the fold too). For a pixel-exact capture of the
 native window, use `screenshot_native`.
 
+The bridge also copies only an allowlist of painted CSS properties onto the
+clone it renders (a full computed-style copy wedges WebKit for minutes on
+style-variable-heavy pages). A page that paints through a property outside
+that list renders without it, with no error — if the PNG does not match what
+you see in the app, that is the first thing to check, and `screenshot_native`
+is the way around it.
+
 **Arguments:**
 
 | Argument | Description |

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -867,14 +867,15 @@ the visible viewport. The bridge serializes the DOM to render it, so the
 current scroll position is not reflected in the image — what you get is the
 entire page from the top. Use `--selector` to capture a single element
 (works for elements below the fold too). For a pixel-exact capture of the
-native window, use `screenshot_native`.
+native window, use `screenshot_native` — macOS only, it returns
+`PERMISSION_DENIED` on Linux and Windows.
 
 The bridge also copies only an allowlist of painted CSS properties onto the
 clone it renders (a full computed-style copy wedges WebKit for minutes on
 style-variable-heavy pages). A page that paints through a property outside
-that list renders without it, with no error — if the PNG does not match what
-you see in the app, that is the first thing to check, and `screenshot_native`
-is the way around it.
+that list renders without it, with no error, so if the PNG does not match
+what you see in the app that is the first thing to check. On macOS,
+`screenshot_native` sidesteps the allowlist entirely.
 
 **Arguments:**
 


### PR DESCRIPTION
Closes #146.

## What was wrong

`screenshot()` calls `htmlToImage.toPng()` without `includeStyleProperties`. In the vendored bundle, `cloneCSSStyle` does:

```js
i.cssText ? (n.cssText = i.cssText, …) : R(r).forEach(o => n.setProperty(o, …))
```

`getComputedStyle(el).cssText` is empty on WebKit *and* Blink (checked in headless Chromium: `cssText.length === 0`), so the per-property branch is always the one taken. `R()` returns every name from `getComputedStyle(document.documentElement)`, custom properties included — ~2200 names on a Tailwind v4 page, ~1760 of them `--*` — and copies all of them onto every cloned element.

macOS 26 WebKit re-serializes the entire style attribute on each `setProperty` (`InlineCSSStyleProperties::didMutate` -> `StyleProperties::asTextAtom` -> `ShorthandSerializer::commonSerializationChecks`, 1195 of 2039 samples in the profile on the issue), which makes the copy quadratic in the property count. The clone loop is synchronous, so the 30 s eval timeout cannot interrupt it and every later bridge call (`eval`, `logs`, `ipc`, `state`) times out until it finishes — the ~10 minute wedge described in the issue.

## The change

Pass `includeStyleProperties` with a curated list of the properties a page actually paints: box and layout, flex/grid, background/border, paint effects, text (including `-webkit-text-fill-color`, `-webkit-line-clamp`, `-webkit-background-clip`), `content` for `::before`/`::after`, replaced content, SVG and the `d` property the library special-cases.

Custom properties are dropped on purpose — computed values arrive with their `var()` already resolved, so nothing on the clone reads them. The tradeoff is real and worth stating: **a painted property missing from this list is missing from the capture**, so the list is the thing to extend when a screenshot comes back wrong.

## Verification

Repro harness: headless Chromium page loading the *real* vendor + bridge.js concatenation (same as the plugin's `concat!`), 648 nodes and 1761 custom properties on `:root`, with `CSSStyleDeclaration.prototype.setProperty` counted.

| | setProperty/element | total | ms (Chromium) |
|---|---|---|---|
| before | 2239 | 2 919 656 | 13 568 |
| after | 158 | 206 032 | 486 |

Isolated: `perElement = 478 standard longhands + number of custom properties`. Chromium is not quadratic per call, so the 13.5 s here is what shows up as ~370 s on the reported macOS build.

Fidelity: a page with gradients, gradient-clipped text, box shadows, flex, grid, list markers, `::after` content, inline SVG and line-clamp renders **pixel-identical** before and after (same PNG md5).

`node --test crates/tauri-plugin-pilot/js/*.test.mjs` 31/31 (the new test is red without the fix), `cargo test --workspace` 315/315.

## Not in this PR

- Estimated macOS cost after the fix is ~4 s on that page, not under a second. Going lower means one `cssText =` assignment instead of N `setProperty` calls, which the library exposes no option for — it would take patching the vendored bundle.
- The two CLI gaps reported alongside this one (`screenshot_native` not printing `available_windows` from `error.data`, and `scale_factor: 2.87` under `tcc_denied`) are separate bugs, untouched here. Filed as #149.
- `cargo clippy --all-targets` already fails on `main` in the CLI crate's MCP module, line 679 (`manual_is_variant_and`, new lint). Pre-existing, fixed separately in #148.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #146 by replacing html-to-image's full computed-style copy during `screenshot()` with a curated 187-property allowlist. This avoids the quadratic WebKit work that can wedge style-variable-heavy pages for minutes, while CSS painted through properties outside the list is omitted from the image.

**Bug Fixes**
- Preserves masked fields, hidden subtrees, counters including `counter-set`, SVG content, masks, and form controls.
- Applies the allowlist to selector captures and verifies that the vendored html-to-image bundle still reads it.
- `screenshot_native` remains the pixel-exact fallback on macOS; it returns `PERMISSION_DENIED` on Linux and Windows.

<sup>Written for commit f8678029115d81844c5051cabf228aafdffe49f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screenshot performance, particularly on pages with many custom CSS properties.
  - Screenshot rendering now uses a curated set of visual styles, including counter styles, for more efficient and consistent captures.

- **Documentation**
  - Documented that unsupported CSS properties may be omitted and could cause PNG output to differ from the app.
  - Clarified that native screenshots are macOS-only, bypass the CSS-property allowlist, and return `PERMISSION_DENIED` on Linux and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
