### PR TITLE
chore: upgrade dependencies in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dependency floors raised in `Cargo.toml`, the only pinning this repo commits
+  (`Cargo.lock` is ignored, so a requirement is what actually reaches a
+  consumer): `anyhow` 1 -> 1.0.104, `libc` 0.2.184 -> 0.2.189 in both crates,
+  `owo-colors` 4.3.0 -> 4.4.0, `rmcp` 3.1.4 -> 3.2.0, and the `tauri-plugin`
+  build dependency 2.6.1 -> 2.6.3. The `anyhow` floor is the one that matters:
+  it clears RUSTSEC-2026-0190, an unsoundness in `Error::downcast_mut()`
+  patched in 1.0.103.
+
 - macOS native captures no longer include the window's drop shadow.
   `capture_screencapture` passes `screencapture -o`, so the PNG matches
   `kCGWindowBounds` and the scale factor is derivable from it. [#149]

--- a/crates/tauri-pilot-cli/Cargo.toml
+++ b/crates/tauri-pilot-cli/Cargo.toml
@@ -25,17 +25,17 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "io-util", "time"] }
 tracing.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
-anyhow = "1"
+anyhow = "1.0.104"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.23.1"
-owo-colors = { version = "4.3.0", features = ["supports-colors"] }
+owo-colors = { version = "4.4.0", features = ["supports-colors"] }
 indicatif = "0.18"
-rmcp = { version = "3.1.4", default-features = false, features = ["server", "transport-io"] }
+rmcp = { version = "3.2.0", default-features = false, features = ["server", "transport-io"] }
 quick-xml = "0.42"
 toml = "1"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.184"
+libc = "0.2.189"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -34,7 +34,7 @@ tauri = { version = "2", features = ["unstable"] }
 enigo = { version = "0.6.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.184"
+libc = "0.2.189"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [
@@ -59,4 +59,4 @@ serial_test = "4"
 tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [build-dependencies]
-tauri-plugin = { version = "2.6.1", features = ["build"] }
+tauri-plugin = { version = "2.6.3", features = ["build"] }


### PR DESCRIPTION
Raises dependency floor versions to resolve security advisory and ensure consumers get current patch releases.

## Changes

- **anyhow** 1 → 1.0.104 — clears RUSTSEC-2026-0190 (unsoundness in `Error::downcast_mut()`, patched in 1.0.103)
- **libc** 0.2.184 → 0.2.189 (both crates, `cfg(unix)`)
- **owo-colors** 4.3.0 → 4.4.0
- **rmcp** 3.1.4 → 3.2.0
- **tauri-plugin** 2.6.1 → 2.6.3 (build dependency)

All tests pass, clippy clean, MSRV 1.95.0 verified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises dependency floor versions in `Cargo.toml` to clear RUSTSEC-2026-0190 and ensure consumers get current patch releases.

**Dependencies**
- `anyhow` 1 → 1.0.104
- `libc` 0.2.184 → 0.2.189 (both crates)
- `owo-colors` 4.3.0 → 4.4.0
- `rmcp` 3.1.4 → 3.2.0
- `tauri-plugin` 2.6.1 → 2.6.3 (build dependency)

<sup>Written for commit b6f24e1a462f745a37eaa1f7250b60ae4e6c585d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum dependency versions across the CLI and plugin components.
  - Updated the build-time Tauri plugin dependency.
  - Updated `anyhow` to address a reported security advisory.

- **Documentation**
  - Documented the updated dependency requirements in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->