### PR TITLE
fix(plugin): log and skip the pilot server when the Unix socket is already bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A second instance of an app that embeds the plugin no longer panics at
+  startup. On Unix the plugin `setup` hook propagated the `AddrInUse` error
+  from the socket bind, which Tauri turns into a fatal `PluginInitialization`
+  error, so the second process died before it showed a window. The plugin is
+  debug-only tooling: it now logs a warning, skips the server and lets the app
+  run, which is what Windows already did. [#152]
+
 - `screenshot_native` errors now carry their detail to the terminal. Every RPC
   error went through one `bail!` in the CLI client that kept the code and the
   message and dropped `error.data`, so a `WINDOW_NOT_FOUND` printed nothing of
@@ -687,3 +694,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#145]: https://github.com/mpiton/tauri-pilot/pull/145
 [#146]: https://github.com/mpiton/tauri-pilot/issues/146
 [#149]: https://github.com/mpiton/tauri-pilot/issues/149
+[#152]: https://github.com/mpiton/tauri-pilot/issues/152

--- a/crates/tauri-plugin-pilot/Cargo.toml
+++ b/crates/tauri-plugin-pilot/Cargo.toml
@@ -56,6 +56,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 
 [dev-dependencies]
 serial_test = "4"
+tauri = { version = "2", features = ["test"] }
 tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [build-dependencies]

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -43,6 +43,11 @@ pub(crate) const BRIDGE_JS: &str = concat!(
 /// reachable via ADB forwarding. The per-instance address is logged at info level.
 /// In debug builds on Windows, starts a Named Pipe server at
 /// `\\.\pipe\tauri-pilot-{identifier}` and registers the instance under `%LOCALAPPDATA%\tauri-pilot\instances\`.
+///
+/// Failing to start the server never prevents the host app from running: if the
+/// socket cannot be bound (for example because another instance of the same app
+/// already owns it), the failure is logged at warn level and the app starts
+/// without a pilot server.
 #[must_use]
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     #[cfg(not(all(any(unix, windows), debug_assertions)))]
@@ -72,18 +77,27 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 let recorder = Recorder::new();
 
                 // Unix binds with the std (sync) `UnixListener`, which needs no
-                // tokio runtime, so binding stays here in `setup` where a failure
-                // surfaces as a hard plugin error. `run` only upgrades the
-                // listener to tokio once it is already on the runtime.
+                // tokio runtime, so binding stays here in `setup` and the socket
+                // is ready before the app finishes starting. `run` only upgrades
+                // the listener to tokio once it is already on the runtime.
+                //
+                // The plugin is debug-only tooling: failing to start the QA
+                // server (e.g. a second instance of the app already owns the
+                // socket, #152) must never prevent the host app from running,
+                // so bind errors are logged and skipped, never returned from
+                // `setup` (where they become a fatal `PluginInitialization`).
                 #[cfg(unix)]
                 {
-                    let address = server::socket_address(&identifier).inspect_err(|e| {
-                        tracing::error!(identifier, "failed to build tauri-pilot socket address: {e}");
-                    })?;
-                    let (listener, guard) = server::bind(&address).map_err(|e| {
-                        tracing::error!(?address, "failed to bind socket: {e}");
-                        e
-                    })?;
+                    let Ok(address) = server::socket_address(&identifier).inspect_err(|e| {
+                        tracing::warn!(identifier, "tauri-pilot server not started, failed to build socket address: {e}");
+                    }) else {
+                        return Ok(());
+                    };
+                    let Ok((listener, guard)) = server::bind(&address).inspect_err(|e| {
+                        tracing::warn!(?address, "tauri-pilot server not started, failed to bind socket: {e}");
+                    }) else {
+                        return Ok(());
+                    };
                     tauri::async_runtime::spawn(server::run(
                         listener,
                         guard,
@@ -500,6 +514,38 @@ mod tests {
         assert!(
             helper_idx < fill_idx,
             "nativeValueSetter must be declared before fill (#85)"
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "android"), debug_assertions))]
+    #[test]
+    fn second_instance_starts_when_socket_already_bound() {
+        // #152: the plugin is debug-only tooling, so a second instance of the
+        // host app must start even though the first one already owns the pilot
+        // socket. The bind failure is logged and the server is skipped.
+        use tauri::Manager;
+
+        let identifier = format!("com.pilot.issue152-{}", std::process::id());
+        let address = super::server::socket_address(&super::sanitize_identifier(&identifier))
+            .expect("socket address");
+        let path = address
+            .as_pathname()
+            .expect("pathname socket")
+            .to_path_buf();
+        // First instance: a live listener on the pilot socket.
+        let _first = std::os::unix::net::UnixListener::bind(&path).expect("bind first instance");
+
+        let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+        context.config_mut().identifier = identifier;
+        let app = tauri::test::mock_builder()
+            .plugin(super::init())
+            .build(context);
+        let _ = std::fs::remove_file(&path);
+
+        let app = app.expect("second instance must start without a pilot server (#152)");
+        assert!(
+            app.try_state::<super::EvalEngine>().is_some(),
+            "plugin setup must still run for the second instance"
         );
     }
 


### PR DESCRIPTION
A second instance of an app that embeds the plugin panicked at startup when the first instance already owned the Unix socket. The plugin setup hook propagated the AddrInUse error from the socket bind—a probe designed to detect stale sockets—which Tauri converted to a fatal PluginInitialization error. The plugin is debug-only tooling; a bind conflict must never prevent the host app from running.

**Changes:**

• Unix bind errors logged at warn level and skipped (return Ok(()))
• Windows unchanged: already logged but did not crash
• Android socket address errors also skipped  
• Unit test for second-instance startup without a pilot server
• Plugin docs clarified: failing to start the QA server never prevents the app
• Changelog entry [#152]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #152: a second instance of an app embedding the plugin no longer panics at startup when it can't bind the pilot socket. The `setup` hook previously propagated the `AddrInUse` error, which Tauri turned into a fatal `PluginInitialization` error. Now the bind failure is logged at warn level and the server is skipped, so the app starts normally (Windows already behaved this way).

Adds a unit test covering second-instance startup without a pilot server, and clarifies the plugin docs and changelog that failing to start the QA server never prevents the host app from running.

<sup>Written for commit 473e5e939ae51f6175a7927a908a6191902856aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Unix startup behavior when the pilot socket is already in use.
  - Additional app instances can now start successfully instead of failing during initialization.
  - A warning is logged and the pilot server is skipped when its socket cannot be opened; other app functionality remains available.

- **Documentation**
  - Updated plugin documentation and the unreleased changelog to describe this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->