### PR TITLE
refactor(plugin): route handlers through a Webviews seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first window by label, and `windows.list` sorts by label. Both used Tauri's
   hash order, which changes from run to run.
 
+- `press` without `--window` now fails when the app has no webview window,
+  instead of sending the key to whatever app has focus.
+
 - `navigate` to an origin the pilot bridge cannot answer from no longer
   reports ok and leaves the session hung. The bridge does run on a foreign
   page, but Tauri's ACL rejects its `__callback` because the pilot permission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forwarded with `adb forward localfilesystem:... localabstract:...`. Connections
   require matching UID/GID pairs for the app, root or ADB shell. [#145]
 
+### Changed
+
+- A bridge command on a page whose origin never said hello no longer runs its
+  script before it fails, so a `click` there no longer clicks. `navigate` still
+  runs, since it is the way back to the app origin.
+
 ### Fixed
+
+- Without `--window` and without a `main` window, commands now target the
+  first window by label, and `windows.list` sorts by label. Both used Tauri's
+  hash order, which changes from run to run.
 
 - `navigate` to an origin the pilot bridge cannot answer from no longer
   reports ok and leaves the session hung. The bridge does run on a foreign

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,9 +1,0 @@
-# tauri-pilot
-
-A CLI that drives a running Tauri app through a debug-only plugin, so an agent can inspect and act on its webviews.
-
-## Language
-
-**Target window**:
-The webview window a command acts on: the `--window` label, else `main`, else the first window by label. An unknown label is an error, never a fallback.
-_Avoid_: current window, active window

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# tauri-pilot
+
+A CLI that drives a running Tauri app through a debug-only plugin, so an agent can inspect and act on its webviews.
+
+## Language
+
+**Target window**:
+The webview window a command acts on: the `--window` label, else `main`, else the first window by label. An unknown label is an error, never a fallback.
+_Avoid_: current window, active window

--- a/crates/tauri-plugin-pilot/build.rs
+++ b/crates/tauri-plugin-pilot/build.rs
@@ -2,4 +2,26 @@ const COMMANDS: &[&str] = &["callback", "__callback"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();
+    embed_common_controls_manifest();
+}
+
+/// Link the Common Controls v6 manifest into this crate's test binaries.
+///
+/// `tauri::test::mock_app` pulls in `TaskDialogIndirect`, which only comctl32
+/// v6 exports. An app gets the manifest from `tauri-build`, but the lib test
+/// harness has none, so Windows refuses to load it with
+/// `STATUS_ENTRYPOINT_NOT_FOUND` (tauri-apps/tauri#13419). Cargo applies link
+/// args only to this package's own targets, never to the app using the plugin.
+fn embed_common_controls_manifest() {
+    let cfg = |key| std::env::var(key).ok();
+    if cfg("CARGO_CFG_TARGET_OS").as_deref() == Some("windows")
+        && cfg("CARGO_CFG_TARGET_ENV").as_deref() == Some("msvc")
+    {
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' \
+             name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+             processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -473,7 +473,13 @@ async fn handle_press(
     // A focuses window X, call B focuses window Y, then both keys land on Y).
     let _order_guard = PRESS_ORDER_LOCK.lock().await;
 
-    match webviews.target(window).and_then(|target| target.focus()) {
+    // With no window to focus, the key would land in whatever app has focus.
+    let target = webviews.target(window).map_err(|e| RpcError {
+        code: -32603,
+        message: format!("cannot focus target window: {e}"),
+        data: None,
+    })?;
+    match target.focus() {
         Ok(()) => {
             // Only wait if the WM actually accepted the focus request —
             // a failed focus call won't transfer focus, so sleeping
@@ -946,6 +952,25 @@ mod tests {
         let err = result.expect_err("dispatch returns Err");
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("focus"));
+    }
+
+    #[cfg(feature = "press")]
+    #[tokio::test]
+    async fn test_dispatch_press_without_any_window_errors() {
+        // Without --window and with no webview, the key would reach another
+        // app. Shift alone keeps a regression harmless.
+        let engine = EvalEngine::new();
+        let result = dispatch(
+            "press",
+            Some(&json!({"key": "Shift"})),
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
+        let err = result.expect_err("dispatch returns Err");
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains("No webview available"));
     }
 
     #[cfg(feature = "press")]

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -5,7 +5,7 @@ use crate::key;
 use crate::protocol::RpcError;
 use crate::recorder::{RecordEntry, Recorder};
 use crate::screenshot;
-use crate::server::{EvalFn, FocusFn, ListWindowsFn};
+use crate::webview::{TargetWindow, Webviews};
 
 use std::time::Duration;
 #[cfg(feature = "press")]
@@ -164,19 +164,14 @@ fn inject_plugin_version(result: &mut serde_json::Value) {
 }
 
 /// Dispatch a JSON-RPC method call to the appropriate handler.
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn dispatch(
     method: &str,
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-    list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
+    webviews: &dyn Webviews,
     recorder: &Recorder,
 ) -> Result<serde_json::Value, RpcError> {
-    #[cfg(not(feature = "press"))]
-    let _ = focus_fn;
-
     // Save original params before window extraction so the recorder can strip
     // "window" internally.
     let original_params = params.cloned();
@@ -191,27 +186,17 @@ pub(crate) async fn dispatch(
             inject_plugin_version(&mut result);
             Ok(result)
         }
-        "windows.list" => {
-            if let Some(f) = list_fn {
-                Ok(f())
-            } else {
-                Err(RpcError {
-                    code: -32603,
-                    message: "No window manager available".to_owned(),
-                    data: None,
-                })
-            }
-        }
+        "windows.list" => Ok(serde_json::json!({"windows": webviews.list()})),
         "snapshot" => {
             let result =
-                handle_eval_method("snapshot", params, engine, eval_fn, win, DEFAULT_TIMEOUT)
+                handle_eval_method("snapshot", params, engine, webviews, win, DEFAULT_TIMEOUT)
                     .await?;
             engine.store_snapshot(&result);
             Ok(result)
         }
-        "diff" => handle_diff(params, engine, eval_fn, win).await,
+        "diff" => handle_diff(params, engine, webviews, win).await,
         #[cfg(feature = "press")]
-        "press" => handle_press(params, focus_fn, win).await,
+        "press" => handle_press(params, webviews, win).await,
         #[cfg(not(feature = "press"))]
         "press" => Err(RpcError {
             code: -32601,
@@ -222,9 +207,9 @@ pub(crate) async fn dispatch(
         "click" | "fill" | "type" | "select" | "check" | "scroll" | "drop" | "text" | "html"
         | "value" | "attrs" | "eval" | "ipc" | "url" | "title" | "visible" | "count"
         | "checked" => {
-            handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method(method, params, engine, webviews, win, DEFAULT_TIMEOUT).await
         }
-        "navigate" => handle_navigate(params, engine, eval_fn, win).await,
+        "navigate" => handle_navigate(params, engine, webviews, win).await,
         // `drag` spends `steps × stepDelayMs + settleMs` in JS timers before it
         // resolves, so the channel timeout has to cover the gesture the caller
         // asked for.
@@ -233,7 +218,7 @@ pub(crate) async fn dispatch(
                 method,
                 params,
                 engine,
-                eval_fn,
+                webviews,
                 win,
                 drag_eval_timeout(params),
             )
@@ -244,7 +229,7 @@ pub(crate) async fn dispatch(
         // `state` call also surfaces plugin/CLI version drift (issue #135).
         "state" => {
             let mut result =
-                handle_eval_method("state", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await?;
+                handle_eval_method("state", params, engine, webviews, win, DEFAULT_TIMEOUT).await?;
             inject_plugin_version(&mut result);
             Ok(result)
         }
@@ -256,7 +241,7 @@ pub(crate) async fn dispatch(
                 method,
                 params,
                 engine,
-                eval_fn,
+                webviews,
                 win,
                 bridge_eval_timeout(params),
             )
@@ -268,21 +253,29 @@ pub(crate) async fn dispatch(
         // two surfaces can't be confused by callers or accidentally folded
         // together by a future refactor.
         "screenshot" => {
-            handle_eval_method(method, params, engine, eval_fn, win, SCREENSHOT_TIMEOUT).await
+            handle_eval_method(method, params, engine, webviews, win, SCREENSHOT_TIMEOUT).await
         }
         "screenshot_native" => screenshot::handle_screenshot(params).await,
         "console.getLogs" => {
-            handle_eval_method("consoleLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method(
+                "consoleLogs",
+                params,
+                engine,
+                webviews,
+                win,
+                DEFAULT_TIMEOUT,
+            )
+            .await
         }
         "console.clear" => {
-            handle_eval_method("clearLogs", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method("clearLogs", params, engine, webviews, win, DEFAULT_TIMEOUT).await
         }
         "network.getRequests" => {
             handle_eval_method(
                 "networkRequests",
                 params,
                 engine,
-                eval_fn,
+                webviews,
                 win,
                 DEFAULT_TIMEOUT,
             )
@@ -293,34 +286,42 @@ pub(crate) async fn dispatch(
                 "clearNetwork",
                 params,
                 engine,
-                eval_fn,
+                webviews,
                 win,
                 DEFAULT_TIMEOUT,
             )
             .await
         }
         "storage.get" => {
-            handle_eval_method("storageGet", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method("storageGet", params, engine, webviews, win, DEFAULT_TIMEOUT).await
         }
         "storage.set" => {
-            handle_eval_method("storageSet", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method("storageSet", params, engine, webviews, win, DEFAULT_TIMEOUT).await
         }
         "storage.list" => {
-            handle_eval_method("storageList", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method(
+                "storageList",
+                params,
+                engine,
+                webviews,
+                win,
+                DEFAULT_TIMEOUT,
+            )
+            .await
         }
         "storage.clear" => {
             handle_eval_method(
                 "storageClear",
                 params,
                 engine,
-                eval_fn,
+                webviews,
                 win,
                 DEFAULT_TIMEOUT,
             )
             .await
         }
         "forms.dump" => {
-            handle_eval_method("formDump", params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
+            handle_eval_method("formDump", params, engine, webviews, win, DEFAULT_TIMEOUT).await
         }
         "record.start" => {
             recorder.start();
@@ -362,15 +363,9 @@ pub(crate) async fn dispatch(
 async fn handle_diff(
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
+    webviews: &dyn Webviews,
     window: Option<&str>,
 ) -> Result<serde_json::Value, RpcError> {
-    let eval_fn = eval_fn.ok_or_else(|| RpcError {
-        code: -32603,
-        message: "No webview available for eval".to_owned(),
-        data: None,
-    })?;
-
     // Determine reference snapshot: from params["reference"] or last stored snapshot
     let reference = if let Some(ref_val) = params.and_then(|p| p.get("reference")) {
         ref_val.clone()
@@ -399,7 +394,7 @@ async fn handle_diff(
             message: msg,
             data: None,
         })?;
-    let result = eval_bridge(&script, engine, eval_fn, window, DEFAULT_TIMEOUT).await?;
+    let result = eval_bridge(&script, engine, webviews, window, DEFAULT_TIMEOUT).await?;
 
     // Parse both snapshots: extract "elements" arrays
     let old_elements: Vec<diff::SnapshotElement> = reference
@@ -450,7 +445,7 @@ async fn handle_diff(
 #[cfg(feature = "press")]
 async fn handle_press(
     params: Option<&serde_json::Value>,
-    focus_fn: Option<&FocusFn>,
+    webviews: &dyn Webviews,
     window: Option<&str>,
 ) -> Result<serde_json::Value, RpcError> {
     let key_str = params
@@ -473,43 +468,30 @@ async fn handle_press(
         data: None,
     })?;
 
-    // An explicit `--window <label>` with no focus hook installed would
-    // otherwise silently drop the focus step and inject into whatever window
-    // currently has focus. Reject before taking any lock.
-    if window.is_some() && focus_fn.is_none() {
-        return Err(RpcError {
-            code: -32603,
-            message: "cannot focus target window: no focus hook installed".to_owned(),
-            data: None,
-        });
-    }
-
     // Hold this lock across the whole focus → settle → inject sequence so
     // two concurrent `press` calls cannot interleave their focus steps (call
     // A focuses window X, call B focuses window Y, then both keys land on Y).
     let _order_guard = PRESS_ORDER_LOCK.lock().await;
 
-    if let Some(focus) = focus_fn {
-        match focus(window) {
-            Ok(()) => {
-                // Only wait if the WM actually accepted the focus request —
-                // a failed focus call won't transfer focus, so sleeping
-                // would just delay the press for nothing.
-                tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
+    match webviews.target(window).and_then(|target| target.focus()) {
+        Ok(()) => {
+            // Only wait if the WM actually accepted the focus request —
+            // a failed focus call won't transfer focus, so sleeping
+            // would just delay the press for nothing.
+            tokio::time::sleep(Duration::from_millis(FOCUS_SETTLE_MS)).await;
+        }
+        Err(e) => {
+            if let Some(label) = window {
+                // The caller explicitly targeted a window; silently
+                // falling through would deliver the key to whatever
+                // window currently has focus and still return ok.
+                return Err(RpcError {
+                    code: -32603,
+                    message: format!("failed to focus window '{label}': {e}"),
+                    data: None,
+                });
             }
-            Err(e) => {
-                if let Some(label) = window {
-                    // The caller explicitly targeted a window; silently
-                    // falling through would deliver the key to whatever
-                    // window currently has focus and still return ok.
-                    return Err(RpcError {
-                        code: -32603,
-                        message: format!("failed to focus window '{label}': {e}"),
-                        data: None,
-                    });
-                }
-                tracing::warn!(error = %e, "focus before press failed (continuing)");
-            }
+            tracing::warn!(error = %e, "focus before press failed (continuing)");
         }
     }
 
@@ -547,22 +529,16 @@ async fn handle_eval_method(
     method: &str,
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
+    webviews: &dyn Webviews,
     window: Option<&str>,
     timeout: Duration,
 ) -> Result<serde_json::Value, RpcError> {
-    let eval_fn = eval_fn.ok_or_else(|| RpcError {
-        code: -32603,
-        message: "No webview available for eval".to_owned(),
-        data: None,
-    })?;
-
     let script = build_bridge_call(method, params).map_err(|msg| RpcError {
         code: -32602,
         message: msg,
         data: None,
     })?;
-    eval_bridge(&script, engine, eval_fn, window, timeout).await
+    eval_bridge(&script, engine, webviews, window, timeout).await
 }
 
 /// How long `navigate` waits for a hello from an origin whose bridge never
@@ -584,21 +560,19 @@ const BRIDGE_GRACE: Duration = Duration::from_secs(3);
 async fn handle_navigate(
     params: Option<&serde_json::Value>,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
+    webviews: &dyn Webviews,
     window: Option<&str>,
 ) -> Result<serde_json::Value, RpcError> {
-    let eval_fn = eval_fn.ok_or_else(|| RpcError {
-        code: -32603,
-        message: "No webview available for eval".to_owned(),
-        data: None,
-    })?;
     let script = build_bridge_call("navigate", params).map_err(|msg| RpcError {
         code: -32602,
         message: msg,
         data: None,
     })?;
     let since = engine.hellos();
-    let (id, rx, page) = send_script(&script, engine, eval_fn, window)?;
+    let target = target(webviews, window)?;
+    // Read before the eval so the URL names the page the script lands on.
+    let page = target.url();
+    let (id, rx) = send_script(&script, engine, target.as_ref())?;
     let dest = navigate_destination(
         page.as_ref(),
         params.and_then(|p| p.get("url").and_then(serde_json::Value::as_str)),
@@ -692,41 +666,50 @@ fn fail_no_bridge(engine: &EvalEngine, id: u64, page: &tauri::Url) -> RpcError {
 
 /// Send a bridge script and wait for its callback.
 ///
-/// Fails at once when the page has no bridge that can call back, instead of
-/// waiting out `timeout` (#153). The script has already run on that page.
+/// Refuses without running the script when the page has no bridge that can
+/// call back, instead of waiting out `timeout` (#153).
 async fn eval_bridge(
     script: &str,
     engine: &EvalEngine,
-    eval_fn: &EvalFn,
+    webviews: &dyn Webviews,
     window: Option<&str>,
     timeout: Duration,
 ) -> Result<serde_json::Value, RpcError> {
-    let (id, rx, page) = send_script(script, engine, eval_fn, window)?;
-    if let Some(page) = page.filter(|page| !engine.has_bridge(page)) {
-        engine.resolve(id, Err("page has no pilot bridge".to_owned()));
+    let target = target(webviews, window)?;
+    if let Some(page) = target.url().filter(|page| !engine.has_bridge(page)) {
         return Err(no_bridge_error(
             engine,
             &format!("no pilot bridge on the current page ({page})"),
         ));
     }
+    let (id, rx) = send_script(script, engine, target.as_ref())?;
     wait(engine, id, rx, timeout).await
 }
 
+/// Resolve the window a request targets.
+fn target<'a>(
+    webviews: &'a dyn Webviews,
+    window: Option<&str>,
+) -> Result<Box<dyn TargetWindow + 'a>, RpcError> {
+    webviews.target(window).map_err(|e| RpcError {
+        code: -32603,
+        message: format!("Eval failed: {e}"),
+        data: None,
+    })
+}
+
 /// Register a callback, then eval `script` wrapped in the ADR-001 pattern.
-///
-/// Returns the callback id and receiver, plus the page URL from `eval_fn`.
 fn send_script(
     script: &str,
     engine: &EvalEngine,
-    eval_fn: &EvalFn,
-    window: Option<&str>,
+    target: &dyn TargetWindow,
 ) -> Result<CallbackSlot, RpcError> {
     let (id, rx) = engine.register();
     let wrapped = EvalEngine::wrap_script(id, script);
-    match eval_fn(window, wrapped) {
-        Ok(page) => Ok((id, rx, page)),
+    match target.eval(&wrapped) {
+        Ok(()) => Ok((id, rx)),
         Err(e) => {
-            // Clean up pending entry on eval_fn failure
+            // Clean up pending entry on eval failure
             engine.resolve(id, Err(format!("Eval failed: {e}")));
             Err(RpcError {
                 code: -32603,
@@ -737,11 +720,10 @@ fn send_script(
     }
 }
 
-/// Callback id, its receiver, and the URL of the page the script was sent to.
+/// Callback id and its receiver.
 type CallbackSlot = (
     u64,
     tokio::sync::oneshot::Receiver<Result<serde_json::Value, String>>,
-    Option<tauri::Url>,
 );
 
 /// Wait for the callback of eval `id`.
@@ -855,7 +837,7 @@ pub(crate) fn callback<R: tauri::Runtime>(
         id,
         result,
         error,
-        crate::current_url(&webview).as_ref(),
+        crate::webview::current_url(&webview).as_ref(),
     );
 }
 
@@ -883,21 +865,28 @@ pub(crate) fn __callback<R: tauri::Runtime>(
         id,
         result,
         error,
-        crate::current_url(&webview).as_ref(),
+        crate::webview::current_url(&webview).as_ref(),
     );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::webview::fake::FakeWebviews;
     use serde_json::json;
 
     #[tokio::test]
     async fn test_dispatch_ping_returns_ok() {
         let engine = EvalEngine::new();
-        let result = dispatch("ping", None, &engine, None, None, None, &Recorder::new())
-            .await
-            .expect("dispatch succeeds");
+        let result = dispatch(
+            "ping",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await
+        .expect("dispatch succeeds");
         assert_eq!(result["status"], json!("ok"));
     }
 
@@ -908,9 +897,15 @@ mod tests {
         // the CLI (issue #135). Older plugins (<= 0.7.0) omit the field, which
         // the CLI reads as "pre-introspection, upgrade recommended".
         let engine = EvalEngine::new();
-        let result = dispatch("ping", None, &engine, None, None, None, &Recorder::new())
-            .await
-            .expect("dispatch succeeds");
+        let result = dispatch(
+            "ping",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await
+        .expect("dispatch succeeds");
         assert_eq!(result["plugin_version"], json!(env!("CARGO_PKG_VERSION")));
     }
 
@@ -924,9 +919,7 @@ mod tests {
             "press",
             Some(&json!({"key": "Control++P"})),
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -937,8 +930,8 @@ mod tests {
 
     #[cfg(feature = "press")]
     #[tokio::test]
-    async fn test_dispatch_press_with_explicit_window_and_no_focus_fn_errors() {
-        // --window <label> with no focus hook must not silently inject into
+    async fn test_dispatch_press_with_unknown_window_errors() {
+        // --window <label> naming no window must not silently inject into
         // the currently focused window. We can pass `window` through params
         // (handler extracts it before dispatch).
         let engine = EvalEngine::new();
@@ -946,9 +939,7 @@ mod tests {
             "press",
             Some(&json!({"key": "Enter", "window": "settings"})),
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -961,7 +952,14 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_press_with_missing_key_returns_invalid_params() {
         let engine = EvalEngine::new();
-        let result = dispatch("press", None, &engine, None, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "press",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
         let err = result.expect_err("dispatch returns Err");
         assert_eq!(err.code, -32602);
     }
@@ -973,9 +971,7 @@ mod tests {
             "nonexistent",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -984,15 +980,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_snapshot_without_eval_fn() {
+    async fn test_dispatch_snapshot_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "snapshot",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1002,9 +996,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_diff_without_eval_fn() {
+    async fn test_dispatch_diff_without_webview() {
         let engine = EvalEngine::new();
-        let result = dispatch("diff", None, &engine, None, None, None, &Recorder::new()).await;
+        let params = json!({"reference": {"elements": []}});
+        let result = dispatch(
+            "diff",
+            Some(&params),
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
         let err = result.expect_err("dispatch returns Err");
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -1013,27 +1015,10 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_diff_without_previous_snapshot() {
         let engine = EvalEngine::new();
-        // Provide a dummy eval_fn that always succeeds (won't be called because we fail before)
-        // Actually diff needs eval_fn first, then checks reference.
-        // We need an eval_fn that returns something, but there's no previous snapshot.
-        // Use an eval_fn that will block forever — but we check reference before eval.
-        // Wait: handle_diff checks eval_fn first, then reference.
-        // So with eval_fn but no previous snapshot, we get -32602 after eval completes.
-        // Let's use a sync eval_fn and resolve manually.
-        // Actually the reference check happens BEFORE the eval call, so we can check:
-        // eval_fn present + no reference in params + no last_snapshot → -32602
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
-        let result = dispatch(
-            "diff",
-            None,
-            &engine,
-            Some(&eval_fn),
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await;
+        // The reference check runs before any eval, so a webview that never
+        // answers is enough: no reference in params + no last_snapshot → -32602
+        let webviews = FakeWebviews::window("main", None);
+        let result = dispatch("diff", None, &engine, &webviews, &Recorder::new()).await;
         let err = result.expect_err("dispatch returns Err");
         assert_eq!(err.code, -32602);
         assert!(err.message.contains("No previous snapshot"));
@@ -1101,15 +1086,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_console_get_logs_without_eval_fn() {
+    async fn test_dispatch_console_get_logs_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "console.getLogs",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1119,15 +1102,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_console_clear_without_eval_fn() {
+    async fn test_dispatch_console_clear_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "console.clear",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1151,15 +1132,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_network_get_requests_without_eval_fn() {
+    async fn test_dispatch_network_get_requests_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "network.getRequests",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1169,15 +1148,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_network_clear_without_eval_fn() {
+    async fn test_dispatch_network_clear_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "network.clear",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1226,9 +1203,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_watch_without_eval_fn() {
+    async fn test_dispatch_watch_without_webview() {
         let engine = EvalEngine::new();
-        let result = dispatch("watch", None, &engine, None, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "watch",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
         let err = result.expect_err("dispatch returns Err");
         assert_eq!(err.code, -32603);
         assert!(err.message.contains("No webview"));
@@ -1245,7 +1229,14 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drag_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drag", None, &engine, None, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "drag",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
         let err = result.expect_err("dispatch returns Err");
         assert_ne!(err.code, -32601);
     }
@@ -1253,7 +1244,14 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_drop_routes_to_eval() {
         let engine = EvalEngine::new();
-        let result = dispatch("drop", None, &engine, None, None, None, &Recorder::new()).await;
+        let result = dispatch(
+            "drop",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await;
         let err = result.expect_err("dispatch returns Err");
         assert_ne!(err.code, -32601);
     }
@@ -1273,15 +1271,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_storage_get_without_eval_fn() {
+    async fn test_dispatch_storage_get_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "storage.get",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1291,15 +1287,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_storage_set_without_eval_fn() {
+    async fn test_dispatch_storage_set_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "storage.set",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1309,15 +1303,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_storage_list_without_eval_fn() {
+    async fn test_dispatch_storage_list_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "storage.list",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1327,15 +1319,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_storage_clear_without_eval_fn() {
+    async fn test_dispatch_storage_clear_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "storage.clear",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1395,15 +1385,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_forms_dump_without_eval_fn() {
+    async fn test_dispatch_forms_dump_without_webview() {
         let engine = EvalEngine::new();
         let result = dispatch(
             "forms.dump",
             None,
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await;
@@ -1413,39 +1401,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_windows_list_without_list_fn() {
+    async fn test_dispatch_windows_list() {
         let engine = EvalEngine::new();
-        let result = dispatch(
-            "windows.list",
-            None,
-            &engine,
-            None,
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await;
-        let err = result.expect_err("dispatch returns Err");
-        assert_eq!(err.code, -32603);
-        assert!(err.message.contains("No window manager"));
-    }
-
-    #[tokio::test]
-    async fn test_dispatch_windows_list_with_list_fn() {
-        let engine = EvalEngine::new();
-        let list_fn: crate::server::ListWindowsFn = std::sync::Arc::new(
-            || serde_json::json!({"windows": [{"label": "main", "url": "http://localhost", "title": "Test"}]}),
-        );
-        let result = dispatch(
-            "windows.list",
-            None,
-            &engine,
-            None,
-            Some(&list_fn),
-            None,
-            &Recorder::new(),
-        )
-        .await;
+        let webviews = FakeWebviews::window("main", Some("http://localhost/"));
+        let result = dispatch("windows.list", None, &engine, &webviews, &Recorder::new()).await;
         let val = result.expect("dispatch succeeds");
         let windows = val
             .get("windows")
@@ -1460,31 +1419,16 @@ mod tests {
     async fn test_dispatch_window_param_extracted_from_params() {
         let engine = EvalEngine::new();
         // The "window" key must be stripped before being forwarded to the bridge.
-        // We verify this by inspecting the script received by eval_fn.
-        let captured: std::sync::Arc<std::sync::Mutex<String>> =
-            std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-        let captured_clone = captured.clone();
+        // We verify this by inspecting the script the webview received.
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, script: String| {
-                *captured_clone.lock().expect("captured mutex") = script;
-                // Resolve the callback immediately to avoid blocking for the default 10s timeout.
-                // ID 1 is the first registered callback on a fresh EvalEngine.
-                engine_clone.resolve(1, Ok(serde_json::json!({"ok": true})));
-                Ok(None)
-            });
+        let webviews = FakeWebviews::window("settings", None).on_eval(move || {
+            // Resolve the callback immediately to avoid blocking for the default 10s timeout.
+            // ID 1 is the first registered callback on a fresh EvalEngine.
+            engine_clone.resolve(1, Ok(serde_json::json!({"ok": true})));
+        });
         let params = serde_json::json!({"ref": "el-1", "window": "settings"});
-        let _ = dispatch(
-            "click",
-            Some(&params),
-            &engine,
-            Some(&eval_fn),
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await;
-        let script = captured.lock().expect("captured mutex").clone();
+        let _ = dispatch("click", Some(&params), &engine, &webviews, &Recorder::new()).await;
+        let script = webviews.scripts().pop().expect("script evaluated");
         // "window" param must not appear in the JS call args
         assert!(!script.contains("\"window\""));
         assert!(script.contains("\"ref\""));
@@ -1500,9 +1444,7 @@ mod tests {
             "screenshot_native",
             Some(&params),
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await
@@ -1524,9 +1466,7 @@ mod tests {
             "screenshot_native",
             Some(&params),
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &Recorder::new(),
         )
         .await
@@ -1551,9 +1491,7 @@ mod tests {
                 "screenshot",
                 Some(&params),
                 &engine,
-                None,
-                None,
-                None,
+                &FakeWebviews::default(),
                 &Recorder::new(),
             )
             .await;
@@ -1567,9 +1505,15 @@ mod tests {
     async fn test_dispatch_record_start_returns_recording() {
         let engine = EvalEngine::new();
         let recorder = Recorder::new();
-        let result = dispatch("record.start", None, &engine, None, None, None, &recorder)
-            .await
-            .expect("dispatch succeeds");
+        let result = dispatch(
+            "record.start",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &recorder,
+        )
+        .await
+        .expect("dispatch succeeds");
         assert_eq!(result["status"], "recording");
         assert!(recorder.is_active());
     }
@@ -1580,9 +1524,15 @@ mod tests {
         let recorder = Recorder::new();
         recorder.start();
         recorder.record("click", Some(&json!({"ref": "e1"})));
-        let result = dispatch("record.stop", None, &engine, None, None, None, &recorder)
-            .await
-            .expect("dispatch succeeds");
+        let result = dispatch(
+            "record.stop",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &recorder,
+        )
+        .await
+        .expect("dispatch succeeds");
         assert_eq!(result["count"], 1);
         assert!(result["entries"].as_array().is_some());
         assert!(!recorder.is_active());
@@ -1593,9 +1543,15 @@ mod tests {
         let engine = EvalEngine::new();
         let recorder = Recorder::new();
         recorder.start();
-        let result = dispatch("record.status", None, &engine, None, None, None, &recorder)
-            .await
-            .expect("dispatch succeeds");
+        let result = dispatch(
+            "record.status",
+            None,
+            &engine,
+            &FakeWebviews::default(),
+            &recorder,
+        )
+        .await
+        .expect("dispatch succeeds");
         assert_eq!(result["active"], true);
         assert_eq!(result["count"], 0);
     }
@@ -1610,9 +1566,7 @@ mod tests {
             "record.add",
             Some(&params),
             &engine,
-            None,
-            None,
-            None,
+            &FakeWebviews::default(),
             &recorder,
         )
         .await
@@ -1808,10 +1762,9 @@ mod tests {
         // whatever timer the dispatch is parked on. The elapsed value reflects
         // the *effective* Rust-side cap.
         let engine = EvalEngine::new();
-        // eval_fn that accepts the script but never resolves the callback —
+        // A webview that accepts the script but never resolves the callback —
         // the timeout decides who wins.
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
+        let webviews = FakeWebviews::window("main", None);
 
         let params = json!({
             "selector": "[data-testid=\"never-exists\"]",
@@ -1819,17 +1772,9 @@ mod tests {
         });
 
         let start = tokio::time::Instant::now();
-        let err = dispatch(
-            "wait",
-            Some(&params),
-            &engine,
-            Some(&eval_fn),
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await
-        .expect_err("dispatch must time out");
+        let err = dispatch("wait", Some(&params), &engine, &webviews, &Recorder::new())
+            .await
+            .expect_err("dispatch must time out");
         let elapsed = start.elapsed();
 
         // The behavioral invariant being defended: the Rust channel must
@@ -1854,17 +1799,14 @@ mod tests {
         // default. The Rust channel must still outlive that default so the
         // bridge gets to surface its own `Timeout waiting for …` rejection.
         let engine = EvalEngine::new();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
+        let webviews = FakeWebviews::window("main", None);
 
         let start = tokio::time::Instant::now();
         let _err = dispatch(
             "wait",
             Some(&json!({"selector": "#root"})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -1882,17 +1824,14 @@ mod tests {
         // Regression guard: `wait` and `watch` share the helper, so the
         // existing `watch` behavior must remain intact.
         let engine = EvalEngine::new();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
+        let webviews = FakeWebviews::window("main", None);
 
         let start = tokio::time::Instant::now();
         let _err = dispatch(
             "watch",
             Some(&json!({"timeout": 25_000_u64})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -1912,21 +1851,17 @@ mod tests {
         // channel error — the buffer is a ceiling, not a per-call cost.
         let engine = EvalEngine::new();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                // The first registered callback on a fresh engine has id == 1
-                // (see EvalEngine::register / next_id init in eval.rs).
-                engine_clone.resolve(1, Ok(json!({"found": true})));
-                Ok(None)
-            });
+        let webviews = FakeWebviews::window("main", None).on_eval(move || {
+            // The first registered callback on a fresh engine has id == 1
+            // (see EvalEngine::register / next_id init in eval.rs).
+            engine_clone.resolve(1, Ok(json!({"found": true})));
+        });
 
         let result = dispatch(
             "wait",
             Some(&json!({"selector": "#root", "timeout": 60_000_u64})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -1941,27 +1876,17 @@ mod tests {
         // from a single `state` call (issue #135).
         let engine = EvalEngine::new();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                // First register on a fresh engine has id == 1 (see eval.rs).
-                engine_clone.resolve(
-                    1,
-                    Ok(json!({"url": "http://localhost/", "title": "App", "ready": true})),
-                );
-                Ok(None)
-            });
+        let webviews = FakeWebviews::window("main", None).on_eval(move || {
+            // First register on a fresh engine has id == 1 (see eval.rs).
+            engine_clone.resolve(
+                1,
+                Ok(json!({"url": "http://localhost/", "title": "App", "ready": true})),
+            );
+        });
 
-        let result = dispatch(
-            "state",
-            None,
-            &engine,
-            Some(&eval_fn),
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await
-        .expect("dispatch succeeds");
+        let result = dispatch("state", None, &engine, &webviews, &Recorder::new())
+            .await
+            .expect("dispatch succeeds");
 
         assert_eq!(result["url"], json!("http://localhost/"));
         assert_eq!(result["ready"], json!(true));
@@ -1990,20 +1915,15 @@ mod tests {
         // navigate used to report success and leave the session broken.
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                engine_clone.resolve(1, Ok(json!({"ok": true})));
-                Ok(Some(url(APP_PAGE)))
-            });
+        let webviews = FakeWebviews::window("main", Some(APP_PAGE))
+            .on_eval(move || engine_clone.resolve(1, Ok(json!({"ok": true}))));
 
         let start = tokio::time::Instant::now();
         let err = dispatch(
             "navigate",
             Some(&json!({"url": FOREIGN_PAGE})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -2028,21 +1948,12 @@ mod tests {
         // #153: every bridge command used to hang for DEFAULT_TIMEOUT once the
         // webview sat on a foreign origin.
         let engine = engine_with_app_bridge();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(Some(url(FOREIGN_PAGE))));
+        let webviews = FakeWebviews::window("main", Some(FOREIGN_PAGE));
 
         let start = tokio::time::Instant::now();
-        let err = dispatch(
-            "title",
-            None,
-            &engine,
-            Some(&eval_fn),
-            None,
-            None,
-            &Recorder::new(),
-        )
-        .await
-        .expect_err("a page without a bridge cannot answer");
+        let err = dispatch("title", None, &engine, &webviews, &Recorder::new())
+            .await
+            .expect_err("a page without a bridge cannot answer");
 
         assert!(
             start.elapsed() < Duration::from_secs(1),
@@ -2058,29 +1969,38 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_dispatch_on_page_without_bridge_runs_no_script() {
+        // The page cannot report a result, so a click there must not act on
+        // it either.
+        let engine = engine_with_app_bridge();
+        let webviews = FakeWebviews::window("main", Some(FOREIGN_PAGE));
+        let params = json!({"ref": "e1"});
+        dispatch("click", Some(&params), &engine, &webviews, &Recorder::new())
+            .await
+            .expect_err("a page without a bridge cannot answer");
+        assert_eq!(webviews.scripts(), Vec::<String>::new());
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_dispatch_navigate_back_to_app_origin_waits_for_bridge_hello() {
         // #153: the way out of a foreign page is navigating back. The foreign
         // page cannot call back, so success is the app bridge's hello.
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                let engine = engine_clone.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(APP_PAGE)));
-                });
-                Ok(Some(url(FOREIGN_PAGE)))
+        let webviews = FakeWebviews::window("main", Some(FOREIGN_PAGE)).on_eval(move || {
+            let engine = engine_clone.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                handle_callback(&engine, HELLO_ID, None, None, Some(&url(APP_PAGE)));
             });
+        });
 
         let result = dispatch(
             "navigate",
             Some(&json!({"url": APP_PAGE})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -2092,19 +2012,14 @@ mod tests {
     async fn test_dispatch_navigate_within_app_origin_returns_bridge_result() {
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                engine_clone.resolve(1, Ok(json!({"ok": true})));
-                Ok(Some(url(APP_PAGE)))
-            });
+        let webviews = FakeWebviews::window("main", Some(APP_PAGE))
+            .on_eval(move || engine_clone.resolve(1, Ok(json!({"ok": true}))));
 
         let result = dispatch(
             "navigate",
             Some(&json!({"url": "/settings"})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -2117,25 +2032,21 @@ mod tests {
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
         let dest = "https://allowed.example/";
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                let engine = engine_clone.clone();
-                engine.resolve(1, Ok(json!({"ok": true})));
-                tokio::spawn(async move {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
-                });
-                Ok(Some(url(APP_PAGE)))
+        let webviews = FakeWebviews::window("main", Some(APP_PAGE)).on_eval(move || {
+            let engine = engine_clone.clone();
+            engine.resolve(1, Ok(json!({"ok": true})));
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
             });
+        });
 
         let start = tokio::time::Instant::now();
         let result = dispatch(
             "navigate",
             Some(&json!({"url": dest})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -2152,20 +2063,15 @@ mod tests {
     async fn test_dispatch_navigate_javascript_url_stays_on_page() {
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                engine_clone.resolve(1, Ok(json!({"ok": true})));
-                Ok(Some(url(APP_PAGE)))
-            });
+        let webviews = FakeWebviews::window("main", Some(APP_PAGE))
+            .on_eval(move || engine_clone.resolve(1, Ok(json!({"ok": true}))));
 
         let start = tokio::time::Instant::now();
         let result = dispatch(
             "navigate",
             Some(&json!({"url": "javascript:void(0)"})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await
@@ -2217,24 +2123,20 @@ mod tests {
         let engine = engine_with_app_bridge();
         let engine_clone = engine.clone();
         let dest = "https://allowed.example/";
-        let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
-                let engine = engine_clone.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
-                });
-                Ok(Some(url(APP_PAGE)))
+        let webviews = FakeWebviews::window("main", Some(APP_PAGE)).on_eval(move || {
+            let engine = engine_clone.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
             });
+        });
 
         let start = tokio::time::Instant::now();
         let result = dispatch(
             "navigate",
             Some(&json!({"url": dest})),
             &engine,
-            Some(&eval_fn),
-            None,
-            None,
+            &webviews,
             &Recorder::new(),
         )
         .await

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -13,6 +13,8 @@ pub(crate) mod recorder;
 pub(crate) mod screenshot;
 #[cfg(any(unix, windows))]
 pub(crate) mod server;
+#[cfg(any(unix, windows))]
+pub(crate) mod webview;
 
 pub use error::Error;
 
@@ -20,8 +22,6 @@ pub use error::Error;
 use eval::EvalEngine;
 #[cfg(any(unix, windows))]
 use recorder::Recorder;
-#[cfg(any(unix, windows))]
-use server::{EvalFn, FocusFn, ListWindowsFn};
 #[cfg(any(unix, windows))]
 use std::sync::Arc;
 #[cfg(any(unix, windows))]
@@ -70,9 +70,8 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
                 let identifier = sanitize_identifier(&app.config().identifier);
 
-                let eval_fn = make_eval_fn(app);
-                let list_fn = make_list_fn(app);
-                let focus_fn = make_focus_fn(app);
+                let webviews: Arc<dyn webview::Webviews> =
+                    Arc::new(webview::TauriWebviews(app.clone()));
 
                 let recorder = Recorder::new();
 
@@ -102,9 +101,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                         listener,
                         guard,
                         engine,
-                        Some(eval_fn),
-                        Some(list_fn),
-                        Some(focus_fn),
+                        webviews,
                         recorder,
                     ));
                 }
@@ -118,9 +115,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 tauri::async_runtime::spawn(server::run(
                     server::socket_path(&identifier),
                     engine,
-                    Some(eval_fn),
-                    Some(list_fn),
-                    Some(focus_fn),
+                    webviews,
                     recorder,
                 ));
 
@@ -153,95 +148,6 @@ fn sanitize_identifier(raw: &str) -> String {
     } else {
         sanitized
     }
-}
-
-/// Create an eval function from the app handle that evaluates JS in a webview.
-///
-/// If `window` is `Some(label)`, targets that specific window (error if not found).
-/// If `window` is `None`, tries "main" first then falls back to the first available window.
-#[cfg(all(any(unix, windows), debug_assertions))]
-fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
-    let handle = app.clone();
-    Arc::new(move |window: Option<&str>, script: String| {
-        let target = if let Some(label) = window {
-            handle
-                .get_webview_window(label)
-                .ok_or_else(|| format!("Window '{label}' not found"))?
-        } else if let Some(w) = handle.get_webview_window("main") {
-            w
-        } else {
-            handle
-                .webview_windows()
-                .values()
-                .next()
-                .cloned()
-                .ok_or_else(|| "No webview available".to_owned())?
-        };
-        // Read before the eval so the URL names the page the script lands on.
-        let page = current_url(&target);
-        // Results come back via the `__callback` IPC command (see
-        // EvalEngine::wrap_script). This eval is fire-and-forget; the IPC handler
-        // resolves the pending request, not this closure.
-        target.eval(&script).map_err(|e| e.to_string())?;
-        Ok(page)
-    })
-}
-
-/// Read the current URL of a webview, or `None` when the runtime cannot report it.
-#[cfg(any(unix, windows))]
-pub(crate) fn current_url<R: tauri::Runtime>(wv: &tauri::WebviewWindow<R>) -> Option<tauri::Url> {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wv.url()))
-        .ok()
-        .and_then(Result::ok)
-}
-
-/// Create a focus function that requests OS focus for a webview window.
-///
-/// Resolution mirrors `make_eval_fn`: explicit label first, then `"main"`, then
-/// the first window. The call is best-effort — failures are returned to the
-/// caller (which logs and continues), since the press still has a chance of
-/// landing on whatever window currently holds focus.
-#[cfg(all(any(unix, windows), debug_assertions))]
-fn make_focus_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> FocusFn {
-    let handle = app.clone();
-    Arc::new(move |window: Option<&str>| {
-        let target = if let Some(label) = window {
-            handle
-                .get_webview_window(label)
-                .ok_or_else(|| format!("Window '{label}' not found"))?
-        } else if let Some(w) = handle.get_webview_window("main") {
-            w
-        } else {
-            handle
-                .webview_windows()
-                .values()
-                .next()
-                .cloned()
-                .ok_or_else(|| "No webview available".to_owned())?
-        };
-        target.set_focus().map_err(|e| e.to_string())
-    })
-}
-
-/// Create a list function that enumerates all available webview windows.
-#[cfg(all(any(unix, windows), debug_assertions))]
-fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
-    let handle = app.clone();
-    Arc::new(move || {
-        let windows = handle.webview_windows();
-        // BTreeMap iterates in sorted key order — no explicit sort needed
-        let list: Vec<serde_json::Value> = windows
-            .iter()
-            .map(|(label, wv)| {
-                serde_json::json!({
-                    "label": label,
-                    "url": current_url(wv).map(|url| url.to_string()).unwrap_or_default(),
-                    "title": wv.title().unwrap_or_default(),
-                })
-            })
-            .collect();
-        serde_json::json!({"windows": list})
-    })
 }
 
 #[cfg(test)]

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -3,31 +3,14 @@ use crate::eval::EvalEngine;
 use crate::handler;
 use crate::protocol::{Request, Response};
 use crate::recorder::Recorder;
+use crate::webview::Webviews;
 
-use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
-
-/// A function that evaluates JS in the webview.
-/// The first argument is an optional window label (`None` means "use default window").
-/// Returns the URL of the page the script was sent to, or `None` when the
-/// webview cannot report it.
-pub(crate) type EvalFn =
-    Arc<dyn Fn(Option<&str>, String) -> Result<Option<tauri::Url>, String> + Send + Sync>;
-
-/// A function that lists all available webview windows and returns their metadata.
-pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;
-
-/// A function that requests focus for a webview window.
-/// `None` means "default window" (same resolution as `EvalFn`).
-/// Used before native key injection so synthesised OS events reach the right window.
-pub(crate) type FocusFn = Arc<dyn Fn(Option<&str>) -> Result<(), String> + Send + Sync>;
 
 pub(crate) async fn handle_connection<S>(
     stream: S,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-    list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
+    webviews: &dyn Webviews,
     recorder: &Recorder,
 ) -> Result<(), Error>
 where
@@ -77,7 +60,7 @@ where
                 -32600,
                 "Invalid JSON-RPC version (expected \"2.0\")",
             ),
-            Ok(req) => dispatch_request(&req, engine, eval_fn, list_fn, focus_fn, recorder).await,
+            Ok(req) => dispatch_request(&req, engine, webviews, recorder).await,
             Err(e) => Response::error(serde_json::Value::Null, -32700, format!("Parse error: {e}")),
         };
 
@@ -93,22 +76,10 @@ where
 pub(crate) async fn dispatch_request(
     req: &Request,
     engine: &EvalEngine,
-    eval_fn: Option<&EvalFn>,
-    list_fn: Option<&ListWindowsFn>,
-    focus_fn: Option<&FocusFn>,
+    webviews: &dyn Webviews,
     recorder: &Recorder,
 ) -> Response {
-    match handler::dispatch(
-        &req.method,
-        req.params.as_ref(),
-        engine,
-        eval_fn,
-        list_fn,
-        focus_fn,
-        recorder,
-    )
-    .await
-    {
+    match handler::dispatch(&req.method, req.params.as_ref(), engine, webviews, recorder).await {
         Ok(result) => Response::success(req.id, result),
         Err(rpc_err) => Response {
             jsonrpc: "2.0".to_owned(),

--- a/crates/tauri-plugin-pilot/src/server/unix.rs
+++ b/crates/tauri-plugin-pilot/src/server/unix.rs
@@ -1,8 +1,9 @@
-use super::{EvalFn, FocusFn, ListWindowsFn, handle_connection};
+use super::handle_connection;
 
 use crate::error::Error;
 use crate::eval::EvalEngine;
 use crate::recorder::Recorder;
+use crate::webview::Webviews;
 
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
@@ -214,9 +215,7 @@ pub async fn run(
     listener: std::os::unix::net::UnixListener,
     _guard: Option<SocketGuard>,
     engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-    list_fn: Option<ListWindowsFn>,
-    focus_fn: Option<FocusFn>,
+    webviews: Arc<dyn Webviews>,
     recorder: Recorder,
 ) {
     let listener = match UnixListener::from_std(listener) {
@@ -226,7 +225,7 @@ pub async fn run(
             return;
         }
     };
-    if let Err(e) = accept_loop(listener, engine, eval_fn, list_fn, focus_fn, recorder).await {
+    if let Err(e) = accept_loop(listener, engine, webviews, recorder).await {
         tracing::error!("socket server error: {e}");
     }
 }
@@ -234,12 +233,10 @@ pub async fn run(
 async fn accept_loop(
     listener: UnixListener,
     engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-    list_fn: Option<ListWindowsFn>,
-    focus_fn: Option<FocusFn>,
+    webviews: Arc<dyn Webviews>,
     recorder: Recorder,
 ) -> Result<(), Error> {
-    let ctx = Arc::new((engine, eval_fn, list_fn, focus_fn, recorder));
+    let ctx = Arc::new((engine, webviews, recorder));
 
     loop {
         let (stream, _addr) = match listener.accept().await {
@@ -276,16 +273,7 @@ async fn accept_loop(
         }
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(
-                stream,
-                &ctx.0,
-                ctx.1.as_ref(),
-                ctx.2.as_ref(),
-                ctx.3.as_ref(),
-                &ctx.4,
-            )
-            .await
-            {
+            if let Err(e) = handle_connection(stream, &ctx.0, ctx.1.as_ref(), &ctx.2).await {
                 tracing::warn!("connection error: {e}");
             }
         });
@@ -304,6 +292,7 @@ fn android_peer_allowed(uid: u32, gid: u32, app_uid: u32) -> bool {
 mod tests {
     use super::*;
     use crate::protocol::Response;
+    use crate::webview::fake::FakeWebviews;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
@@ -380,7 +369,14 @@ mod tests {
         let (listener, guard) = bind(&address).expect("bind test socket");
         let engine = EvalEngine::new();
         let handle = tokio::spawn(async move {
-            run(listener, guard, engine, None, None, None, Recorder::new()).await;
+            run(
+                listener,
+                guard,
+                engine,
+                Arc::new(FakeWebviews::default()),
+                Recorder::new(),
+            )
+            .await;
         });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle

--- a/crates/tauri-plugin-pilot/src/server/windows.rs
+++ b/crates/tauri-plugin-pilot/src/server/windows.rs
@@ -1,8 +1,9 @@
-use super::{EvalFn, FocusFn, ListWindowsFn, handle_connection};
+use super::handle_connection;
 
 use crate::error::Error;
 use crate::eval::EvalEngine;
 use crate::recorder::Recorder;
+use crate::webview::Webviews;
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::ffi::c_void;
@@ -432,9 +433,7 @@ pub fn bind(pipe_path: &Path) -> Result<(NamedPipeServer, RegistryGuard), Error>
 pub async fn run(
     pipe_path: PathBuf,
     engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-    list_fn: Option<ListWindowsFn>,
-    focus_fn: Option<FocusFn>,
+    webviews: Arc<dyn Webviews>,
     recorder: Recorder,
 ) {
     let (first_server, guard) = match bind(&pipe_path) {
@@ -445,17 +444,7 @@ pub async fn run(
         }
     };
     let identifier = guard.identifier.clone();
-    if let Err(e) = accept_loop(
-        first_server,
-        &identifier,
-        engine,
-        eval_fn,
-        list_fn,
-        focus_fn,
-        recorder,
-    )
-    .await
-    {
+    if let Err(e) = accept_loop(first_server, &identifier, engine, webviews, recorder).await {
         tracing::error!("named pipe server error: {e}");
     }
 }
@@ -464,12 +453,10 @@ async fn accept_loop(
     first_server: NamedPipeServer,
     identifier: &str,
     engine: EvalEngine,
-    eval_fn: Option<EvalFn>,
-    list_fn: Option<ListWindowsFn>,
-    focus_fn: Option<FocusFn>,
+    webviews: Arc<dyn Webviews>,
     recorder: Recorder,
 ) -> Result<(), Error> {
-    let ctx = Arc::new((engine, eval_fn, list_fn, focus_fn, recorder));
+    let ctx = Arc::new((engine, webviews, recorder));
     let mut server = first_server;
     let pipe_path = socket_path(identifier);
 
@@ -523,16 +510,7 @@ async fn accept_loop(
 
         let ctx = Arc::clone(&ctx);
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(
-                current,
-                &ctx.0,
-                ctx.1.as_ref(),
-                ctx.2.as_ref(),
-                ctx.3.as_ref(),
-                &ctx.4,
-            )
-            .await
-            {
+            if let Err(e) = handle_connection(current, &ctx.0, ctx.1.as_ref(), &ctx.2).await {
                 tracing::warn!("connection error: {e}");
             }
         });
@@ -543,6 +521,7 @@ async fn accept_loop(
 mod tests {
     use super::*;
     use crate::protocol::Response;
+    use crate::webview::fake::FakeWebviews;
     use serial_test::serial;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
@@ -561,7 +540,13 @@ mod tests {
         let engine = EvalEngine::new();
         let path = path.to_path_buf();
         let handle = tokio::spawn(async move {
-            run(path, engine, None, None, None, Recorder::new()).await;
+            run(
+                path,
+                engine,
+                Arc::new(FakeWebviews::default()),
+                Recorder::new(),
+            )
+            .await;
         });
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle
@@ -673,9 +658,7 @@ mod tests {
             run(
                 dup_path,
                 EvalEngine::new(),
-                None,
-                None,
-                None,
+                Arc::new(FakeWebviews::default()),
                 Recorder::new(),
             )
             .await;

--- a/crates/tauri-plugin-pilot/src/webview.rs
+++ b/crates/tauri-plugin-pilot/src/webview.rs
@@ -243,7 +243,10 @@ mod tests {
             let url = format!("https://{name}.test/")
                 .parse()
                 .expect("valid test URL");
+            // An existing data directory keeps tauri from creating the user's
+            // real one, which races with the umask the socket tests set.
             WebviewWindowBuilder::new(&app, *name, WebviewUrl::External(url))
+                .data_directory(std::env::temp_dir())
                 .build()
                 .expect("build mock window");
         }

--- a/crates/tauri-plugin-pilot/src/webview.rs
+++ b/crates/tauri-plugin-pilot/src/webview.rs
@@ -1,0 +1,285 @@
+//! The webview windows the pilot server drives.
+//!
+//! Handlers reach webviews only through [`Webviews`]: [`TauriWebviews`] in the
+//! app, and `fake::FakeWebviews` in handler tests.
+
+#[cfg(debug_assertions)]
+use tauri::Manager;
+use tauri::Url;
+
+/// Metadata of one window, as `windows.list` reports it.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct WindowInfo {
+    pub(crate) label: String,
+    /// Empty when the runtime cannot report the URL.
+    pub(crate) url: String,
+    pub(crate) title: String,
+}
+
+/// The webview windows of the host app.
+pub(crate) trait Webviews: Send + Sync {
+    /// Resolve the target window: `label`, else `main`, else the first window.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `label` names no window, since an explicit label
+    /// never falls back to another window, or when the app has no window.
+    fn target(&self, label: Option<&str>) -> Result<Box<dyn TargetWindow + '_>, String>;
+
+    /// List every window, sorted by label.
+    fn list(&self) -> Vec<WindowInfo>;
+}
+
+/// A window resolved by [`Webviews::target`].
+///
+/// `Send` so a handler can keep one across an `.await`.
+pub(crate) trait TargetWindow: Send {
+    /// URL of the current page, or `None` when the runtime cannot report it.
+    fn url(&self) -> Option<Url>;
+
+    /// Evaluate `script` in the current page without waiting for a result.
+    ///
+    /// Results come back through the `__callback` IPC command (ADR-001).
+    ///
+    /// # Errors
+    ///
+    /// Returns the runtime error when the script cannot be dispatched.
+    fn eval(&self, script: &str) -> Result<(), String>;
+
+    /// Ask the OS to focus the window.
+    ///
+    /// # Errors
+    ///
+    /// Returns the runtime error when the focus request fails.
+    #[cfg(feature = "press")]
+    fn focus(&self) -> Result<(), String>;
+}
+
+/// [`Webviews`] backed by the Tauri app handle.
+///
+/// Windows are resolved on each call, so every request can target a
+/// different window.
+#[cfg(debug_assertions)]
+pub(crate) struct TauriWebviews<R: tauri::Runtime>(pub(crate) tauri::AppHandle<R>);
+
+#[cfg(debug_assertions)]
+impl<R: tauri::Runtime> TauriWebviews<R> {
+    /// Every webview window, in label order.
+    ///
+    /// Tauri returns a `HashMap`, whose order is not stable.
+    fn windows(&self) -> std::collections::BTreeMap<String, tauri::WebviewWindow<R>> {
+        self.0.webview_windows().into_iter().collect()
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<R: tauri::Runtime> Webviews for TauriWebviews<R> {
+    fn target(&self, label: Option<&str>) -> Result<Box<dyn TargetWindow + '_>, String> {
+        let window = match label {
+            Some(label) => self
+                .0
+                .get_webview_window(label)
+                .ok_or_else(|| format!("Window '{label}' not found"))?,
+            None => self
+                .0
+                .get_webview_window("main")
+                .or_else(|| self.windows().into_values().next())
+                .ok_or_else(|| "No webview available".to_owned())?,
+        };
+        Ok(Box::new(window))
+    }
+
+    fn list(&self) -> Vec<WindowInfo> {
+        self.windows()
+            .into_iter()
+            .map(|(label, window)| WindowInfo {
+                url: TargetWindow::url(&window)
+                    .map(|url| url.to_string())
+                    .unwrap_or_default(),
+                title: window.title().unwrap_or_default(),
+                label,
+            })
+            .collect()
+    }
+}
+
+/// Read the current URL of a webview, or `None` when the runtime cannot report it.
+///
+/// Also used by the `__callback` command to tag hellos with the page they
+/// come from.
+pub(crate) fn current_url<R: tauri::Runtime>(webview: &tauri::WebviewWindow<R>) -> Option<Url> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| webview.url()))
+        .ok()
+        .and_then(Result::ok)
+}
+
+// The bodies call the inherent `WebviewWindow` methods, which take precedence
+// over these trait methods of the same name.
+#[cfg(debug_assertions)]
+impl<R: tauri::Runtime> TargetWindow for tauri::WebviewWindow<R> {
+    fn url(&self) -> Option<Url> {
+        current_url(self)
+    }
+
+    fn eval(&self, script: &str) -> Result<(), String> {
+        Self::eval(self, script).map_err(|e| e.to_string())
+    }
+
+    #[cfg(feature = "press")]
+    fn focus(&self) -> Result<(), String> {
+        self.set_focus().map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod fake {
+    use super::{TargetWindow, Url, Webviews, WindowInfo};
+    use std::sync::Mutex;
+
+    /// In-memory [`Webviews`] for handler tests.
+    ///
+    /// Without a label, `target` picks the first window. Every evaluated
+    /// script is recorded, then the responder runs: that is where a test
+    /// plays the bridge and resolves the engine.
+    #[derive(Default)]
+    pub(crate) struct FakeWebviews {
+        windows: Vec<(String, Option<Url>)>,
+        scripts: Mutex<Vec<String>>,
+        responder: Option<Box<dyn Fn() + Send + Sync>>,
+    }
+
+    impl FakeWebviews {
+        /// One window labeled `label`, showing `url`.
+        pub(crate) fn window(label: &str, url: Option<&str>) -> Self {
+            let url = url.map(|url| Url::parse(url).expect("valid test URL"));
+            Self {
+                windows: vec![(label.to_owned(), url)],
+                ..Self::default()
+            }
+        }
+
+        /// Run `responder` after each eval.
+        pub(crate) fn on_eval(mut self, responder: impl Fn() + Send + Sync + 'static) -> Self {
+            self.responder = Some(Box::new(responder));
+            self
+        }
+
+        /// Scripts evaluated so far, oldest first.
+        pub(crate) fn scripts(&self) -> Vec<String> {
+            self.scripts.lock().expect("scripts mutex").clone()
+        }
+    }
+
+    impl Webviews for FakeWebviews {
+        fn target(&self, label: Option<&str>) -> Result<Box<dyn TargetWindow + '_>, String> {
+            let (_, url) = match label {
+                Some(label) => self
+                    .windows
+                    .iter()
+                    .find(|(name, _)| name == label)
+                    .ok_or_else(|| format!("Window '{label}' not found"))?,
+                None => self
+                    .windows
+                    .first()
+                    .ok_or_else(|| "No webview available".to_owned())?,
+            };
+            Ok(Box::new(FakeTarget {
+                webviews: self,
+                url: url.clone(),
+            }))
+        }
+
+        fn list(&self) -> Vec<WindowInfo> {
+            self.windows
+                .iter()
+                .map(|(label, url)| WindowInfo {
+                    label: label.clone(),
+                    url: url.as_ref().map(Url::to_string).unwrap_or_default(),
+                    title: String::new(),
+                })
+                .collect()
+        }
+    }
+
+    struct FakeTarget<'a> {
+        webviews: &'a FakeWebviews,
+        url: Option<Url>,
+    }
+
+    impl TargetWindow for FakeTarget<'_> {
+        fn url(&self) -> Option<Url> {
+            self.url.clone()
+        }
+
+        fn eval(&self, script: &str) -> Result<(), String> {
+            self.webviews
+                .scripts
+                .lock()
+                .expect("scripts mutex")
+                .push(script.to_owned());
+            if let Some(respond) = &self.webviews.responder {
+                respond();
+            }
+            Ok(())
+        }
+
+        #[cfg(feature = "press")]
+        fn focus(&self) -> Result<(), String> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::{TauriWebviews, Webviews};
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+
+    /// Resolve `label` in a mock app with one window per entry of `windows`,
+    /// each showing `https://<label>.test/`, and return the host it shows.
+    fn target_host(windows: &[&str], label: Option<&str>) -> Result<String, String> {
+        let app = tauri::test::mock_app();
+        for name in windows {
+            let url = format!("https://{name}.test/")
+                .parse()
+                .expect("valid test URL");
+            WebviewWindowBuilder::new(&app, *name, WebviewUrl::External(url))
+                .build()
+                .expect("build mock window");
+        }
+        let webviews = TauriWebviews(app.handle().clone());
+        let url = webviews.target(label)?.url().expect("mock window URL");
+        Ok(url.host_str().expect("test URL host").to_owned())
+    }
+
+    #[test]
+    fn target_uses_the_requested_label() {
+        let host = target_host(&["main", "settings"], Some("settings"));
+        assert_eq!(host.as_deref(), Ok("settings.test"));
+    }
+
+    #[test]
+    fn target_without_label_prefers_main() {
+        // "alpha" sorts first, so only the `main` rule can pick main here.
+        let host = target_host(&["alpha", "main"], None);
+        assert_eq!(host.as_deref(), Ok("main.test"));
+    }
+
+    #[test]
+    fn target_without_label_or_main_takes_the_first_by_label() {
+        let host = target_host(&["beta", "alpha"], None);
+        assert_eq!(host.as_deref(), Ok("alpha.test"));
+    }
+
+    #[test]
+    fn target_with_unknown_label_does_not_fall_back() {
+        let host = target_host(&["main"], Some("settings"));
+        assert_eq!(host, Err("Window 'settings' not found".to_owned()));
+    }
+
+    #[test]
+    fn target_without_windows_errors() {
+        let host = target_host(&[], None);
+        assert_eq!(host, Err("No webview available".to_owned()));
+    }
+}

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -99,7 +99,7 @@ The `EvalEngine` maintains:
 - A `HashMap<u64, oneshot::Sender<Result<Value, String>>>` for in-flight requests
 - An `AtomicU64` counter for request IDs
 
-The eval function dynamically resolves the target window on each call — it captures the `AppHandle` and looks up the window by label at eval time, rather than binding to a single window at startup. This allows targeting different windows across requests.
+Handlers reach webviews only through the `Webviews` trait in `webview.rs`. Its Tauri implementation holds the `AppHandle` and resolves the target window on each request: the `--window` label, else `main`, else the first window by label. This allows targeting different windows across requests. Handler tests use an in-memory fake instead.
 
 This makes every eval effectively async and type-safe from the Rust side.
 
@@ -107,7 +107,7 @@ This makes every eval effectively async and type-safe from the Rust side.
 
 The bridge is injected into every page, but Tauri's ACL lets `__callback` through only from origins that hold the pilot permission: the app origin, plus any origin a capability lists in `remote.urls`. On any other origin the script runs and its result is dropped, and a denied call sends the plugin no signal. To find out which origins can answer, the bridge sends a hello on each page load: `__callback` with id `0`, which no eval request uses, and its `location.href` as the result. The `EvalEngine` records the origin (scheme, host and port) of each hello.
 
-The eval function returns the URL of the page it sent the script to. When that page's origin never said hello, the command fails at once instead of waiting 10 seconds, and the error names the origins that did. `navigate` goes one step further. The old page answers before the webview leaves it, so for a destination origin with no hello yet, `navigate` waits up to 3 seconds for a hello from the new page and fails without one. Until the first hello arrives, the plugin cannot tell origins apart and every command takes the plain path.
+Before it sends a script, the handler reads the URL of the target window. When that page's origin never said hello, the command fails at once without running the script, instead of waiting 10 seconds, and the error names the origins that did. `navigate` still runs on such a page, since leaving is the way out, and it goes one step further. The old page answers before the webview leaves it, so for a destination origin with no hello yet, `navigate` waits up to 3 seconds for a hello from the new page and fails without one. Until the first hello arrives, the plugin cannot tell origins apart and every command takes the plain path.
 
 Hellos are tracked per origin, not per window. A slow page allowed by `remote.urls` can miss the 3-second grace on its first visit; later commands succeed once its hello arrives. The plugin records the invoking webview's URL, not the hello payload.
 
@@ -136,6 +136,7 @@ tauri-pilot/
 │   │   │   ├── protocol.rs        # Request, Response, RpcError
 │   │   │   ├── handler.rs         # Dispatch method → handler
 │   │   │   ├── eval.rs            # EvalEngine (callback pattern)
+│   │   │   ├── webview.rs         # Webviews trait: target window, eval, focus
 │   │   │   ├── diff.rs            # Snapshot diff (added/removed/changed)
 │   │   │   ├── key.rs             # press command key-combo parser
 │   │   │   ├── recorder.rs        # record/replay interaction capture

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -12,7 +12,7 @@ These options can be used with any command.
 | Option | Description |
 |--------|-------------|
 | `--socket <path>` | Explicit path to the Unix socket. Auto-detected if omitted. Env: `TAURI_PILOT_SOCKET` |
-| `--window <label>` | Target a specific window by label. Env: `TAURI_PILOT_WINDOW`. Default: `main`, falls back to first available |
+| `--window <label>` | Target a specific window by label. Env: `TAURI_PILOT_WINDOW`. Default: `main`, falls back to the first window by label |
 | `--json` | Output JSON instead of human-readable text |
 
 ### Socket Auto-Detection
@@ -33,7 +33,7 @@ tauri-pilot click @e3 --window main       # click in the main window
 TAURI_PILOT_WINDOW=settings tauri-pilot snapshot
 ```
 
-If `--window` is not specified, the CLI targets the `main` window and falls back to the first available window. If the specified window label does not exist, the command exits with an error.
+If `--window` is not specified, the CLI targets the `main` window and falls back to the first window by label. If the specified window label does not exist, the command exits with an error.
 
 ## Target Syntax
 


### PR DESCRIPTION
## Summary

• Handlers reach webviews through one `Webviews` trait (`webview.rs`) instead of three optional closures. `TauriWebviews` wraps the app handle; `FakeWebviews` replaces the eval mocks in handler tests. The target window (label, else `main`, else first by label) is resolved in one place and covered by MockRuntime tests.
• Behavior change: a bridge command checks the page origin before it evals, so it no longer runs its script on a page whose bridge cannot call back (a `click` there used to click, then fail). `navigate` still runs, since it is the way back.
• Fix: Tauri returns windows in a `HashMap`, so the fallback target and `windows.list` followed hash order. Both follow label order now.
• Server plumbing takes `Arc<dyn Webviews>`; `dispatch` loses `too_many_arguments`. Updates the architecture and CLI docs.

## Type

refactor




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Bridge commands on pages without a prior hello now fail before executing scripts.
  * The `navigate` command remains available for returning to the app’s origin.
  * Window targeting now prefers the requested label, then `main`, then the first window alphabetically by label.

* **Bug Fixes**
  * `windows.list` output is now sorted by window label.
  * Windowless `press` commands now fail when no app webview exists.
  * Improved handling of invalid targets, unavailable bridges, navigation checks, and focus failures.

* **Documentation**
  * Updated architecture and CLI guides with window selection and bridge validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->