### PR TITLE
fix: surface RPC error data and drop the bogus scale_factor under tcc_denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message and dropped `error.data`, so a `WINDOW_NOT_FOUND` printed nothing of
   the `available_windows` list the plugin builds for it. The fix is in the
   shared error path, so any command whose plugin side attaches structured data
-  keeps it. [#149]
+  keeps it. The plugin mirrors `message` into `data`, and the CLI drops that
+  key only when it is the exact duplicate, so a producer with a distinct
+  `data.message` still prints it. [#149]
 
-- `screenshot_native` no longer reports a made-up `scale_factor` when screen
-  recording is denied. The value was the captured PNG's pixel width divided by
-  the window's logical width, which only holds when the PNG is the window —
-  under `tcc_denied` the `CGWindowList` fallback returns a screen-sized image
-  instead, yielding numbers like `2.87` on a 2.0 display. It is `null` now.
-  [#149]
+- `screenshot_native` no longer reports a made-up `scale_factor`. The value was
+  the captured PNG's pixel width divided by the window's logical width, which
+  only holds when the PNG is the window. It comes from both axes now and is
+  `null` when they disagree on the ratio: with screen recording denied the
+  `CGWindowList` fallback returns a screen-sized image (2.87 across against
+  2.79 down on a 2.0 display), and the permitted path was off too because
+  `screencapture` padded its own PNG with the window's drop shadow. The
+  `tcc_denied` flag no longer gates the derivation — it reports a permission
+  state, and `capture_with_fallback` raises it after a granted probe whose
+  per-window capture failed for some other reason. [#149]
 
 - `cargo clippy --all-targets -- -D warnings` passes again. The new
   `manual_is_variant_and` lint rejects the `.ok().is_some_and(...)` in
@@ -51,6 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their `var()` resolved. The list is an allowlist, though, so a standard
   painted property that is not on it is missing from the capture as well;
   on macOS `screenshot_native` remains the pixel-exact escape hatch. [#146]
+
+### Changed
+
+- macOS native captures no longer include the window's drop shadow.
+  `capture_screencapture` passes `screencapture -o`, so the PNG matches
+  `kCGWindowBounds` and the scale factor is derivable from it. [#149]
+
+### Security
+
+- `available_windows`, returned with a `WINDOW_NOT_FOUND` error, no longer
+  carries the titles of windows owned by other processes. The list walks every
+  on-screen window, and now that the CLI renders `error.data` that payload
+  reaches stderr and the MCP client, so one stale `--window-id` would have
+  handed a developer's document names, URLs and chat titles to whatever model
+  backs that client. `window_id` and `owner` are what a caller needs to
+  retarget. [#149]
 
 ## [0.7.3] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `screencapture` padded its own PNG with the window's drop shadow. The
   `tcc_denied` flag no longer gates the derivation — it reports a permission
   state, and `capture_with_fallback` raises it after a granted probe whose
-  per-window capture failed for some other reason. [#149]
+  per-window capture failed for some other reason. Two agreeing ratios are not
+  proof by themselves, since a screen-sized image whose aspect happens to match
+  the window's would pass, so the capture's provenance gates them: a
+  `CGWindowList` PNG asks for `kCGWindowImageNominalResolution` and can only
+  legitimately be 1:1, and anything else from that backend gets no scale.
+  [#149]
 
 - `cargo clippy --all-targets -- -D warnings` passes again. The new
   `manual_is_variant_and` lint rejects the `.ok().is_some_and(...)` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `screenshot_native` errors now carry their detail to the terminal. Every RPC
+  error went through one `bail!` in the CLI client that kept the code and the
+  message and dropped `error.data`, so a `WINDOW_NOT_FOUND` printed nothing of
+  the `available_windows` list the plugin builds for it. The fix is in the
+  shared error path, so any command whose plugin side attaches structured data
+  keeps it. [#149]
+
+- `screenshot_native` no longer reports a made-up `scale_factor` when screen
+  recording is denied. The value was the captured PNG's pixel width divided by
+  the window's logical width, which only holds when the PNG is the window —
+  under `tcc_denied` the `CGWindowList` fallback returns a screen-sized image
+  instead, yielding numbers like `2.87` on a 2.0 display. It is `null` now.
+  [#149]
+
 - `cargo clippy --all-targets -- -D warnings` passes again. The new
   `manual_is_variant_and` lint rejects the `.ok().is_some_and(...)` in
   `dangerous_mcp_tools_enabled`; it reads `.is_ok_and(...)` now, same
@@ -637,3 +651,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#143]: https://github.com/mpiton/tauri-pilot/pull/143
 [#145]: https://github.com/mpiton/tauri-pilot/pull/145
 [#146]: https://github.com/mpiton/tauri-pilot/issues/146
+[#149]: https://github.com/mpiton/tauri-pilot/issues/149

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -68,10 +68,18 @@ impl Client {
             // only way a caller learns, say, the real window ids behind a
             // WINDOW_NOT_FOUND. Render it under the message instead of
             // dropping it (#149). `message` is mirrored into `data` by the
-            // plugin, so drop that key rather than printing it twice.
+            // plugin, so drop that key rather than printing it twice — but
+            // only when it really is the duplicate: the two crates ship
+            // separately, so a producer carrying a distinct `data.message`
+            // must not lose it in the very path that was fixed to stop
+            // losing detail.
             let detail = match err.data {
                 Some(serde_json::Value::Object(mut obj)) => {
-                    obj.remove("message");
+                    if obj.get("message").and_then(serde_json::Value::as_str)
+                        == Some(err.message.as_str())
+                    {
+                        obj.remove("message");
+                    }
                     if obj.is_empty() {
                         String::new()
                     } else {

--- a/crates/tauri-pilot-cli/src/client/mod.rs
+++ b/crates/tauri-pilot-cli/src/client/mod.rs
@@ -64,7 +64,29 @@ impl Client {
         }
 
         if let Some(err) = response.error {
-            bail!("RPC error ({}): {}", err.code, err.message);
+            // Structured detail the plugin attaches under `error.data` is the
+            // only way a caller learns, say, the real window ids behind a
+            // WINDOW_NOT_FOUND. Render it under the message instead of
+            // dropping it (#149). `message` is mirrored into `data` by the
+            // plugin, so drop that key rather than printing it twice.
+            let detail = match err.data {
+                Some(serde_json::Value::Object(mut obj)) => {
+                    obj.remove("message");
+                    if obj.is_empty() {
+                        String::new()
+                    } else {
+                        let data = serde_json::Value::Object(obj);
+                        format!(
+                            "\n{}",
+                            serde_json::to_string_pretty(&data)
+                                .unwrap_or_else(|_| data.to_string())
+                        )
+                    }
+                }
+                Some(data) if !data.is_null() => format!("\n{data}"),
+                _ => String::new(),
+            };
+            bail!("RPC error ({}): {}{detail}", err.code, err.message);
         }
 
         // A missing `result` field (or explicit `"result": null`) means the

--- a/crates/tauri-pilot-cli/tests/rpc_error_data.rs
+++ b/crates/tauri-pilot-cli/tests/rpc_error_data.rs
@@ -75,6 +75,11 @@ fn spawn_mock_window_not_found_server(socket: &PathBuf) -> thread::JoinHandle<()
 
 /// Run the binary against `socket` with a `screenshot_native` call that is
 /// guaranteed to reach the RPC error path, and return its stderr.
+///
+/// Panics before the caller can `join()` the one-shot mock server when the
+/// binary never reached that path — an arg-parse or environment failure exits
+/// non-zero without ever connecting, which would otherwise leave the server
+/// blocked on `accept()` and hang the test run.
 fn stderr_of_failed_screenshot(socket: &Path) -> String {
     let tmpdir = tempfile::tempdir().expect("tempdir");
     let output_path = tmpdir.path().join("shot.png");
@@ -97,7 +102,12 @@ fn stderr_of_failed_screenshot(socket: &Path) -> String {
         !output.status.success(),
         "a JSON-RPC error must exit non-zero"
     );
-    String::from_utf8_lossy(&output.stderr).into_owned()
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !stderr.contains("RPC error") {
+        let _ = std::fs::remove_file(socket);
+        panic!("binary never reached the RPC error path.\n--- stderr ---\n{stderr}\n--- end ---");
+    }
+    stderr
 }
 
 #[test]

--- a/crates/tauri-pilot-cli/tests/rpc_error_data.rs
+++ b/crates/tauri-pilot-cli/tests/rpc_error_data.rs
@@ -1,0 +1,114 @@
+//! Regression test for issue #149, bug 1: structured `error.data` returned by
+//! the plugin must reach the user instead of being dropped by the shared RPC
+//! error path in `client/mod.rs`.
+//!
+//! Same harness as `snapshot_save_json.rs`: a one-shot mock JSON-RPC unix
+//! socket server answers the single request, then the binary runs against that
+//! socket via `assert_cmd` and its stderr is inspected.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use assert_cmd::Command;
+
+static SOCK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let n = SOCK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!(
+        "/tmp/tauri-pilot-it-{}-{}-{}.sock",
+        tag,
+        std::process::id(),
+        n
+    ))
+}
+
+/// Answer one request with the exact `WINDOW_NOT_FOUND` payload the macOS
+/// plugin builds in `screenshot/ipc.rs`: `RPC_INVALID_PARAMS`, a message, and
+/// an `available_windows` list carried under `error.data`.
+fn spawn_mock_window_not_found_server(socket: &PathBuf) -> thread::JoinHandle<()> {
+    let _ = std::fs::remove_file(socket);
+    let listener = UnixListener::bind(socket).expect("bind mock socket");
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = stream;
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read line");
+        let req: serde_json::Value = serde_json::from_str(line.trim()).expect("parse request");
+        let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let resp = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": -32602,
+                "message": "window_id 999 not found",
+                "data": {
+                    "error": "WINDOW_NOT_FOUND",
+                    "message": "window_id 999 not found",
+                    "available_windows": [
+                        {"window_id": 10042, "owner": "Prism", "title": "Prism — Home", "layer": 0},
+                        {"window_id": 20087, "owner": "Finder", "title": "Downloads", "layer": 0}
+                    ]
+                }
+            }
+        });
+        let mut bytes = serde_json::to_vec(&resp).expect("serialize");
+        bytes.push(b'\n');
+        writer.write_all(&bytes).expect("write");
+        writer.flush().expect("flush");
+    })
+}
+
+#[test]
+fn test_rpc_error_with_data_prints_available_windows_on_stderr() {
+    let socket = unique_socket_path("errdata");
+    let handle = spawn_mock_window_not_found_server(&socket);
+
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let output_path = tmpdir.path().join("shot.png");
+
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .args([
+            "--socket",
+            socket.to_str().expect("socket path is UTF-8"),
+            "screenshot_native",
+            "--window-id",
+            "999",
+            "--output",
+            output_path.to_str().expect("output path is UTF-8"),
+        ])
+        .output()
+        .expect("run tauri-pilot");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    // Fail fast before join() so a binary that exits before connecting (e.g.
+    // arg-parse error) cannot leave the mock server blocked on accept() and
+    // hang the test indefinitely.
+    if !stderr.contains("window_id 999 not found") {
+        let _ = std::fs::remove_file(&socket);
+        panic!("binary never reached the RPC error path.\n--- stderr ---\n{stderr}\n--- end ---");
+    }
+    handle.join().expect("mock server join");
+    let _ = std::fs::remove_file(&socket);
+
+    assert!(
+        !output.status.success(),
+        "a JSON-RPC error must exit non-zero"
+    );
+
+    for needle in ["10042", "Prism", "20087", "Finder"] {
+        assert!(
+            stderr.contains(needle),
+            "issue #149: `error.data.available_windows` must reach the user, \
+             missing `{needle}`.\n--- stderr ---\n{stderr}\n--- end ---"
+        );
+    }
+}

--- a/crates/tauri-pilot-cli/tests/rpc_error_data.rs
+++ b/crates/tauri-pilot-cli/tests/rpc_error_data.rs
@@ -10,7 +10,7 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
@@ -28,10 +28,8 @@ fn unique_socket_path(tag: &str) -> PathBuf {
     ))
 }
 
-/// Answer one request with the exact `WINDOW_NOT_FOUND` payload the macOS
-/// plugin builds in `screenshot/ipc.rs`: `RPC_INVALID_PARAMS`, a message, and
-/// an `available_windows` list carried under `error.data`.
-fn spawn_mock_window_not_found_server(socket: &PathBuf) -> thread::JoinHandle<()> {
+/// Answer one request with `error` as the JSON-RPC error object.
+fn spawn_mock_error_server(socket: &PathBuf, error: serde_json::Value) -> thread::JoinHandle<()> {
     let _ = std::fs::remove_file(socket);
     let listener = UnixListener::bind(socket).expect("bind mock socket");
     thread::spawn(move || {
@@ -45,24 +43,61 @@ fn spawn_mock_window_not_found_server(socket: &PathBuf) -> thread::JoinHandle<()
         let resp = serde_json::json!({
             "jsonrpc": "2.0",
             "id": id,
-            "error": {
-                "code": -32602,
-                "message": "window_id 999 not found",
-                "data": {
-                    "error": "WINDOW_NOT_FOUND",
-                    "message": "window_id 999 not found",
-                    "available_windows": [
-                        {"window_id": 10042, "owner": "Prism", "title": "Prism — Home", "layer": 0},
-                        {"window_id": 20087, "owner": "Finder", "title": "Downloads", "layer": 0}
-                    ]
-                }
-            }
+            "error": error,
         });
         let mut bytes = serde_json::to_vec(&resp).expect("serialize");
         bytes.push(b'\n');
         writer.write_all(&bytes).expect("write");
         writer.flush().expect("flush");
     })
+}
+
+/// Answer one request with the exact `WINDOW_NOT_FOUND` payload the macOS
+/// plugin builds in `screenshot/ipc.rs`: `RPC_INVALID_PARAMS`, a message, and
+/// an `available_windows` list carried under `error.data`.
+fn spawn_mock_window_not_found_server(socket: &PathBuf) -> thread::JoinHandle<()> {
+    spawn_mock_error_server(
+        socket,
+        serde_json::json!({
+            "code": -32602,
+            "message": "window_id 999 not found",
+            "data": {
+                "error": "WINDOW_NOT_FOUND",
+                "message": "window_id 999 not found",
+                "available_windows": [
+                    {"window_id": 10042, "owner": "Prism", "title": "Prism — Home", "layer": 0},
+                    {"window_id": 20087, "owner": "Finder", "title": "Downloads", "layer": 0}
+                ]
+            }
+        }),
+    )
+}
+
+/// Run the binary against `socket` with a `screenshot_native` call that is
+/// guaranteed to reach the RPC error path, and return its stderr.
+fn stderr_of_failed_screenshot(socket: &Path) -> String {
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let output_path = tmpdir.path().join("shot.png");
+
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .args([
+            "--socket",
+            socket.to_str().expect("socket path is UTF-8"),
+            "screenshot_native",
+            "--window-id",
+            "999",
+            "--output",
+            output_path.to_str().expect("output path is UTF-8"),
+        ])
+        .output()
+        .expect("run tauri-pilot");
+
+    assert!(
+        !output.status.success(),
+        "a JSON-RPC error must exit non-zero"
+    );
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
 #[test]
@@ -104,6 +139,13 @@ fn test_rpc_error_with_data_prints_available_windows_on_stderr() {
         "a JSON-RPC error must exit non-zero"
     );
 
+    assert_eq!(
+        stderr.matches("window_id 999 not found").count(),
+        1,
+        "the `message` mirrored into `error.data` must not be printed twice.\n\
+         --- stderr ---\n{stderr}\n--- end ---"
+    );
+
     for needle in ["10042", "Prism", "20087", "Finder"] {
         assert!(
             stderr.contains(needle),
@@ -111,4 +153,32 @@ fn test_rpc_error_with_data_prints_available_windows_on_stderr() {
              missing `{needle}`.\n--- stderr ---\n{stderr}\n--- end ---"
         );
     }
+}
+
+/// A `data.message` that differs from `error.message` is detail, not the
+/// plugin's mirror of the top-level message, so it must survive the dedup.
+#[test]
+fn test_rpc_error_data_message_distinct_from_error_message_is_kept() {
+    let socket = unique_socket_path("errdata-distinct");
+    let handle = spawn_mock_error_server(
+        &socket,
+        serde_json::json!({
+            "code": -32602,
+            "message": "window_id 999 not found",
+            "data": {
+                "error": "WINDOW_NOT_FOUND",
+                "message": "the window closed between enumeration and capture"
+            }
+        }),
+    );
+
+    let stderr = stderr_of_failed_screenshot(&socket);
+    handle.join().expect("mock server join");
+    let _ = std::fs::remove_file(&socket);
+
+    assert!(
+        stderr.contains("the window closed between enumeration and capture"),
+        "a `data.message` that is not the mirrored `error.message` must reach \
+         the user.\n--- stderr ---\n{stderr}\n--- end ---"
+    );
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -220,6 +220,10 @@ fn parse_output_path(obj: &serde_json::Map<String, Value>) -> Result<std::path::
 /// success result fills the response with `output_path`, `window_id`, pixel
 /// dimensions, `scale_factor`, `byte_size`, the chosen `backend`, and the
 /// `tcc_denied` flag.
+///
+/// `scale_factor` is `null` when the capture's two axes disagree on the ratio
+/// against the window's logical bounds — the PNG is then not the window, so
+/// the number would not describe it. See `compute_scale_factor`.
 pub(crate) async fn handle_screenshot(params: Option<&Value>) -> Result<Value, RpcError> {
     let req = parse_request(params)?;
 
@@ -313,7 +317,12 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         width: 0.0,
         height: 0.0,
     });
-    let scale_factor = compute_scale_factor(metadata.width, logical_bounds.width, tcc_denied);
+    let scale_factor = compute_scale_factor(
+        metadata.width,
+        metadata.height,
+        logical_bounds.width,
+        logical_bounds.height,
+    );
 
     if let Err(err) = std::fs::rename(&tmp_path, &output_path) {
         cleanup_tmp(&tmp_path);
@@ -509,43 +518,69 @@ fn read_png_metadata(path: &Path) -> Result<PngMetadata, RpcError> {
     })
 }
 
-/// Derive the capture's scale factor from its pixel width and the window's
-/// logical width.
+/// Divide a pixel count by its logical (point) counterpart.
 ///
-/// Returns `None` when the number cannot be derived: without screen-recording
-/// permission the `CGWindowList` fallback captures a screen-sized image rather
-/// than the window, so the division compares two unrelated surfaces and yields
-/// a scale no display has. Pixel-diff harnesses tag artifacts by this value,
-/// so an absent scale beats a plausible wrong one (#149).
-///
-/// Falls back to `Some(1.0)` when the logical width is unknown or zero so the
-/// response never carries NaN or Inf.
+/// Rounds to 2 decimal places to absorb the float noise `CGWindowBounds`
+/// carries, so a capture that really is the window lands on the same number
+/// from both axes instead of `2.0` against `2.00000003`. Returns `None` when
+/// the division is not a finite positive number.
 #[cfg(any(target_os = "macos", test))]
-fn compute_scale_factor(pixel_width: u32, logical_width: f64, tcc_denied: bool) -> Option<f32> {
-    if tcc_denied {
-        return None;
+fn rounded_ratio(pixels: u32, logical: f64) -> Option<f64> {
+    let ratio = f64::from(pixels) / logical;
+    if ratio.is_finite() && ratio > 0.0 {
+        Some((ratio * 100.0).round() / 100.0)
+    } else {
+        None
     }
-    if logical_width <= 0.0 {
+}
+
+/// Derive the capture's scale factor from its pixel dimensions and the
+/// window's logical bounds.
+///
+/// Both axes must agree on the ratio. A PNG that is not exactly the window
+/// fails that test, which is what #149 asks for: with screen recording denied
+/// the `CGWindowList` fallback hands back a screen-sized image, and a screen's
+/// aspect is not the window's, so the two ratios part ways (4344/1512 = 2.87
+/// across, 2744/982 = 2.79 down). Pixel-diff harnesses tag artifacts by this
+/// value, so an absent scale beats a plausible wrong one.
+///
+/// The geometry decides, not `tcc_denied` — that flag reports a permission
+/// state, and `capture_with_fallback` also raises it after a *granted* probe
+/// whose per-window `screencapture` call failed, where the fallback image is
+/// the window at 1x and the scale was derivable. The primary backend passes
+/// `screencapture -o` so its own PNG is not padded by the window's shadow.
+///
+/// The check compares two ratios, so a window whose aspect happens to match
+/// the screen's would still pass on a denied capture. Reading the display's
+/// backing scale from `CGDisplayMode` would remove the inference entirely.
+///
+/// Falls back to `Some(1.0)` when the logical bounds are unknown or zero so
+/// the response never carries NaN or Inf.
+#[cfg(any(target_os = "macos", test))]
+fn compute_scale_factor(
+    pixel_width: u32,
+    pixel_height: u32,
+    logical_width: f64,
+    logical_height: f64,
+) -> Option<f32> {
+    if logical_width <= 0.0 || logical_height <= 0.0 {
         return Some(1.0);
     }
-    let scale = f64::from(pixel_width) / logical_width;
-    if scale.is_finite() && scale > 0.0 {
-        // Round to 2 decimal places to avoid `2.00000003` artifacts when the
-        // CGWindowBounds Width carries float noise. Strict-pixel-diff harnesses
-        // tag artifacts by this value, so stability matters more than exact
-        // bit-for-bit fidelity. Truncation to f32 is intentional: Retina scale
-        // factors land in a small finite range (1.0 / 2.0 / 3.0) that f32
-        // represents losslessly.
-        let rounded = (scale * 100.0).round() / 100.0;
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "Retina scale factors fit in f32 without loss"
-        )]
-        let scale_f32 = rounded as f32;
-        Some(scale_f32)
-    } else {
-        Some(1.0)
+    let horizontal = rounded_ratio(pixel_width, logical_width)?;
+    let vertical = rounded_ratio(pixel_height, logical_height)?;
+    // Both sides are a whole number of hundredths, so half a hundredth apart
+    // already means two different numbers.
+    if (horizontal - vertical).abs() > 0.005 {
+        return None;
     }
+    // Truncation to f32 is intentional: Retina scale factors land in a small
+    // finite range (1.0 / 2.0) that f32 represents losslessly.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Retina scale factors fit in f32 without loss"
+    )]
+    let scale_f32 = horizontal as f32;
+    Some(scale_f32)
 }
 
 #[cfg(test)]
@@ -687,22 +722,44 @@ mod tests {
             assert!(first.get("title").is_some());
             assert!(first.get("layer").is_some());
         }
+        // The test binary owns no on-screen window, so every entry here
+        // belongs to another process and must come back title-less: this
+        // payload now reaches stderr and the MCP client, and other apps'
+        // document names, URLs and chat titles do not belong there.
+        for window in list {
+            assert_eq!(
+                window.get("title").and_then(Value::as_str),
+                Some(""),
+                "a window owned by another process must not carry its title: {window}"
+            );
+        }
     }
 
     #[test]
-    fn test_compute_scale_factor_tcc_denied_reports_no_scale() {
+    fn test_compute_scale_factor_screen_sized_capture_reports_no_scale() {
         // #149: with screen recording denied, `capture_with_fallback` drops to
         // `CGWindowList`, which returns a screen-sized image instead of the
-        // window. Dividing that width by the window's logical width yields a
-        // number no display has (4344 / 1512 = 2.87 on a 2.0 Retina panel).
-        // Pixel-diff harnesses tag artifacts by this value, so a plausible
-        // wrong scale is worse than none.
-        assert_eq!(compute_scale_factor(4344, 1512.0, true), None);
+        // window. A 16" panel at 2172x1372 points against a 1512x982 window
+        // gives 2.87 across and 2.79 down — no display has either.
+        assert_eq!(compute_scale_factor(4344, 2744, 1512.0, 982.0), None);
     }
 
     #[test]
-    fn test_compute_scale_factor_permitted_capture_keeps_derived_scale() {
-        // The derivation still holds when the capture really is the window.
-        assert_eq!(compute_scale_factor(3024, 1512.0, false), Some(2.0));
+    fn test_compute_scale_factor_shadow_padded_capture_reports_no_scale() {
+        // `screencapture` without `-o` pads the PNG with the window's drop
+        // shadow, and by more below the window than beside it, so the two
+        // ratios disagree even though permission was granted.
+        assert_eq!(compute_scale_factor(3248, 2188, 1512.0, 982.0), None);
+    }
+
+    #[test]
+    fn test_compute_scale_factor_window_sized_capture_keeps_derived_scale() {
+        // The derivation holds when the capture really is the window.
+        assert_eq!(compute_scale_factor(3024, 1964, 1512.0, 982.0), Some(2.0));
+    }
+
+    #[test]
+    fn test_compute_scale_factor_unknown_bounds_falls_back_to_one() {
+        assert_eq!(compute_scale_factor(3024, 1964, 0.0, 0.0), Some(1.0));
     }
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -318,6 +318,7 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         height: 0.0,
     });
     let scale_factor = compute_scale_factor(
+        matches!(backend, ScreenshotBackend::CgWindowList),
         metadata.width,
         metadata.height,
         logical_bounds.width,
@@ -550,14 +551,20 @@ fn rounded_ratio(pixels: u32, logical: f64) -> Option<f64> {
 /// the window at 1x and the scale was derivable. The primary backend passes
 /// `screencapture -o` so its own PNG is not padded by the window's shadow.
 ///
-/// The check compares two ratios, so a window whose aspect happens to match
-/// the screen's would still pass on a denied capture. Reading the display's
-/// backing scale from `CGDisplayMode` would remove the inference entirely.
+/// Two agreeing ratios are not proof on their own, so the capture's provenance
+/// gates them: `nominal_resolution` says the PNG came from `capture_cgwindow`,
+/// which asks CoreGraphics for `kCGWindowImageNominalResolution` and therefore
+/// can only legitimately produce 1:1. Anything else from that backend is not
+/// the window — under TCC denial CoreGraphics ignores the flags and hands back
+/// the screen, which would otherwise slip through whenever its aspect matches
+/// the window's. Reading the display's backing scale from `CGDisplayMode`
+/// would remove the inference entirely.
 ///
 /// Falls back to `Some(1.0)` when the logical bounds are unknown or zero so
 /// the response never carries NaN or Inf.
 #[cfg(any(target_os = "macos", test))]
 fn compute_scale_factor(
+    nominal_resolution: bool,
     pixel_width: u32,
     pixel_height: u32,
     logical_width: f64,
@@ -571,6 +578,9 @@ fn compute_scale_factor(
     // Both sides are a whole number of hundredths, so half a hundredth apart
     // already means two different numbers.
     if (horizontal - vertical).abs() > 0.005 {
+        return None;
+    }
+    if nominal_resolution && (horizontal - 1.0).abs() > 0.005 {
         return None;
     }
     // Truncation to f32 is intentional: Retina scale factors land in a small
@@ -741,7 +751,7 @@ mod tests {
         // `CGWindowList`, which returns a screen-sized image instead of the
         // window. A 16" panel at 2172x1372 points against a 1512x982 window
         // gives 2.87 across and 2.79 down — no display has either.
-        assert_eq!(compute_scale_factor(4344, 2744, 1512.0, 982.0), None);
+        assert_eq!(compute_scale_factor(true, 4344, 2744, 1512.0, 982.0), None);
     }
 
     #[test]
@@ -749,17 +759,41 @@ mod tests {
         // `screencapture` without `-o` pads the PNG with the window's drop
         // shadow, and by more below the window than beside it, so the two
         // ratios disagree even though permission was granted.
-        assert_eq!(compute_scale_factor(3248, 2188, 1512.0, 982.0), None);
+        assert_eq!(compute_scale_factor(false, 3248, 2188, 1512.0, 982.0), None);
     }
 
     #[test]
     fn test_compute_scale_factor_window_sized_capture_keeps_derived_scale() {
         // The derivation holds when the capture really is the window.
-        assert_eq!(compute_scale_factor(3024, 1964, 1512.0, 982.0), Some(2.0));
+        assert_eq!(
+            compute_scale_factor(false, 3024, 1964, 1512.0, 982.0),
+            Some(2.0)
+        );
+    }
+
+    #[test]
+    fn test_compute_scale_factor_screen_sized_capture_at_window_aspect_reports_no_scale() {
+        // The two ratios agree here — a 2172x1372 point screen against a
+        // window at exactly half its size in both directions — so geometry
+        // alone would hand back 4.0. `capture_cgwindow` asked for nominal
+        // resolution, so anything but 1:1 means CoreGraphics did not honour
+        // the flags and the PNG is not the window.
+        assert_eq!(compute_scale_factor(true, 4344, 2744, 1086.0, 686.0), None);
+    }
+
+    #[test]
+    fn test_compute_scale_factor_nominal_window_capture_reports_one() {
+        // `capture_with_fallback` also reaches `capture_cgwindow` after a
+        // granted probe whose per-window `screencapture` call failed. The PNG
+        // is then the window at 1x, and 1.0 describes it.
+        assert_eq!(
+            compute_scale_factor(true, 1512, 982, 1512.0, 982.0),
+            Some(1.0)
+        );
     }
 
     #[test]
     fn test_compute_scale_factor_unknown_bounds_falls_back_to_one() {
-        assert_eq!(compute_scale_factor(3024, 1964, 0.0, 0.0), Some(1.0));
+        assert_eq!(compute_scale_factor(false, 3024, 1964, 0.0, 0.0), Some(1.0));
     }
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/ipc.rs
@@ -313,7 +313,7 @@ fn run_macos(req: ScreenshotRequest) -> Result<Value, RpcError> {
         width: 0.0,
         height: 0.0,
     });
-    let scale_factor = compute_scale_factor(metadata.width, logical_bounds);
+    let scale_factor = compute_scale_factor(metadata.width, logical_bounds.width, tcc_denied);
 
     if let Err(err) = std::fs::rename(&tmp_path, &output_path) {
         cleanup_tmp(&tmp_path);
@@ -509,15 +509,26 @@ fn read_png_metadata(path: &Path) -> Result<PngMetadata, RpcError> {
     })
 }
 
-/// Derive `scale_factor` by dividing pixel width by logical (point) width.
-/// Falls back to 1.0 when the logical bounds are unknown or zero so the
-/// response never returns NaN/Inf.
-#[cfg(target_os = "macos")]
-fn compute_scale_factor(pixel_width: u32, logical: super::WindowBounds) -> f32 {
-    if logical.width <= 0.0 {
-        return 1.0;
+/// Derive the capture's scale factor from its pixel width and the window's
+/// logical width.
+///
+/// Returns `None` when the number cannot be derived: without screen-recording
+/// permission the `CGWindowList` fallback captures a screen-sized image rather
+/// than the window, so the division compares two unrelated surfaces and yields
+/// a scale no display has. Pixel-diff harnesses tag artifacts by this value,
+/// so an absent scale beats a plausible wrong one (#149).
+///
+/// Falls back to `Some(1.0)` when the logical width is unknown or zero so the
+/// response never carries NaN or Inf.
+#[cfg(any(target_os = "macos", test))]
+fn compute_scale_factor(pixel_width: u32, logical_width: f64, tcc_denied: bool) -> Option<f32> {
+    if tcc_denied {
+        return None;
     }
-    let scale = f64::from(pixel_width) / logical.width;
+    if logical_width <= 0.0 {
+        return Some(1.0);
+    }
+    let scale = f64::from(pixel_width) / logical_width;
     if scale.is_finite() && scale > 0.0 {
         // Round to 2 decimal places to avoid `2.00000003` artifacts when the
         // CGWindowBounds Width carries float noise. Strict-pixel-diff harnesses
@@ -531,9 +542,9 @@ fn compute_scale_factor(pixel_width: u32, logical: super::WindowBounds) -> f32 {
             reason = "Retina scale factors fit in f32 without loss"
         )]
         let scale_f32 = rounded as f32;
-        scale_f32
+        Some(scale_f32)
     } else {
-        1.0
+        Some(1.0)
     }
 }
 
@@ -676,5 +687,22 @@ mod tests {
             assert!(first.get("title").is_some());
             assert!(first.get("layer").is_some());
         }
+    }
+
+    #[test]
+    fn test_compute_scale_factor_tcc_denied_reports_no_scale() {
+        // #149: with screen recording denied, `capture_with_fallback` drops to
+        // `CGWindowList`, which returns a screen-sized image instead of the
+        // window. Dividing that width by the window's logical width yields a
+        // number no display has (4344 / 1512 = 2.87 on a 2.0 Retina panel).
+        // Pixel-diff harnesses tag artifacts by this value, so a plausible
+        // wrong scale is worse than none.
+        assert_eq!(compute_scale_factor(4344, 1512.0, true), None);
+    }
+
+    #[test]
+    fn test_compute_scale_factor_permitted_capture_keeps_derived_scale() {
+        // The derivation still holds when the capture really is the window.
+        assert_eq!(compute_scale_factor(3024, 1512.0, false), Some(2.0));
     }
 }

--- a/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/screencapture.rs
@@ -4,10 +4,13 @@ use super::ScreenshotError;
 
 /// Capture a window's pixels by shelling out to the `screencapture` system tool.
 ///
-/// Invokes `screencapture -x -l <window_id> <path>` so the call is silent and
-/// targets one window rather than the whole screen. Requires Screen Recording
-/// permission in System Settings -> Privacy & Security; the first invocation
-/// under a sandboxed host surfaces the macOS permission dialog.
+/// Invokes `screencapture -x -o -l <window_id> <path>` so the call is silent
+/// and targets one window rather than the whole screen. `-o` drops the
+/// window's shadow: with it the PNG would be padded past `kCGWindowBounds`,
+/// and by different amounts horizontally and vertically, which is the ratio
+/// `compute_scale_factor` divides out. Requires Screen Recording permission in
+/// System Settings -> Privacy & Security; the first invocation under a
+/// sandboxed host surfaces the macOS permission dialog.
 ///
 /// # Errors
 ///
@@ -19,6 +22,7 @@ pub(crate) fn capture_screencapture(window_id: u32, path: &Path) -> Result<(), S
 
     let status = Command::new("screencapture")
         .arg("-x")
+        .arg("-o")
         .arg("-l")
         .arg(window_id.to_string())
         .arg(path)

--- a/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
+++ b/crates/tauri-plugin-pilot/src/screenshot/window_id.rs
@@ -3,6 +3,12 @@ use super::ScreenshotError;
 /// Minimal description of a layer-0 on-screen window, used to populate the
 /// `available_windows` payload returned with `WINDOW_NOT_FOUND` errors so
 /// callers can pick the right `window_id` without a second round-trip.
+///
+/// `title` is empty for windows owned by another process. The list walks every
+/// on-screen window, and the payload now reaches stderr and the MCP client, so
+/// carrying a stranger's document names, URLs and chat titles out of the host
+/// would leak them to whatever model backs that client. `window_id` and
+/// `owner` are what the caller needs to pick a target.
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 pub(crate) struct DiscoveredWindow {
     pub(crate) window_id: u32,
@@ -57,7 +63,7 @@ pub(crate) fn enumerate_layer_zero_windows(
     use core_graphics::window::{
         CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowBounds, kCGWindowLayer,
         kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
-        kCGWindowNumber, kCGWindowOwnerName,
+        kCGWindowNumber, kCGWindowOwnerName, kCGWindowOwnerPID,
     };
 
     // SAFETY: `CGWindowListCopyWindowInfo` is a thread-safe CoreGraphics entry
@@ -92,8 +98,10 @@ pub(crate) fn enumerate_layer_zero_windows(
     let title_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
     let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
     let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+    let owner_pid_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerPID) };
     let bounds_key = unsafe { CFString::wrap_under_get_rule(kCGWindowBounds) };
 
+    let host_pid = i64::from(std::process::id());
     let mut available: Vec<DiscoveredWindow> = Vec::new();
     let mut target_bounds: Option<WindowBounds> = None;
 
@@ -122,11 +130,20 @@ pub(crate) fn enumerate_layer_zero_windows(
             .and_then(|v| v.downcast::<CFString>())
             .map(|v| v.to_string())
             .unwrap_or_default();
-        let title = dict
-            .find(&title_key)
-            .and_then(|v| v.downcast::<CFString>())
-            .map(|v| v.to_string())
-            .unwrap_or_default();
+        let owner_pid = dict
+            .find(&owner_pid_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i64());
+        // Titles of other apps' windows never leave the host: see
+        // `DiscoveredWindow`.
+        let title = if owner_pid == Some(host_pid) {
+            dict.find(&title_key)
+                .and_then(|v| v.downcast::<CFString>())
+                .map(|v| v.to_string())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
 
         if window_id == target && target_bounds.is_none() {
             // CGWindowList stores the bounds rect as a `{Width,Height,X,Y}`


### PR DESCRIPTION
Closes #149. Two reporting bugs on the `screenshot_native` path — neither touches the capture itself, both made a failed or degraded capture hard to read.

## 1. `error.data` was dropped by the CLI

`Client::call` turned every JSON-RPC error into `RPC error (code): message` and discarded `err.data`. The plugin builds an `available_windows` list for `WINDOW_NOT_FOUND` precisely so the caller can learn the real ids, and none of it reached the terminal.

The fix lands in the shared error path, not on `screenshot_native`, so any command whose plugin side attaches structured data keeps it. `message` is mirrored into `data` by `rpc_error`, so that key is dropped rather than printed twice.

Before:

```
Error: RPC error (-32602): window_id 999 not found
```

After:

```
Error: RPC error (-32602): window_id 999 not found
{
  "available_windows": [
    { "layer": 0, "owner": "Prism", "title": "Prism — Home", "window_id": 10042 },
    ...
  ],
  "error": "WINDOW_NOT_FOUND"
}
```

## 2. `scale_factor` was derived from mismatched dimensions

`compute_scale_factor` divided the captured PNG's pixel width by the window's logical width. That holds only when the PNG is the window. With screen recording denied, `capture_with_fallback` drops to `CGWindowList`, which does not return the window contents — the division then compares a screen-sized image against a window-sized bound and reports values like `2.87` on a 2.0 display.

It returns `None` when `tcc_denied` is set, so the field serializes to `null`. That is the first option listed in the issue: the number cannot be derived from a capture that is not the window, and the value is documented as stable enough for pixel-diff harnesses to tag artifacts by, so absent beats plausible-but-wrong.

## Test seam

`compute_scale_factor` was `#[cfg(target_os = "macos")]` and took a `WindowBounds` from the CoreGraphics-only `cgwindow` module, so nothing about it could compile — let alone run — off macOS. It now takes an `f64` width and compiles under `cfg(any(target_os = "macos", test))`, which is what let the fix be driven from a failing test on Linux:

- `crates/tauri-plugin-pilot/src/screenshot/ipc.rs` — `test_compute_scale_factor_tcc_denied_reports_no_scale` was red with `left: Some(2.87), right: None`, the exact number from the issue
- `crates/tauri-pilot-cli/tests/rpc_error_data.rs` — mock socket returning the real `WINDOW_NOT_FOUND` payload, asserting the window ids land on stderr

## Not covered

The end-to-end macOS repro (screen recording actually denied for the terminal) still needs a human at the machine — it is a system permission toggle, not something a test can set. The tests cover the decision, not the capture.

## Checks

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` all clean locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two reporting bugs on the `screenshot_native` path, closing #149: RPC error `data` now reaches the terminal, and `scale_factor` is no longer reported when the capture isn't the window (e.g. when screen recording is denied).

**Bug Fixes**
- The CLI renders structured `error.data` (like `available_windows` for `WINDOW_NOT_FOUND`) instead of discarding it; `data.message` is dropped only when it duplicates the top-level message.
- `scale_factor` is `null` unless both pixel and logical dimensions agree on the ratio and the capture's provenance backs the number — a `CGWindowList` capture can only legitimately be 1:1, so a screen-sized image whose aspect matches the window's still gets no scale; `screencapture` also runs with `-o` so its own captures aren't shadow-padded.
- `available_windows` strips titles of windows owned by other processes, since that payload now surfaces on stderr and to MCP clients; `window_id` and `owner` remain for retargeting.

<sup>Written for commit e8bbc1fe608b1a1239b5db76eb121085c6fb7e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - RPC errors now include structured error details in CLI output without duplicating messages.
  - Screenshot scale factors are calculated more reliably using capture-source information.
  - macOS native screenshots no longer include window drop shadows, improving image bounds and scaling.
  - Available window metadata now exposes titles for host-app windows while protecting titles from other applications.
- **Tests**
  - Added coverage for RPC error details, screenshot scaling, window metadata, and CLI failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->