### PR TITLE
fix(cli): read the dangerous-tools env var with is_ok_and

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forwarded with `adb forward localfilesystem:... localabstract:...`. Connections
   require matching UID/GID pairs for the app, root or ADB shell. [#145]
 
+### Fixed
+
+- `cargo clippy --all-targets -- -D warnings` passes again. The new
+  `manual_is_variant_and` lint rejects the `.ok().is_some_and(...)` in
+  `dangerous_mcp_tools_enabled`; it reads `.is_ok_and(...)` now, same
+  behaviour.
+
 ## [0.7.3] - 2026-08-30
 
 ### Changed

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -676,14 +676,12 @@ fn namespaced_tool_name(name: &str) -> String {
 }
 
 fn dangerous_mcp_tools_enabled() -> bool {
-    std::env::var(ENABLE_DANGEROUS_MCP_TOOLS_ENV)
-        .ok()
-        .is_some_and(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
+    std::env::var(ENABLE_DANGEROUS_MCP_TOOLS_ENV).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 fn validate_navigate_url(url: &str) -> Result<(), McpError> {


### PR DESCRIPTION
## Why

`cargo clippy --workspace --all-targets -- -D warnings` fails on `main`:

```
error: called `.ok().is_some_and(..)` on a `Result` value
   --> crates/tauri-pilot-cli/src/mcp.rs:679:5
    = note: `-D clippy::manual-is-variant-and` implied by `-D warnings`
    = help: use `is_ok_and` instead
```

`manual_is_variant_and` is new in the clippy release the toolchain picked up. Nothing in the code changed, the lint did — so every PR opened against `main` starts red on the lint job, including #147.

## What

`std::env::var(..).ok().is_some_and(..)` becomes `std::env::var(..).is_ok_and(..)` in `dangerous_mcp_tools_enabled`. Identical semantics: `Result::is_ok_and` is what `.ok().is_some_and(..)` desugars to, minus the intermediate `Option`.

No test added. The change has no behaviour to cover that `matches!` arm did not already have, and the gate itself (`DANGEROUS_MCP_TOOLS` refused unless the env var is set) is exercised by the existing MCP suite.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` 319 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `cargo clippy --workspace --all-targets -- -D warnings` check on `main` by replacing `.ok().is_some_and(..)` with `.is_ok_and(..)` in `dangerous_mcp_tools_enabled`. The new clippy lint `manual_is_variant_and` rejects the old form, so every PR was opening red.

Semantics are identical — `is_ok_and` is the direct equivalent desugaring. No tests added because the existing MCP suite already covers the env-var gate, and the change only swaps the combinator. Also updates the changelog.

<sup>Written for commit 8e80d412d497699bff9d8bfda00bcab053cc8a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation reliability without changing the accepted configuration values or application behavior.
  * Resolved static analysis warnings to support cleaner, more consistent builds.

* **Documentation**
  * Added an Unreleased changelog entry describing the validation and build-quality improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->