### PR TITLE
fix(plugin): fail fast when the page cannot answer pilot callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page, but Tauri's ACL rejects its `__callback` because the pilot permission
   only covers the app origin, so every later command waited out the 10 s eval
   timeout. The bridge now says hello through `__callback` on each page load,
-  which tells the plugin which origins can answer. `navigate` fails after 3 s
-  when no hello comes from the destination. Other commands on such a page fail
-  at once, and the error names the page and the origins that work. Navigating
-  back to the app origin recovers the session, and an origin listed in a
-  capability's `remote.urls` keeps working. Pilot's own IPC calls also no
-  longer show up in `network.getRequests`. [#153]
+  which tells the plugin which origins can answer. On a first visit, `navigate`
+  waits up to 3 s for that hello and fails without it; a destination that
+  already said hello waits the usual 10 s for the new page. Other commands on
+  a page with no hello fail at once, and the error names the page and the
+  origins that work. Navigating back to the app origin recovers the session,
+  and an origin listed in a capability's `remote.urls` keeps working. Pilot's
+  own IPC calls also no longer show up in `network.getRequests`. [#153]
 
 - A second instance of an app that embeds the plugin no longer panics at
   startup. On Unix the plugin `setup` hook propagated the `AddrInUse` error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `navigate` to an origin the pilot bridge cannot answer from no longer
+  reports ok and leaves the session hung. The bridge does run on a foreign
+  page, but Tauri's ACL rejects its `__callback` because the pilot permission
+  only covers the app origin, so every later command waited out the 10 s eval
+  timeout. The bridge now says hello through `__callback` on each page load,
+  which tells the plugin which origins can answer. `navigate` fails after 3 s
+  when no hello comes from the destination. Other commands on such a page fail
+  at once, and the error names the page and the origins that work. Navigating
+  back to the app origin recovers the session, and an origin listed in a
+  capability's `remote.urls` keeps working. Pilot's own IPC calls also no
+  longer show up in `network.getRequests`. [#153]
+
 - A second instance of an app that embeds the plugin no longer panics at
   startup. On Unix the plugin `setup` hook propagated the `AddrInUse` error
   from the socket bind, which Tauri turns into a fatal `PluginInitialization`
@@ -695,3 +707,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#146]: https://github.com/mpiton/tauri-pilot/issues/146
 [#149]: https://github.com/mpiton/tauri-pilot/issues/149
 [#152]: https://github.com/mpiton/tauri-pilot/issues/152
+[#153]: https://github.com/mpiton/tauri-pilot/issues/153

--- a/README.md
+++ b/README.md
@@ -79,11 +79,16 @@ fn main() {
 >
 > ```json
 > {
+>   "remote": {
+>     "urls": ["https://allowed.example/*"]
+>   },
 >   "permissions": ["core:default", "pilot:default"]
 > }
 > ```
 >
 > Without `pilot:default`, eval commands fail with: `eval timed out after 10s`.
+> List a foreign origin in `remote.urls` on the same capability if you need to
+> drive that origin.
 
 ### 2. Install the CLI
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -143,9 +143,14 @@
       const q = text.indexOf("?");
       path = q === -1 ? text : text.slice(0, q);
     }
-    // Tauri encodes the command in the IPC path (`.../plugin%3Apilot%7C__callback`).
-    // A query string that happens to contain the same text is still app traffic.
-    return path.indexOf("plugin%3Apilot%7C") !== -1;
+    let decoded;
+    try {
+      decoded = decodeURIComponent(path);
+    } catch (_) {
+      decoded = path;
+    }
+    // Exact IPC path for the two callback commands, not a substring match.
+    return decoded === "/plugin:pilot|callback" || decoded === "/plugin:pilot|__callback";
   }
 
   const _originalFetch = window.fetch.bind(window);

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -133,12 +133,27 @@
     return 0;
   }
 
+  function isPilotIpcUrl(url) {
+    const text = String(url);
+    let path;
+    try {
+      const base = (window.location && window.location.href) || "http://localhost/";
+      path = new URL(text, base).pathname;
+    } catch (_) {
+      const q = text.indexOf("?");
+      path = q === -1 ? text : text.slice(0, q);
+    }
+    // Tauri encodes the command in the IPC path (`.../plugin%3Apilot%7C__callback`).
+    // A query string that happens to contain the same text is still app traffic.
+    return path.indexOf("plugin%3Apilot%7C") !== -1;
+  }
+
   const _originalFetch = window.fetch.bind(window);
   window.fetch = function(input, init) {
     const method = (init && init.method) || (input && input.method) || "GET";
     const url = (typeof input === "string") ? input : (input && input.url) || String(input);
     // Pilot's own IPC (eval callbacks, the bridge hello) is not app traffic.
-    if (url.indexOf("plugin%3Apilot%7C") !== -1) return _originalFetch(input, init);
+    if (isPilotIpcUrl(url)) return _originalFetch(input, init);
     const timestamp = Date.now();
     const requestSize = bodySize(init && init.body);
     return _originalFetch(input, init).then(function(response) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -137,6 +137,8 @@
   window.fetch = function(input, init) {
     const method = (init && init.method) || (input && input.method) || "GET";
     const url = (typeof input === "string") ? input : (input && input.url) || String(input);
+    // Pilot's own IPC (eval callbacks, the bridge hello) is not app traffic.
+    if (url.indexOf("plugin%3Apilot%7C") !== -1) return _originalFetch(input, init);
     const timestamp = Date.now();
     const requestSize = bodySize(init && init.body);
     return _originalFetch(input, init).then(function(response) {
@@ -1435,4 +1437,14 @@
     storageClear: storageClear,
     formDump: formDump,
   };
+
+  // Tell the plugin this origin can answer (#153). The ACL denies
+  // `__callback` to origins without the pilot permission, and a denied page
+  // can run the bridge but never deliver a result, so its silence here is the
+  // signal. Id 0 is HELLO_ID in eval.rs, never used by an eval request.
+  try {
+    window.__TAURI_INTERNALS__
+      .invoke("plugin:pilot|__callback", { id: 0, result: location.href })
+      .catch(function() {});
+  } catch (_) {}
 })();

--- a/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
@@ -1,0 +1,62 @@
+// Dependency-free tests for network capture skipping Pilot IPC (#153).
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// real file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function loadBridge() {
+  Object.assign(console, REAL_CONSOLE);
+
+  globalThis.location = { href: "https://app.example/" };
+  globalThis.window = {
+    fetch(input) {
+      return Promise.resolve({
+        status: 200,
+        headers: { get() { return "0"; } },
+      });
+    },
+    location: globalThis.location,
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  globalThis.document = { querySelector() { return null; } };
+
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("plugin IPC fetch is omitted from networkRequests", async () => {
+  const pilot = loadBridge();
+  await window.fetch("http://ipc.localhost/plugin%3Apilot%7C__callback");
+  await window.fetch("https://app.example/api");
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, ["https://app.example/api"]);
+});
+
+test("an app URL whose query contains the IPC substring is still recorded", async () => {
+  const pilot = loadBridge();
+  const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";
+  await window.fetch(app);
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, [app]);
+});

--- a/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
@@ -60,3 +60,11 @@ test("an app URL whose query contains the IPC substring is still recorded", asyn
   const urls = pilot.networkRequests().map((e) => e.url);
   assert.deepEqual(urls, [app]);
 });
+
+test("an app path that only contains the IPC substring is still recorded", async () => {
+  const pilot = loadBridge();
+  const app = "https://app.example/api/plugin%3Apilot%7C__callback";
+  await window.fetch(app);
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, [app]);
+});

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -3,7 +3,33 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::sync::oneshot;
+use tauri::Url;
+use tokio::sync::{oneshot, watch};
+
+/// Callback id the bridge sends its hello with when a page loads (#153).
+///
+/// Eval request ids start at 1 (see [`EvalEngine::new`]), so 0 never collides
+/// with a pending eval. `bridge.js` hardcodes the same value.
+pub(crate) const HELLO_ID: u64 = 0;
+
+/// Origins whose bridge said hello, each with the hello count at its latest hello.
+#[derive(Debug, Default)]
+struct Bridges {
+    hellos: u64,
+    latest: HashMap<String, u64>,
+}
+
+/// Key a URL by scheme, host and port.
+///
+/// `Url::origin` is opaque for custom schemes such as `tauri://`, which would
+/// make every app page its own origin, so the key is built by hand.
+fn origin_key(url: &Url) -> String {
+    match (url.host_str(), url.port()) {
+        (Some(host), Some(port)) => format!("{}://{host}:{port}", url.scheme()),
+        (Some(host), None) => format!("{}://{host}", url.scheme()),
+        (None, _) => format!("{}:", url.scheme()),
+    }
+}
 
 /// Error types for eval operations.
 #[derive(Debug, thiserror::Error)]
@@ -27,6 +53,7 @@ pub(crate) struct EvalEngine {
     pending: Arc<Mutex<PendingMap>>,
     next_id: Arc<AtomicU64>,
     last_snapshot: Arc<Mutex<Option<serde_json::Value>>>,
+    bridges: Arc<watch::Sender<Bridges>>,
 }
 
 impl EvalEngine {
@@ -35,7 +62,57 @@ impl EvalEngine {
             pending: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU64::new(1)),
             last_snapshot: Arc::new(Mutex::new(None)),
+            bridges: Arc::new(watch::Sender::new(Bridges::default())),
         }
+    }
+
+    /// Record the hello the bridge sends from `page` (its `location.href`).
+    ///
+    /// Only pages whose origin may call `__callback` can say hello, so the
+    /// hellos tell which origins answer bridge commands (#153).
+    pub fn bridge_hello(&self, page: &str) {
+        let Ok(url) = Url::parse(page) else {
+            tracing::warn!(page, "bridge hello with an invalid page URL");
+            return;
+        };
+        let key = origin_key(&url);
+        self.bridges.send_modify(|b| {
+            b.hellos += 1;
+            b.latest.insert(key, b.hellos);
+        });
+    }
+
+    /// Number of bridge hellos received so far.
+    pub fn hellos(&self) -> u64 {
+        self.bridges.borrow().hellos
+    }
+
+    /// Whether a bridge on the origin of `url` can answer.
+    ///
+    /// Also `true` before any hello: without one the engine cannot tell app
+    /// origins from foreign ones, so callers keep the plain eval path.
+    pub fn has_bridge(&self, url: &Url) -> bool {
+        let bridges = self.bridges.borrow();
+        bridges.hellos == 0 || bridges.latest.contains_key(&origin_key(url))
+    }
+
+    /// Origins whose bridge said hello, sorted.
+    pub fn bridge_origins(&self) -> Vec<String> {
+        let mut origins: Vec<String> = self.bridges.borrow().latest.keys().cloned().collect();
+        origins.sort();
+        origins
+    }
+
+    /// Wait for a hello from the origin of `url` newer than hello number `since`.
+    ///
+    /// Returns `false` when none arrives within `limit`.
+    pub async fn wait_bridge(&self, url: &Url, since: u64, limit: Duration) -> bool {
+        let key = origin_key(url);
+        let mut rx = self.bridges.subscribe();
+        let hello = rx.wait_for(|b| b.latest.get(&key).is_some_and(|&n| n > since));
+        tokio::time::timeout(limit, hello)
+            .await
+            .is_ok_and(|seen| seen.is_ok())
     }
 
     /// Store the last snapshot result for later diff comparison.
@@ -250,6 +327,46 @@ mod tests {
         assert!(
             script.contains("__r===undefined?'null':JSON.stringify(__r)"),
             "wrapped script must normalize undefined to the string 'null'; got: {script}"
+        );
+    }
+
+    #[test]
+    fn test_has_bridge_keys_by_scheme_host_and_port() {
+        let engine = EvalEngine::new();
+        let url = |text| Url::parse(text).expect("valid test URL");
+        // Before any hello the engine cannot tell origins apart.
+        assert!(engine.has_bridge(&url("https://example.com/")));
+
+        engine.bridge_hello("tauri://localhost/index.html");
+        // `Url::origin` is opaque for custom schemes; app pages must share a key.
+        assert!(engine.has_bridge(&url("tauri://localhost/settings")));
+        assert!(!engine.has_bridge(&url("https://example.com/")));
+
+        engine.bridge_hello("http://127.0.0.1:8080/");
+        assert!(!engine.has_bridge(&url("http://127.0.0.1:9090/")));
+        assert_eq!(
+            engine.bridge_origins(),
+            ["http://127.0.0.1:8080", "tauri://localhost"]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_bridge_ignores_hellos_before_since() {
+        let engine = EvalEngine::new();
+        let app = Url::parse("tauri://localhost/").expect("valid test URL");
+        engine.bridge_hello(app.as_str());
+        let since = engine.hellos();
+        assert!(
+            !engine
+                .wait_bridge(&app, since, Duration::from_secs(1))
+                .await,
+            "an old hello must not count as the new page's"
+        );
+        engine.bridge_hello(app.as_str());
+        assert!(
+            engine
+                .wait_bridge(&app, since, Duration::from_secs(1))
+                .await
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -121,16 +121,11 @@ impl EvalEngine {
     ///
     /// Also `true` before any hello: without one the engine cannot tell app
     /// origins from foreign ones, so callers keep the plain eval path.
-    /// An `http` URL also matches a hello from the `https` upgrade of the
-    /// same host and port, so an HSTS hop still counts.
+    /// Scheme-specific: a previous `https` hello does not make `http` look
+    /// callable. [`wait_bridge`] still accepts a fresh `https` upgrade.
     pub fn has_bridge(&self, url: &Url) -> bool {
         let bridges = self.bridges.borrow();
-        if bridges.hellos == 0 {
-            return true;
-        }
-        origin_keys(url)
-            .iter()
-            .any(|key| bridges.latest.contains_key(key))
+        bridges.hellos == 0 || bridges.latest.contains_key(&origin_key(url))
     }
 
     /// Origins whose bridge said hello, sorted.
@@ -399,8 +394,8 @@ mod tests {
         engine.bridge_hello("https://example.com/");
         assert!(engine.has_bridge(&url("https://example.com:443/login")));
         assert!(
-            engine.has_bridge(&url("http://example.com/")),
-            "http dest must match an https hello (HSTS)"
+            !engine.has_bridge(&url("http://example.com/")),
+            "a previous https hello must not make http look callable"
         );
         assert!(!engine.has_bridge(&url("https://other.example/")));
 
@@ -409,6 +404,28 @@ mod tests {
         assert!(
             !engine.has_bridge(&url("file:///tmp/b.html")),
             "hostless pages must not share a key"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_bridge_http_dest_matches_fresh_https_hello() {
+        let engine = EvalEngine::new();
+        let https = Url::parse("https://example.com/").expect("valid test URL");
+        let http = Url::parse("http://example.com/").expect("valid test URL");
+        engine.bridge_hello(https.as_str());
+        let since = engine.hellos();
+        assert!(
+            !engine
+                .wait_bridge(&http, since, Duration::from_secs(1))
+                .await,
+            "an old https hello must not count as this navigation's upgrade"
+        );
+        engine.bridge_hello(https.as_str());
+        assert!(
+            engine
+                .wait_bridge(&http, since, Duration::from_secs(1))
+                .await,
+            "a hello after since from the https upgrade must count"
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/eval.rs
+++ b/crates/tauri-plugin-pilot/src/eval.rs
@@ -23,11 +23,41 @@ struct Bridges {
 ///
 /// `Url::origin` is opaque for custom schemes such as `tauri://`, which would
 /// make every app page its own origin, so the key is built by hand.
-fn origin_key(url: &Url) -> String {
-    match (url.host_str(), url.port()) {
+/// Default ports are always written (`https://host` and `https://host:443`
+/// share a key). Hostless URLs (`file:`, `data:`) keep the rest of the URL
+/// so they do not inherit each other's hello.
+pub(crate) fn origin_key(url: &Url) -> String {
+    match (
+        url.host_str().filter(|host| !host.is_empty()),
+        url.port_or_known_default(),
+    ) {
         (Some(host), Some(port)) => format!("{}://{host}:{port}", url.scheme()),
         (Some(host), None) => format!("{}://{host}", url.scheme()),
-        (None, _) => format!("{}:", url.scheme()),
+        (None, _) => match url.as_str().split_once('#') {
+            Some((without_fragment, _)) => without_fragment.to_owned(),
+            None => url.as_str().to_owned(),
+        },
+    }
+}
+
+/// Origin keys `url` can match, including an `http` → `https` upgrade.
+///
+/// HSTS (and similar) hops store the hello under `https://host` while
+/// `navigate` still asked for `http://host`. Same host and port, new scheme.
+fn origin_keys(url: &Url) -> Vec<String> {
+    let key = origin_key(url);
+    if url.scheme() != "http" {
+        return vec![key];
+    }
+    let mut https = url.clone();
+    if https.set_scheme("https").is_err() {
+        return vec![key];
+    }
+    let https_key = origin_key(&https);
+    if https_key == key {
+        vec![key]
+    } else {
+        vec![key, https_key]
     }
 }
 
@@ -66,7 +96,7 @@ impl EvalEngine {
         }
     }
 
-    /// Record the hello the bridge sends from `page` (its `location.href`).
+    /// Record a hello from `page` (the invoking webview's URL).
     ///
     /// Only pages whose origin may call `__callback` can say hello, so the
     /// hellos tell which origins answer bridge commands (#153).
@@ -91,9 +121,16 @@ impl EvalEngine {
     ///
     /// Also `true` before any hello: without one the engine cannot tell app
     /// origins from foreign ones, so callers keep the plain eval path.
+    /// An `http` URL also matches a hello from the `https` upgrade of the
+    /// same host and port, so an HSTS hop still counts.
     pub fn has_bridge(&self, url: &Url) -> bool {
         let bridges = self.bridges.borrow();
-        bridges.hellos == 0 || bridges.latest.contains_key(&origin_key(url))
+        if bridges.hellos == 0 {
+            return true;
+        }
+        origin_keys(url)
+            .iter()
+            .any(|key| bridges.latest.contains_key(key))
     }
 
     /// Origins whose bridge said hello, sorted.
@@ -105,11 +142,16 @@ impl EvalEngine {
 
     /// Wait for a hello from the origin of `url` newer than hello number `since`.
     ///
-    /// Returns `false` when none arrives within `limit`.
+    /// Returns `false` when none arrives within `limit`. An `http` destination
+    /// also succeeds when the hello comes from the `https` upgrade of the
+    /// same host and port.
     pub async fn wait_bridge(&self, url: &Url, since: u64, limit: Duration) -> bool {
-        let key = origin_key(url);
+        let keys = origin_keys(url);
         let mut rx = self.bridges.subscribe();
-        let hello = rx.wait_for(|b| b.latest.get(&key).is_some_and(|&n| n > since));
+        let hello = rx.wait_for(move |b| {
+            keys.iter()
+                .any(|key| b.latest.get(key).is_some_and(|&n| n > since))
+        });
         tokio::time::timeout(limit, hello)
             .await
             .is_ok_and(|seen| seen.is_ok())
@@ -347,6 +389,42 @@ mod tests {
         assert_eq!(
             engine.bridge_origins(),
             ["http://127.0.0.1:8080", "tauri://localhost"]
+        );
+    }
+
+    #[test]
+    fn test_origin_key_normalizes_default_ports_and_opaque_urls() {
+        let engine = EvalEngine::new();
+        let url = |text| Url::parse(text).expect("valid test URL");
+        engine.bridge_hello("https://example.com/");
+        assert!(engine.has_bridge(&url("https://example.com:443/login")));
+        assert!(
+            engine.has_bridge(&url("http://example.com/")),
+            "http dest must match an https hello (HSTS)"
+        );
+        assert!(!engine.has_bridge(&url("https://other.example/")));
+
+        engine.bridge_hello("file:///tmp/a.html");
+        assert!(engine.has_bridge(&url("file:///tmp/a.html")));
+        assert!(
+            !engine.has_bridge(&url("file:///tmp/b.html")),
+            "hostless pages must not share a key"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_wait_bridge_ignores_hello_from_another_origin() {
+        let engine = EvalEngine::new();
+        let app = Url::parse("tauri://localhost/").expect("valid test URL");
+        let foreign = Url::parse("https://example.com/").expect("valid test URL");
+        engine.bridge_hello(app.as_str());
+        let since = engine.hellos();
+        engine.bridge_hello(app.as_str());
+        assert!(
+            !engine
+                .wait_bridge(&foreign, since, Duration::from_secs(1))
+                .await,
+            "a later hello from the app origin must not count for a foreign dest"
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,5 +1,5 @@
 use crate::diff;
-use crate::eval::{EvalEngine, HELLO_ID, origin_key};
+use crate::eval::{EvalEngine, EvalError, HELLO_ID, origin_key};
 #[cfg(feature = "press")]
 use crate::key;
 use crate::protocol::RpcError;
@@ -614,9 +614,18 @@ async fn handle_navigate(
         }
         (Some(page), Some(dest)) => {
             if engine.has_bridge(page) {
-                let result = wait(engine, id, rx, DEFAULT_TIMEOUT).await?;
-                if engine.has_bridge(dest) {
-                    return Ok(result);
+                // The departing page may be torn down before `__callback` runs.
+                // Treat that timeout as non-fatal and let the dest hello decide.
+                match engine.wait(id, rx, BRIDGE_GRACE).await {
+                    Ok(result) if engine.has_bridge(dest) => return Ok(result),
+                    Ok(_) | Err(EvalError::Timeout(_)) => {}
+                    Err(e) => {
+                        return Err(RpcError {
+                            code: -32603,
+                            message: format!("Eval error: {e}"),
+                            data: None,
+                        });
+                    }
                 }
             } else {
                 // The script still navigates, but this page cannot call back.
@@ -800,12 +809,18 @@ pub(crate) fn handle_callback(
     page: Option<&tauri::Url>,
 ) {
     if id == HELLO_ID {
-        // The invoking webview's URL is the origin that was allowed to call
-        // `__callback`. The IPC `result` is client-supplied and is ignored.
-        if let Some(page) = page {
-            engine.bridge_hello(page.as_str());
-        } else {
-            tracing::warn!("bridge hello without a webview URL");
+        // Record the invoking webview's URL, not the client payload. If the
+        // payload parses as a different origin, the webview likely navigated
+        // before this IPC landed; drop the hello rather than tagging dest.
+        let client = result
+            .as_deref()
+            .and_then(|href| tauri::Url::parse(href).ok());
+        match (page, client.as_ref()) {
+            (Some(webview), Some(client)) if origin_key(webview) != origin_key(client) => {
+                tracing::warn!("bridge hello origin mismatch, ignoring");
+            }
+            (Some(webview), _) => engine.bridge_hello(webview.as_str()),
+            (None, _) => tracing::warn!("bridge hello without a webview URL"),
         }
         return;
     }
@@ -2165,7 +2180,7 @@ mod tests {
 
     #[test]
     fn test_hello_uses_webview_url_not_client_payload() {
-        let engine = EvalEngine::new();
+        let engine = engine_with_app_bridge();
         handle_callback(
             &engine,
             HELLO_ID,
@@ -2177,6 +2192,58 @@ mod tests {
         assert!(
             !engine.has_bridge(&url("https://evil.example/")),
             "client-supplied href must not be recorded as a hello"
+        );
+    }
+
+    #[test]
+    fn test_hello_dropped_when_webview_url_does_not_match_payload() {
+        let engine = engine_with_app_bridge();
+        handle_callback(
+            &engine,
+            HELLO_ID,
+            Some(APP_PAGE.to_owned()),
+            None,
+            Some(&url(FOREIGN_PAGE)),
+        );
+        assert!(engine.has_bridge(&url(APP_PAGE)));
+        assert!(
+            !engine.has_bridge(&url(FOREIGN_PAGE)),
+            "a stale hello must not tag the page the webview already left"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_succeeds_when_page_callback_times_out_but_dest_hellos() {
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let dest = "https://allowed.example/";
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                let engine = engine_clone.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
+                });
+                Ok(Some(url(APP_PAGE)))
+            });
+
+        let start = tokio::time::Instant::now();
+        let result = dispatch(
+            "navigate",
+            Some(&json!({"url": dest})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("dest hello must still succeed if the old page never callbacks");
+        assert_eq!(result, json!({"ok": true}));
+        assert!(
+            start.elapsed() < DEFAULT_TIMEOUT,
+            "took {:?}",
+            start.elapsed()
         );
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,5 +1,5 @@
 use crate::diff;
-use crate::eval::{EvalEngine, HELLO_ID};
+use crate::eval::{EvalEngine, HELLO_ID, origin_key};
 #[cfg(feature = "press")]
 use crate::key;
 use crate::protocol::RpcError;
@@ -599,32 +599,71 @@ async fn handle_navigate(
     })?;
     let since = engine.hellos();
     let (id, rx, page) = send_script(&script, engine, eval_fn, window)?;
-    let dest = page
-        .as_ref()
-        .zip(params.and_then(|p| p.get("url")?.as_str()))
-        .and_then(|(page, url)| page.join(url).ok())
-        // A `javascript:` URL runs in the current page instead of leaving it.
-        .filter(|dest| dest.scheme() != "javascript");
-    let (Some(page), Some(dest)) = (page, dest) else {
-        return wait(engine, id, rx, DEFAULT_TIMEOUT).await;
-    };
+    let dest = navigate_destination(
+        page.as_ref(),
+        params.and_then(|p| p.get("url").and_then(serde_json::Value::as_str)),
+    );
 
-    if engine.has_bridge(&page) {
-        let result = wait(engine, id, rx, DEFAULT_TIMEOUT).await?;
-        if engine.has_bridge(&dest) {
-            return Ok(result);
+    match (page.as_ref(), dest.as_ref()) {
+        (Some(page), Some(dest)) if origin_key(page) == origin_key(dest) => {
+            if engine.has_bridge(page) {
+                wait(engine, id, rx, DEFAULT_TIMEOUT).await
+            } else {
+                Err(fail_no_bridge(engine, id, page))
+            }
         }
-    } else {
-        // The script still navigates, but this page cannot call back.
-        engine.resolve(id, Err("page has no pilot bridge".to_owned()));
+        (Some(page), Some(dest)) => {
+            if engine.has_bridge(page) {
+                let result = wait(engine, id, rx, DEFAULT_TIMEOUT).await?;
+                if engine.has_bridge(dest) {
+                    return Ok(result);
+                }
+            } else {
+                // The script still navigates, but this page cannot call back.
+                engine.resolve(id, Err("page has no pilot bridge".to_owned()));
+            }
+            wait_dest_bridge(engine, dest, since).await
+        }
+        (Some(page), None) => {
+            if engine.has_bridge(page) {
+                wait(engine, id, rx, DEFAULT_TIMEOUT).await
+            } else {
+                Err(fail_no_bridge(engine, id, page))
+            }
+        }
+        (None, Some(dest)) => {
+            engine.resolve(id, Err("waiting for destination bridge".to_owned()));
+            wait_dest_bridge(engine, dest, since).await
+        }
+        (None, None) => wait(engine, id, rx, DEFAULT_TIMEOUT).await,
     }
+}
 
-    let limit = if engine.has_bridge(&dest) {
+/// Resolve `navigate`'s `url` param against the current page when needed.
+///
+/// Absolute URLs do not need a base, so they survive a missing page URL.
+/// A `javascript:` URL runs in the current document, so dest is that page.
+fn navigate_destination(page: Option<&tauri::Url>, raw: Option<&str>) -> Option<tauri::Url> {
+    let raw = raw?;
+    match tauri::Url::parse(raw) {
+        Ok(absolute) if absolute.scheme() == "javascript" => page.cloned(),
+        Ok(absolute) => Some(absolute),
+        Err(_) => page.and_then(|base| base.join(raw).ok()),
+    }
+}
+
+/// Wait for a hello from `dest`, using the 3s grace on a first visit.
+async fn wait_dest_bridge(
+    engine: &EvalEngine,
+    dest: &tauri::Url,
+    since: u64,
+) -> Result<serde_json::Value, RpcError> {
+    let limit = if engine.has_bridge(dest) {
         DEFAULT_TIMEOUT
     } else {
         BRIDGE_GRACE
     };
-    if engine.wait_bridge(&dest, since, limit).await {
+    if engine.wait_bridge(dest, since, limit).await {
         Ok(serde_json::json!({"ok": true}))
     } else {
         Err(no_bridge_error(
@@ -632,6 +671,14 @@ async fn handle_navigate(
             &format!("navigated to {dest}, but no pilot bridge answered there within {limit:?}"),
         ))
     }
+}
+
+fn fail_no_bridge(engine: &EvalEngine, id: u64, page: &tauri::Url) -> RpcError {
+    engine.resolve(id, Err("page has no pilot bridge".to_owned()));
+    no_bridge_error(
+        engine,
+        &format!("no pilot bridge on the current page ({page})"),
+    )
 }
 
 /// Send a bridge script and wait for its callback.
@@ -750,10 +797,15 @@ pub(crate) fn handle_callback(
     id: u64,
     result: Option<String>,
     error: Option<String>,
+    page: Option<&tauri::Url>,
 ) {
     if id == HELLO_ID {
-        if let Some(page) = result {
-            engine.bridge_hello(&page);
+        // The invoking webview's URL is the origin that was allowed to call
+        // `__callback`. The IPC `result` is client-supplied and is ignored.
+        if let Some(page) = page {
+            engine.bridge_hello(page.as_str());
+        } else {
+            tracing::warn!("bridge hello without a webview URL");
         }
         return;
     }
@@ -776,13 +828,20 @@ pub(crate) fn handle_callback(
     clippy::needless_pass_by_value,
     reason = "tauri::command contract — macro wrapper is the real consumer"
 )]
-pub(crate) fn callback(
+pub(crate) fn callback<R: tauri::Runtime>(
     eval_engine: tauri::State<'_, EvalEngine>,
+    webview: tauri::WebviewWindow<R>,
     id: u64,
     result: Option<String>,
     error: Option<String>,
 ) {
-    handle_callback(&eval_engine, id, result, error);
+    handle_callback(
+        &eval_engine,
+        id,
+        result,
+        error,
+        crate::current_url(&webview).as_ref(),
+    );
 }
 
 /// Legacy Tauri IPC command for the `__callback` handler.
@@ -797,13 +856,20 @@ pub(crate) fn callback(
     clippy::needless_pass_by_value,
     reason = "tauri::command contract — macro wrapper is the real consumer"
 )]
-pub(crate) fn __callback(
+pub(crate) fn __callback<R: tauri::Runtime>(
     eval_engine: tauri::State<'_, EvalEngine>,
+    webview: tauri::WebviewWindow<R>,
     id: u64,
     result: Option<String>,
     error: Option<String>,
 ) {
-    handle_callback(&eval_engine, id, result, error);
+    handle_callback(
+        &eval_engine,
+        id,
+        result,
+        error,
+        crate::current_url(&webview).as_ref(),
+    );
 }
 
 #[cfg(test)]
@@ -987,7 +1053,13 @@ mod tests {
     async fn test_callback_with_json_result() {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
-        handle_callback(&engine, id, Some(r#"{"title":"hello"}"#.to_owned()), None);
+        handle_callback(
+            &engine,
+            id,
+            Some(r#"{"title":"hello"}"#.to_owned()),
+            None,
+            None,
+        );
         let val = rx.await.expect("channel not dropped").expect("eval ok");
         assert_eq!(val, json!({"title": "hello"}));
     }
@@ -999,7 +1071,7 @@ mod tests {
         // Value::Null so the client sees a clean success, not a warn fallback.
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
-        handle_callback(&engine, id, Some("null".to_owned()), None);
+        handle_callback(&engine, id, Some("null".to_owned()), None, None);
         let val = rx.await.expect("channel not dropped").expect("eval ok");
         assert_eq!(val, serde_json::Value::Null);
     }
@@ -1008,7 +1080,7 @@ mod tests {
     async fn test_callback_with_error() {
         let engine = EvalEngine::new();
         let (id, rx) = engine.register();
-        handle_callback(&engine, id, None, Some("TypeError: x".to_owned()));
+        handle_callback(&engine, id, None, Some("TypeError: x".to_owned()), None);
         let result = rx.await.expect("channel not dropped");
         assert_eq!(result, Err("TypeError: x".to_owned()));
     }
@@ -1892,7 +1964,7 @@ mod tests {
     /// when the app page loads.
     fn engine_with_app_bridge() -> EvalEngine {
         let engine = EvalEngine::new();
-        handle_callback(&engine, 0, Some(APP_PAGE.to_owned()), None);
+        handle_callback(&engine, HELLO_ID, None, None, Some(&url(APP_PAGE)));
         engine
     }
 
@@ -1922,6 +1994,11 @@ mod tests {
         .await
         .expect_err("navigate to a foreign origin must not report ok");
 
+        assert!(
+            start.elapsed() >= BRIDGE_GRACE,
+            "must wait the 3s grace, took {:?}",
+            start.elapsed()
+        );
         assert!(
             start.elapsed() < DEFAULT_TIMEOUT,
             "took {:?}",
@@ -1977,7 +2054,7 @@ mod tests {
                 let engine = engine_clone.clone();
                 tokio::spawn(async move {
                     tokio::time::sleep(Duration::from_millis(500)).await;
-                    handle_callback(&engine, 0, Some(APP_PAGE.to_owned()), None);
+                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(APP_PAGE)));
                 });
                 Ok(Some(url(FOREIGN_PAGE)))
             });
@@ -2018,5 +2095,88 @@ mod tests {
         .await
         .expect("same-origin navigate succeeds");
         assert_eq!(result, json!({"ok": true}));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_to_new_origin_succeeds_when_hello_arrives() {
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let dest = "https://allowed.example/";
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                let engine = engine_clone.clone();
+                engine.resolve(1, Ok(json!({"ok": true})));
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    handle_callback(&engine, HELLO_ID, None, None, Some(&url(dest)));
+                });
+                Ok(Some(url(APP_PAGE)))
+            });
+
+        let start = tokio::time::Instant::now();
+        let result = dispatch(
+            "navigate",
+            Some(&json!({"url": dest})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("first visit must succeed when the dest hellos in time");
+        assert_eq!(result, json!({"ok": true}));
+        assert!(
+            start.elapsed() < DEFAULT_TIMEOUT,
+            "took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_javascript_url_stays_on_page() {
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                engine_clone.resolve(1, Ok(json!({"ok": true})));
+                Ok(Some(url(APP_PAGE)))
+            });
+
+        let start = tokio::time::Instant::now();
+        let result = dispatch(
+            "navigate",
+            Some(&json!({"url": "javascript:void(0)"})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("javascript: navigate stays on the current page");
+        assert_eq!(result, json!({"ok": true}));
+        assert!(
+            start.elapsed() < BRIDGE_GRACE,
+            "must not wait the dest grace, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn test_hello_uses_webview_url_not_client_payload() {
+        let engine = EvalEngine::new();
+        handle_callback(
+            &engine,
+            HELLO_ID,
+            Some("https://evil.example/".to_owned()),
+            None,
+            Some(&url(APP_PAGE)),
+        );
+        assert!(engine.has_bridge(&url(APP_PAGE)));
+        assert!(
+            !engine.has_bridge(&url("https://evil.example/")),
+            "client-supplied href must not be recorded as a hello"
+        );
     }
 }

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1,5 +1,5 @@
 use crate::diff;
-use crate::eval::EvalEngine;
+use crate::eval::{EvalEngine, HELLO_ID};
 #[cfg(feature = "press")]
 use crate::key;
 use crate::protocol::RpcError;
@@ -220,10 +220,11 @@ pub(crate) async fn dispatch(
             data: None,
         }),
         "click" | "fill" | "type" | "select" | "check" | "scroll" | "drop" | "text" | "html"
-        | "value" | "attrs" | "eval" | "ipc" | "navigate" | "url" | "title" | "visible"
-        | "count" | "checked" => {
+        | "value" | "attrs" | "eval" | "ipc" | "url" | "title" | "visible" | "count"
+        | "checked" => {
             handle_eval_method(method, params, engine, eval_fn, win, DEFAULT_TIMEOUT).await
         }
+        "navigate" => handle_navigate(params, engine, eval_fn, win).await,
         // `drag` spends `steps × stepDelayMs + settleMs` in JS timers before it
         // resolves, so the channel timeout has to cover the gesture the caller
         // asked for.
@@ -398,26 +399,7 @@ async fn handle_diff(
             message: msg,
             data: None,
         })?;
-    let (id, rx) = engine.register();
-    let wrapped = EvalEngine::wrap_script(id, &script);
-
-    if let Err(e) = eval_fn(window, wrapped) {
-        engine.resolve(id, Err(format!("Eval failed: {e}")));
-        return Err(RpcError {
-            code: -32603,
-            message: format!("Eval failed: {e}"),
-            data: None,
-        });
-    }
-
-    let result = engine
-        .wait(id, rx, DEFAULT_TIMEOUT)
-        .await
-        .map_err(|e| RpcError {
-            code: -32603,
-            message: format!("Eval error: {e}"),
-            data: None,
-        })?;
+    let result = eval_bridge(&script, engine, eval_fn, window, DEFAULT_TIMEOUT).await?;
 
     // Parse both snapshots: extract "elements" arrays
     let old_elements: Vec<diff::SnapshotElement> = reference
@@ -580,24 +562,158 @@ async fn handle_eval_method(
         message: msg,
         data: None,
     })?;
-    let (id, rx) = engine.register();
-    let wrapped = EvalEngine::wrap_script(id, &script);
+    eval_bridge(&script, engine, eval_fn, window, timeout).await
+}
 
-    if let Err(e) = eval_fn(window, wrapped) {
-        // Clean up pending entry on eval_fn failure
-        engine.resolve(id, Err(format!("Eval failed: {e}")));
-        return Err(RpcError {
-            code: -32603,
-            message: format!("Eval failed: {e}"),
-            data: None,
-        });
+/// How long `navigate` waits for a hello from an origin whose bridge never
+/// said hello before (#153).
+///
+/// A foreign origin can only call back when a capability lists it in
+/// `remote.urls`, and a denied call sends no signal, so silence past this
+/// delay is the verdict. Long enough for a local page to load and run the
+/// init script. A slow remote page that misses it still answers the next
+/// commands once its hello lands.
+const BRIDGE_GRACE: Duration = Duration::from_secs(3);
+
+/// Handle `navigate`, which reports ok only once a bridge can answer on the
+/// destination (#153).
+///
+/// The bridge answers before the webview leaves the page, so the callback
+/// alone proves nothing about the destination. When the destination origin
+/// has no known bridge, the hello of the new page is the proof.
+async fn handle_navigate(
+    params: Option<&serde_json::Value>,
+    engine: &EvalEngine,
+    eval_fn: Option<&EvalFn>,
+    window: Option<&str>,
+) -> Result<serde_json::Value, RpcError> {
+    let eval_fn = eval_fn.ok_or_else(|| RpcError {
+        code: -32603,
+        message: "No webview available for eval".to_owned(),
+        data: None,
+    })?;
+    let script = build_bridge_call("navigate", params).map_err(|msg| RpcError {
+        code: -32602,
+        message: msg,
+        data: None,
+    })?;
+    let since = engine.hellos();
+    let (id, rx, page) = send_script(&script, engine, eval_fn, window)?;
+    let dest = page
+        .as_ref()
+        .zip(params.and_then(|p| p.get("url")?.as_str()))
+        .and_then(|(page, url)| page.join(url).ok())
+        // A `javascript:` URL runs in the current page instead of leaving it.
+        .filter(|dest| dest.scheme() != "javascript");
+    let (Some(page), Some(dest)) = (page, dest) else {
+        return wait(engine, id, rx, DEFAULT_TIMEOUT).await;
+    };
+
+    if engine.has_bridge(&page) {
+        let result = wait(engine, id, rx, DEFAULT_TIMEOUT).await?;
+        if engine.has_bridge(&dest) {
+            return Ok(result);
+        }
+    } else {
+        // The script still navigates, but this page cannot call back.
+        engine.resolve(id, Err("page has no pilot bridge".to_owned()));
     }
 
+    let limit = if engine.has_bridge(&dest) {
+        DEFAULT_TIMEOUT
+    } else {
+        BRIDGE_GRACE
+    };
+    if engine.wait_bridge(&dest, since, limit).await {
+        Ok(serde_json::json!({"ok": true}))
+    } else {
+        Err(no_bridge_error(
+            engine,
+            &format!("navigated to {dest}, but no pilot bridge answered there within {limit:?}"),
+        ))
+    }
+}
+
+/// Send a bridge script and wait for its callback.
+///
+/// Fails at once when the page has no bridge that can call back, instead of
+/// waiting out `timeout` (#153). The script has already run on that page.
+async fn eval_bridge(
+    script: &str,
+    engine: &EvalEngine,
+    eval_fn: &EvalFn,
+    window: Option<&str>,
+    timeout: Duration,
+) -> Result<serde_json::Value, RpcError> {
+    let (id, rx, page) = send_script(script, engine, eval_fn, window)?;
+    if let Some(page) = page.filter(|page| !engine.has_bridge(page)) {
+        engine.resolve(id, Err("page has no pilot bridge".to_owned()));
+        return Err(no_bridge_error(
+            engine,
+            &format!("no pilot bridge on the current page ({page})"),
+        ));
+    }
+    wait(engine, id, rx, timeout).await
+}
+
+/// Register a callback, then eval `script` wrapped in the ADR-001 pattern.
+///
+/// Returns the callback id and receiver, plus the page URL from `eval_fn`.
+fn send_script(
+    script: &str,
+    engine: &EvalEngine,
+    eval_fn: &EvalFn,
+    window: Option<&str>,
+) -> Result<CallbackSlot, RpcError> {
+    let (id, rx) = engine.register();
+    let wrapped = EvalEngine::wrap_script(id, script);
+    match eval_fn(window, wrapped) {
+        Ok(page) => Ok((id, rx, page)),
+        Err(e) => {
+            // Clean up pending entry on eval_fn failure
+            engine.resolve(id, Err(format!("Eval failed: {e}")));
+            Err(RpcError {
+                code: -32603,
+                message: format!("Eval failed: {e}"),
+                data: None,
+            })
+        }
+    }
+}
+
+/// Callback id, its receiver, and the URL of the page the script was sent to.
+type CallbackSlot = (
+    u64,
+    tokio::sync::oneshot::Receiver<Result<serde_json::Value, String>>,
+    Option<tauri::Url>,
+);
+
+/// Wait for the callback of eval `id`.
+async fn wait(
+    engine: &EvalEngine,
+    id: u64,
+    rx: tokio::sync::oneshot::Receiver<Result<serde_json::Value, String>>,
+    timeout: Duration,
+) -> Result<serde_json::Value, RpcError> {
     engine.wait(id, rx, timeout).await.map_err(|e| RpcError {
         code: -32603,
         message: format!("Eval error: {e}"),
         data: None,
     })
+}
+
+/// Build the error for a page whose bridge cannot answer, naming the
+/// origins where it can.
+fn no_bridge_error(engine: &EvalEngine, what: &str) -> RpcError {
+    let origins = engine.bridge_origins().join(", ");
+    RpcError {
+        code: -32603,
+        message: format!(
+            "{what}. Bridge commands only work on {origins}: navigate back there, \
+             or allow this origin in a capability's remote.urls"
+        ),
+        data: None,
+    }
 }
 
 /// Build a `window.__PILOT__.<method>(params)` JS call string.
@@ -635,6 +751,12 @@ pub(crate) fn handle_callback(
     result: Option<String>,
     error: Option<String>,
 ) {
+    if id == HELLO_ID {
+        if let Some(page) = result {
+            engine.bridge_hello(&page);
+        }
+        return;
+    }
     if let Some(err) = error {
         engine.resolve(id, Err(err));
     } else if let Some(res) = result {
@@ -820,7 +942,7 @@ mod tests {
         // Actually the reference check happens BEFORE the eval call, so we can check:
         // eval_fn present + no reference in params + no last_snapshot → -32602
         let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
         let result = dispatch(
             "diff",
             None,
@@ -1262,7 +1384,7 @@ mod tests {
                 // Resolve the callback immediately to avoid blocking for the default 10s timeout.
                 // ID 1 is the first registered callback on a fresh EvalEngine.
                 engine_clone.resolve(1, Ok(serde_json::json!({"ok": true})));
-                Ok(())
+                Ok(None)
             });
         let params = serde_json::json!({"ref": "el-1", "window": "settings"});
         let _ = dispatch(
@@ -1602,7 +1724,7 @@ mod tests {
         // eval_fn that accepts the script but never resolves the callback —
         // the timeout decides who wins.
         let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
 
         let params = json!({
             "selector": "[data-testid=\"never-exists\"]",
@@ -1646,7 +1768,7 @@ mod tests {
         // bridge gets to surface its own `Timeout waiting for …` rejection.
         let engine = EvalEngine::new();
         let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
 
         let start = tokio::time::Instant::now();
         let _err = dispatch(
@@ -1674,7 +1796,7 @@ mod tests {
         // existing `watch` behavior must remain intact.
         let engine = EvalEngine::new();
         let eval_fn: crate::server::EvalFn =
-            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(()));
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(None));
 
         let start = tokio::time::Instant::now();
         let _err = dispatch(
@@ -1708,7 +1830,7 @@ mod tests {
                 // The first registered callback on a fresh engine has id == 1
                 // (see EvalEngine::register / next_id init in eval.rs).
                 engine_clone.resolve(1, Ok(json!({"found": true})));
-                Ok(())
+                Ok(None)
             });
 
         let result = dispatch(
@@ -1739,7 +1861,7 @@ mod tests {
                     1,
                     Ok(json!({"url": "http://localhost/", "title": "App", "ready": true})),
                 );
-                Ok(())
+                Ok(None)
             });
 
         let result = dispatch(
@@ -1757,5 +1879,144 @@ mod tests {
         assert_eq!(result["url"], json!("http://localhost/"));
         assert_eq!(result["ready"], json!(true));
         assert_eq!(result["plugin_version"], json!(env!("CARGO_PKG_VERSION")));
+    }
+
+    const APP_PAGE: &str = "tauri://localhost/";
+    const FOREIGN_PAGE: &str = "https://example.com/";
+
+    fn url(text: &str) -> tauri::Url {
+        tauri::Url::parse(text).expect("valid test URL")
+    }
+
+    /// Engine whose bridge already said hello from the app origin, as it does
+    /// when the app page loads.
+    fn engine_with_app_bridge() -> EvalEngine {
+        let engine = EvalEngine::new();
+        handle_callback(&engine, 0, Some(APP_PAGE.to_owned()), None);
+        engine
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_to_foreign_origin_does_not_report_ok() {
+        // #153: the bridge on the app page answers `{ok: true}` before the
+        // webview leaves for an origin whose bridge cannot call back, so
+        // navigate used to report success and leave the session broken.
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                engine_clone.resolve(1, Ok(json!({"ok": true})));
+                Ok(Some(url(APP_PAGE)))
+            });
+
+        let start = tokio::time::Instant::now();
+        let err = dispatch(
+            "navigate",
+            Some(&json!({"url": FOREIGN_PAGE})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("navigate to a foreign origin must not report ok");
+
+        assert!(
+            start.elapsed() < DEFAULT_TIMEOUT,
+            "took {:?}",
+            start.elapsed()
+        );
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains(FOREIGN_PAGE), "got: {}", err.message);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_on_page_without_bridge_fails_fast_naming_origins() {
+        // #153: every bridge command used to hang for DEFAULT_TIMEOUT once the
+        // webview sat on a foreign origin.
+        let engine = engine_with_app_bridge();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(|_w: Option<&str>, _script: String| Ok(Some(url(FOREIGN_PAGE))));
+
+        let start = tokio::time::Instant::now();
+        let err = dispatch(
+            "title",
+            None,
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("a page without a bridge cannot answer");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "took {:?}",
+            start.elapsed()
+        );
+        assert_eq!(err.code, -32603);
+        assert!(err.message.contains(FOREIGN_PAGE), "got: {}", err.message);
+        assert!(
+            err.message.contains("tauri://localhost"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_back_to_app_origin_waits_for_bridge_hello() {
+        // #153: the way out of a foreign page is navigating back. The foreign
+        // page cannot call back, so success is the app bridge's hello.
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                let engine = engine_clone.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    handle_callback(&engine, 0, Some(APP_PAGE.to_owned()), None);
+                });
+                Ok(Some(url(FOREIGN_PAGE)))
+            });
+
+        let result = dispatch(
+            "navigate",
+            Some(&json!({"url": APP_PAGE})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("navigate back to the app origin must succeed");
+        assert_eq!(result, json!({"ok": true}));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dispatch_navigate_within_app_origin_returns_bridge_result() {
+        let engine = engine_with_app_bridge();
+        let engine_clone = engine.clone();
+        let eval_fn: crate::server::EvalFn =
+            std::sync::Arc::new(move |_w: Option<&str>, _script: String| {
+                engine_clone.resolve(1, Ok(json!({"ok": true})));
+                Ok(Some(url(APP_PAGE)))
+            });
+
+        let result = dispatch(
+            "navigate",
+            Some(&json!({"url": "/settings"})),
+            &engine,
+            Some(&eval_fn),
+            None,
+            None,
+            &Recorder::new(),
+        )
+        .await
+        .expect("same-origin navigate succeeds");
+        assert_eq!(result, json!({"ok": true}));
     }
 }

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -177,11 +177,22 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
                 .cloned()
                 .ok_or_else(|| "No webview available".to_owned())?
         };
+        // Read before the eval so the URL names the page the script lands on.
+        let page = current_url(&target);
         // Results come back via the `__callback` IPC command (see
         // EvalEngine::wrap_script). This eval is fire-and-forget; the IPC handler
         // resolves the pending request, not this closure.
-        target.eval(&script).map_err(|e| e.to_string())
+        target.eval(&script).map_err(|e| e.to_string())?;
+        Ok(page)
     })
+}
+
+/// Read the current URL of a webview, or `None` when the runtime cannot report it.
+#[cfg(all(any(unix, windows), debug_assertions))]
+fn current_url<R: tauri::Runtime>(wv: &tauri::WebviewWindow<R>) -> Option<tauri::Url> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wv.url()))
+        .ok()
+        .and_then(Result::ok)
 }
 
 /// Create a focus function that requests OS focus for a webview window.
@@ -224,11 +235,7 @@ fn make_list_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> ListWindowsFn {
             .map(|(label, wv)| {
                 serde_json::json!({
                     "label": label,
-                    "url": std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wv.url()))
-                        .ok()
-                        .and_then(Result::ok)
-                        .map(|url| url.to_string())
-                        .unwrap_or_default(),
+                    "url": current_url(wv).map(|url| url.to_string()).unwrap_or_default(),
                     "title": wv.title().unwrap_or_default(),
                 })
             })
@@ -258,6 +265,20 @@ mod tests {
         assert!(
             html_idx < pilot_idx,
             "html-to-image must be injected before pilot bridge code"
+        );
+    }
+
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
+    fn bridge_says_hello_with_reserved_callback_id() {
+        // #153: the plugin learns which origins can call back from this hello.
+        let hello = format!(
+            r#"invoke("plugin:pilot|__callback", {{ id: {}, result: location.href }})"#,
+            crate::eval::HELLO_ID
+        );
+        assert!(
+            super::BRIDGE_JS.contains(&hello),
+            "bridge must send its hello as `{hello}`"
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -188,8 +188,8 @@ fn make_eval_fn<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> EvalFn {
 }
 
 /// Read the current URL of a webview, or `None` when the runtime cannot report it.
-#[cfg(all(any(unix, windows), debug_assertions))]
-fn current_url<R: tauri::Runtime>(wv: &tauri::WebviewWindow<R>) -> Option<tauri::Url> {
+#[cfg(any(unix, windows))]
+pub(crate) fn current_url<R: tauri::Runtime>(wv: &tauri::WebviewWindow<R>) -> Option<tauri::Url> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wv.url()))
         .ok()
         .and_then(Result::ok)

--- a/crates/tauri-plugin-pilot/src/server/mod.rs
+++ b/crates/tauri-plugin-pilot/src/server/mod.rs
@@ -9,7 +9,10 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 /// A function that evaluates JS in the webview.
 /// The first argument is an optional window label (`None` means "use default window").
-pub(crate) type EvalFn = Arc<dyn Fn(Option<&str>, String) -> Result<(), String> + Send + Sync>;
+/// Returns the URL of the page the script was sent to, or `None` when the
+/// webview cannot report it.
+pub(crate) type EvalFn =
+    Arc<dyn Fn(Option<&str>, String) -> Result<Option<tauri::Url>, String> + Send + Sync>;
 
 /// A function that lists all available webview windows and returns their metadata.
 pub(crate) type ListWindowsFn = Arc<dyn Fn() -> serde_json::Value + Send + Sync>;

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -45,11 +45,14 @@ Add `pilot:default` to your app's capability file (e.g. `src-tauri/capabilities/
 
 ```json
 {
+  "remote": {
+    "urls": ["https://allowed.example/*"]
+  },
   "permissions": ["core:default", "pilot:default"]
 }
 ```
 
-Without this permission, eval commands fail with: `eval timed out after 10s`.
+Without this permission, eval commands fail with: `eval timed out after 10s`. List a foreign origin in `remote.urls` on the same capability if you need to drive that origin.
 
 ### 4. Install the CLI
 

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -109,6 +109,8 @@ The bridge is injected into every page, but Tauri's ACL lets `__callback` throug
 
 The eval function returns the URL of the page it sent the script to. When that page's origin never said hello, the command fails at once instead of waiting 10 seconds, and the error names the origins that did. `navigate` goes one step further. The old page answers before the webview leaves it, so for a destination origin with no hello yet, `navigate` waits up to 3 seconds for a hello from the new page and fails without one. Until the first hello arrives, the plugin cannot tell origins apart and every command takes the plain path.
 
+Hellos are tracked per origin, not per window. A slow page allowed by `remote.urls` can miss the 3-second grace on its first visit; later commands succeed once its hello arrives. The plugin records the invoking webview's URL, not the hello payload.
+
 ## JS Bridge Structure
 
 The JS bridge is compiled into the plugin binary via `include_str!("../js/bridge.js")` and injected into every WebView at boot through `js_init_script()`. It is available before any frontend framework code runs.

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -103,6 +103,12 @@ The eval function dynamically resolves the target window on each call — it cap
 
 This makes every eval effectively async and type-safe from the Rust side.
 
+### Origins without a callback
+
+The bridge is injected into every page, but Tauri's ACL lets `__callback` through only from origins that hold the pilot permission: the app origin, plus any origin a capability lists in `remote.urls`. On any other origin the script runs and its result is dropped, and a denied call sends the plugin no signal. To find out which origins can answer, the bridge sends a hello on each page load: `__callback` with id `0`, which no eval request uses, and its `location.href` as the result. The `EvalEngine` records the origin (scheme, host and port) of each hello.
+
+The eval function returns the URL of the page it sent the script to. When that page's origin never said hello, the command fails at once instead of waiting 10 seconds, and the error names the origins that did. `navigate` goes one step further. The old page answers before the webview leaves it, so for a destination origin with no hello yet, `navigate` waits up to 3 seconds for a hello from the new page and fails without one. Until the first hello arrives, the plugin cannot tell origins apart and every command takes the plain path.
+
 ## JS Bridge Structure
 
 The JS bridge is compiled into the plugin binary via `include_str!("../js/bridge.js")` and injected into every WebView at boot through `js_init_script()`. It is available before any frontend framework code runs.

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -66,11 +66,14 @@ The plugin requires the `pilot:default` permission for its internal `__callback`
 
 ```json
 {
+  "remote": {
+    "urls": ["https://allowed.example/*"]
+  },
   "permissions": ["core:default", "pilot:default"]
 }
 ```
 
-Without this permission, eval commands will time out with "eval timed out after 10s".
+Without this permission, eval commands will time out with "eval timed out after 10s". List a foreign origin in `remote.urls` on the same capability if you need to drive that origin; otherwise commands there fail fast.
 
 ## 6. Verify the setup
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -915,10 +915,14 @@ tauri-pilot navigate "/"
 ```
 
 Bridge commands only work on origins allowed to call the plugin back: the app
-origin, plus any origin a capability lists in `remote.urls`. When the
-destination is another origin, `navigate` still loads it but fails after 3
-seconds, and later commands fail at once with an error that names the page.
-Run `tauri-pilot navigate` with an app URL to get the session back.
+origin, plus any origin listed in a capability's `remote.urls` that also
+grants `pilot:default`. `navigate` still loads any URL. If the destination
+origin has never said hello, it waits up to 3 seconds for one and fails
+without it. A slow page allowed by `remote.urls` can miss that window on
+its first visit; later commands succeed once the hello arrives. On an
+origin that cannot call back, later commands fail at once with an error
+that names the page and the origins that work. Run `tauri-pilot navigate`
+with an app URL to get the session back.
 
 ---
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -914,6 +914,12 @@ tauri-pilot navigate "http://localhost:1420/settings"
 tauri-pilot navigate "/"
 ```
 
+Bridge commands only work on origins allowed to call the plugin back: the app
+origin, plus any origin a capability lists in `remote.urls`. When the
+destination is another origin, `navigate` still loads it but fails after 3
+seconds, and later commands fail at once with an error that names the page.
+Run `tauri-pilot navigate` with an app URL to get the session back.
+
 ---
 
 ### `url`


### PR DESCRIPTION
Fixes #153.

## Summary

• Root cause: the bridge does run on a foreign origin, but Tauri's ACL rejects `plugin:pilot|__callback` there (`allow-eval-callbacks` only covers the app origin unless a capability lists the origin in `remote.urls`). A denied call sends nothing, so every eval waited out its 10 s timeout.
• The bridge sends a hello on each page load (`__callback`, reserved id 0, `location.href`). `EvalEngine` records the origins that said hello.
• A command on a page whose origin never said hello fails at once, and the error names the origins that can answer.
• `navigate` to an origin without a hello waits up to 3 s for one, then fails instead of reporting ok. Navigating back recovers.
• Pilot's own IPC no longer shows up in `network.getRequests`.

Known limits: hellos are tracked per origin, not per window, and a slow remote page allowed by `remote.urls` can miss the 3 s grace on its first visit.

#169 is stacked on this branch.

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #153 so pilot commands fail fast instead of timing out when the current page can't call back. The bridge now sends a hello on each page load, letting the plugin track which origins can answer; commands on an unknown origin fail immediately, and `navigate` to one waits 3s before failing. The error names working origins, and navigating back restores the session.

**Bug Fixes**
- Bridge sends a hello with reserved id 0 on each page load; the plugin records the invoking webview's origin by scheme, host, and port, dropping hellos whose payload disagrees.
- Origin matching shares default ports and treats an `http` destination as matching its `https` upgrade.
- Commands on a page without a bridge return an error immediately, naming the origins that can answer.
- `navigate` parses absolute URLs without a page base, treats `javascript:` as same-document, and waits up to 3s for a destination hello before failing; a departing page that never callbacks doesn't stop that wait.
- Pilot's own IPC no longer appears in `network.getRequests`.
- Known limit: hellos are tracked per origin, not per window, and a slow remote page allowed by `remote.urls` may miss the 3s grace on first visit.

<sup>Written for commit 709a70a771336786e8950ad7a94fcc9a43e5f3d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation now verifies destination bridge availability and recovers when returning to supported pages.
  * Added controlled access to remote origins through capability-based URL allowlists.
  * Pilot IPC requests are excluded from application network traffic reporting while matching application URLs remain recorded.

* **Bug Fixes**
  * Improved cross-origin navigation, origin matching, bridge detection, and page-specific error handling.
  * Navigation now applies appropriate wait times for new and previously recognized origins.

* **Documentation**
  * Documented remote-origin permissions, bridge handshakes, navigation timeouts, recovery behavior, and network request filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->