### PR TITLE
docs: document and verify iOS Simulator support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
           cargo check -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features
           cargo clippy -p tauri-plugin-pilot --target aarch64-linux-android --no-default-features -- -D warnings
 
+      - name: Check iOS plugin
+        if: runner.os == 'macOS'
+        run: |
+          rustup target add aarch64-apple-ios-sim
+          cargo check -p tauri-plugin-pilot --target aarch64-apple-ios-sim --no-default-features
+          cargo clippy -p tauri-plugin-pilot --target aarch64-apple-ios-sim --no-default-features -- -D warnings
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forwarded with `adb forward localfilesystem:... localabstract:...`. Connections
   require matching UID/GID pairs for the app, root or ADB shell. [#145]
 
+- iOS Simulator support. A Simulator shares the Mac's filesystem, so the usual
+  socket file is already reachable and the CLI needs no extra flags. Physical
+  devices are not supported yet.
+
 ### Changed
 
 - A bridge command on a page whose origin never said hello no longer runs its

--- a/README.md
+++ b/README.md
@@ -227,12 +227,15 @@ Use global flags before `mcp` to pin a specific app socket or window:
 
 - **Linux** (WebKitGTK), **macOS** (WebKit), or **Windows** (WebView2)
 - **Android** via [ADB from Linux or macOS](https://mpiton.github.io/tauri-pilot/guides/plugin-setup/#android-via-adb)
+- **iOS Simulator** [from a Mac](https://mpiton.github.io/tauri-pilot/guides/plugin-setup/#ios-simulator)
 - **Tauri v2** (v1 not supported)
 - **Rust 1.95.0+** (edition 2024)
 
 ## Known limitations
 
 - **Android from Windows hosts** — the Windows CLI uses named pipes and cannot connect through the Unix socket forwarding used by this Android setup.
+
+- **Physical iOS devices** — an app sandbox on a device hides its socket file from the Mac, so the CLI has no path to open. Simulator only for now.
 
 - **`press` and global shortcuts on X11** — synthetic key events from `press` (via `enigo`'s `XTestFakeKeyEvent` backend) frequently fail to trigger handlers registered with `tauri-plugin-global-shortcut`.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -7,6 +7,7 @@ description: Install tauri-pilot and start testing your Tauri v2 app interactive
 
 - Linux (WebKitGTK), macOS (WebKit), or Windows (WebView2)
 - Android via [ADB](/tauri-pilot/guides/plugin-setup/#android-via-adb)
+- iOS Simulator [from a Mac](/tauri-pilot/guides/plugin-setup/#ios-simulator)
 - Tauri v2 (v1 not supported)
 - Rust 1.95.0+ (edition 2024)
 

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -197,7 +197,7 @@ Before connecting:
   that restricts `platforms` must include `iOS`.
 
 Disabling the desktop `press` backend on iOS is recommended. Replace the shared
-plugin dependency — or the Android-only pair from the section above — with these
+plugin dependency — or the combined pair from the Android section above — with these
 target-specific entries, so desktop builds keep it enabled:
 
 ```toml

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -226,18 +226,21 @@ tauri-pilot snapshot
 ```
 
 Every Simulator running the same app resolves to the same default socket path,
-so isolate them when running more than one at a time:
+so isolate them when running more than one at a time. The app must already be
+installed on each Simulator (one `cargo tauri ios dev` run against it does
+that); relaunch it with a private socket directory:
 
 ```sh
 mkdir -m 700 /tmp/pilot-my-simulator
 SIMCTL_CHILD_XDG_RUNTIME_DIR=/tmp/pilot-my-simulator \
-  xcrun simctl launch SIMULATOR_UDID YOUR_BUNDLE_IDENTIFIER
+  xcrun simctl launch --terminate-running-process SIMULATOR_UDID YOUR_BUNDLE_IDENTIFIER
 tauri-pilot --socket /tmp/pilot-my-simulator/tauri-pilot-YOUR_BUNDLE_IDENTIFIER.sock ping
 ```
 
-Keep that directory short and owned by you with mode 0700. The long container
-paths a Simulator uses by default can exceed the length limit on Unix socket
-addresses.
+Keep that directory short, owned by you, and mode 0700 — the plugin ignores a
+non-private `XDG_RUNTIME_DIR` and falls back to `/tmp`, and a long path (for
+example, deep inside a Simulator's data container) can exceed the length limit
+on Unix socket addresses.
 
 Physical iOS devices are not supported yet: an app sandbox on a device hides
 its socket file from the Mac, so the CLI has no path to open.

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -127,10 +127,10 @@ Before connecting:
 Disabling the desktop `press` backend on Android is recommended. Replace the shared plugin dependency with target-specific entries so desktop builds keep it enabled:
 
 ```toml
-[target.'cfg(target_os = "android")'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", default-features = false }
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
 ```
 
@@ -189,7 +189,8 @@ file is already reachable from the CLI and no forwarding is needed.
 Before connecting:
 
 - Complete [Tauri's iOS prerequisites](https://v2.tauri.app/start/prerequisites/#ios),
-  including Xcode and the `aarch64-apple-ios-sim` Rust target.
+  including Xcode and the `aarch64-apple-ios-sim` Rust target
+  (`x86_64-apple-ios` on an Intel Mac).
 - Run `cargo tauri ios init` once for the app.
 - Register the plugin in the mobile `run()` entry point in `src-tauri/src/lib.rs`,
   with the debug guard and `pilot:default` permission shown above. A capability
@@ -199,16 +200,16 @@ Disabling the desktop `press` backend on iOS is recommended. Replace the shared
 plugin dependency with target-specific entries so desktop builds keep it enabled:
 
 ```toml
-[target.'cfg(target_os = "ios")'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", default-features = false }
 
-[target.'cfg(not(target_os = "ios"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
 ```
 
-Cargo unions features across dependency entries, so keep these mutually
-exclusive rather than adding `default-features = false` to an iOS entry that
-sits alongside a plain one.
+Cargo unions features across dependency entries, so use this single combined
+pair rather than one pair per platform: a plain `not(target_os = "ios")` entry
+would also match Android and re-enable `press` there.
 
 `press` needs an OS keyboard backend that iOS does not provide, and
 `screenshot_native` is macOS-only. Use `fill` or `type` for text input, and the

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -179,3 +179,64 @@ rm -f "$XDG_RUNTIME_DIR/tauri-pilot-{identifier}.sock"
 ```
 
 Use a private directory rather than a bare `/tmp` socket, since ADB creates the host socket with its own permissions.
+
+## iOS Simulator
+
+The computer running the CLI must be a Mac, since building for iOS requires
+Xcode. A Simulator shares the Mac's filesystem, so the plugin's usual socket
+file is already reachable from the CLI and no forwarding is needed.
+
+Before connecting:
+
+- Complete [Tauri's iOS prerequisites](https://v2.tauri.app/start/prerequisites/#ios),
+  including Xcode and the `aarch64-apple-ios-sim` Rust target.
+- Run `cargo tauri ios init` once for the app.
+- Register the plugin in the mobile `run()` entry point in `src-tauri/src/lib.rs`,
+  with the debug guard and `pilot:default` permission shown above. A capability
+  that restricts `platforms` must include `iOS`.
+
+Disabling the desktop `press` backend on iOS is recommended. Replace the shared
+plugin dependency with target-specific entries so desktop builds keep it enabled:
+
+```toml
+[target.'cfg(target_os = "ios")'.dependencies]
+tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", default-features = false }
+
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
+```
+
+Cargo unions features across dependency entries, so keep these mutually
+exclusive rather than adding `default-features = false` to an iOS entry that
+sits alongside a plain one.
+
+`press` needs an OS keyboard backend that iOS does not provide, and
+`screenshot_native` is macOS-only. Use `fill` or `type` for text input, and the
+regular `screenshot`, which captures the webview. Window operations are limited
+to the mobile app's single window.
+
+Start a debug build in a Simulator and use the CLI exactly as you would for a
+desktop app:
+
+```sh
+cargo tauri ios dev
+tauri-pilot ping
+tauri-pilot snapshot
+```
+
+Every Simulator running the same app resolves to the same default socket path,
+so isolate them when running more than one at a time:
+
+```sh
+mkdir -m 700 /tmp/pilot-my-simulator
+SIMCTL_CHILD_XDG_RUNTIME_DIR=/tmp/pilot-my-simulator \
+  xcrun simctl launch SIMULATOR_UDID YOUR_BUNDLE_IDENTIFIER
+tauri-pilot --socket /tmp/pilot-my-simulator/tauri-pilot-YOUR_BUNDLE_IDENTIFIER.sock ping
+```
+
+Keep that directory short and owned by you with mode 0700. The long container
+paths a Simulator uses by default can exceed the length limit on Unix socket
+addresses.
+
+Physical iOS devices are not supported yet: an app sandbox on a device hides
+its socket file from the Mac, so the CLI has no path to open.

--- a/docs/src/content/docs/guides/plugin-setup.md
+++ b/docs/src/content/docs/guides/plugin-setup.md
@@ -197,7 +197,8 @@ Before connecting:
   that restricts `platforms` must include `iOS`.
 
 Disabling the desktop `press` backend on iOS is recommended. Replace the shared
-plugin dependency with target-specific entries so desktop builds keep it enabled:
+plugin dependency — or the Android-only pair from the section above — with these
+target-specific entries, so desktop builds keep it enabled:
 
 ```toml
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
@@ -208,8 +209,9 @@ tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot" }
 ```
 
 Cargo unions features across dependency entries, so use this single combined
-pair rather than one pair per platform: a plain `not(target_os = "ios")` entry
-would also match Android and re-enable `press` there.
+pair rather than one pair per platform. A leftover `not(target_os = "android")`
+or a naive `not(target_os = "ios")` entry matches the other mobile OS and
+re-enables `press` there.
 
 `press` needs an OS keyboard backend that iOS does not provide, and
 `screenshot_native` is macOS-only. Use `fill` or `type` for text input, and the
@@ -225,10 +227,12 @@ tauri-pilot ping
 tauri-pilot snapshot
 ```
 
-Every Simulator running the same app resolves to the same default socket path,
-so isolate them when running more than one at a time. The app must already be
-installed on each Simulator (one `cargo tauri ios dev` run against it does
-that); relaunch it with a private socket directory:
+A desktop build and every Simulator running the same app all resolve to the
+same default socket path. Whichever starts first owns it; the others log a
+warning, start without a pilot server, and the CLI then drives that first
+instance instead. Quit the extra ones, or give a Simulator its own socket
+directory. The app must already be installed on it (one `cargo tauri ios dev`
+run against that Simulator does this):
 
 ```sh
 mkdir -m 700 /tmp/pilot-my-simulator

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -385,8 +385,8 @@ tauri-pilot type @e2 " additional text"
 
 Inject keyboard events at the OS level via [`enigo`](https://crates.io/crates/enigo).
 Events are `isTrusted=true` and reach DOM listeners and Tauri accelerators on
-supported desktop platforms. Android has no native `press` backend; use `fill`
-or `type` for text input.
+supported desktop platforms. Android and iOS have no native `press` backend;
+use `fill` or `type` for text input.
 
 :::caution[X11 global shortcuts]
 On X11, synthetic key events from `enigo`'s `XTestFakeKeyEvent` backend
@@ -868,7 +868,8 @@ current scroll position is not reflected in the image — what you get is the
 entire page from the top. Use `--selector` to capture a single element
 (works for elements below the fold too). For a pixel-exact capture of the
 native window, use `screenshot_native` — macOS only, it returns
-`PERMISSION_DENIED` on Linux and Windows.
+`PERMISSION_DENIED` on Linux, Windows, Android and iOS. A Simulator build is an
+iOS build even though the host is a Mac, so use `screenshot` there.
 
 The bridge also copies only an allowlist of painted CSS properties onto the
 clone it renders (a full computed-style copy wedges WebKit for minutes on


### PR DESCRIPTION
## Summary

- Document iOS Simulator support and guard it with a macOS CI compile check, as the first step of iOS support.

## Motivation

This continues the mobile support started in #145, which brought tauri-pilot to Android. As mentioned there, iOS support starts with the Simulator.

It turns out no runtime changes are needed: a Simulator shares the Mac's filesystem, so the existing Unix socket, JSON-RPC handlers and JS bridge work unchanged, and the CLI connects with no extra flags. What was missing is documentation of the setup, and a CI check that the plugin keeps compiling for the Simulator target.

## Changes

- A new iOS Simulator section in the plugin setup guide: registration in the mobile `run()` entry point, the `pilot:default` permission, disabling the desktop `press` backend with mutually exclusive target dependencies (Cargo unions features across entries, so a single `default-features = false` entry next to a plain one would not work), and isolating several Simulators with `SIMCTL_CHILD_XDG_RUNTIME_DIR`.
- Platform lists in the README and Getting Started now name the iOS Simulator, and the README's known limitations explain why physical devices are not covered yet.
- A macOS CI step checks `cargo check` and `cargo clippy` for `aarch64-apple-ios-sim` with `--no-default-features`, mirroring the Android step. The CI step only guards compilation; runtime behaviour on the Simulator is verified manually as described below.

Physical devices need a further step: the app sandbox hides the socket file from the Mac, and Apple ships no `adb forward` equivalent. My plan is to let the plugin listen on a loopback TCP port on the device — debug builds only, bound to `127.0.0.1`, taking a fresh kernel-assigned port on each launch and reporting it in the startup log, like the Android socket name — and have the CLI reach that port through `usbmuxd`, which macOS already runs for Finder sync and Xcode, so there is no third-party tooling and no forwarding step. I have prototyped this against a physical iPhone. Would you be open to that approach? If so, I can submit a separate PR for it.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Tested manually with a Tauri app (if applicable)

To check the approach, I used a small Tauri v2 app with a counter and a text input, built with `default-features = false`. I performed a full Xcode archive, installed it into a dedicated aarch64 Simulator (Xcode 26.6, iOS Simulator 26.5, Tauri 2.11.5) and connected from the host Mac, then checked `ping`, snapshots, clicks, text input, assertions, `eval`, `state`, `windows`, `screenshot` and `logs` over the default `/tmp` socket, and repeated the smoke over a private `XDG_RUNTIME_DIR` socket with `--socket`. With the `press` feature off, `press` returns the existing feature-disabled error.

`cargo check -p tauri-plugin-pilot --target aarch64-apple-ios-sim --no-default-features` also passes.

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents iOS Simulator support and adds a macOS CI check that the plugin keeps compiling for `aarch64-apple-ios-sim`. No runtime changes were needed because a Simulator shares the Mac's filesystem, so the existing Unix socket, JSON-RPC handlers, and JS bridge work unchanged.

- Adds an iOS Simulator section to the plugin setup guide covering mobile entry-point registration, the `pilot:default` permission, disabling the desktop `press` backend via a combined `any(target_os = "android", target_os = "ios")` target dependency pair, and isolating multiple Simulators with `SIMCTL_CHILD_XDG_RUNTIME_DIR` and a `--terminate-running-process` relaunch.
- Warns that a desktop build and Simulators of the same app share the default socket path; the first to start owns it and extra instances run without a pilot server.
- Names the `x86_64-apple-ios` Rust target for Intel Macs, and updates the CLI reference for iOS: no `press` backend and `screenshot_native` returns `PERMISSION_DENIED`.
- Updates the README, Getting Started, and CHANGELOG to list the iOS Simulator and note that physical devices are not supported yet.
- Adds a macOS CI step mirroring the Android one: `cargo check` and `cargo clippy` for `aarch64-apple-ios-sim` with `--no-default-features`.

<sup>Written for commit ce8ea84274da81fcbcd03656698377b7e131c9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running the plugin with iOS Simulator from macOS, including Intel and Apple silicon Macs.
  - Added guidance for launching multiple Simulators and handling shared socket behavior.

- **Known Limitations**
  - Physical iOS devices are not supported.
  - `press` and native screenshots are unavailable on iOS.

- **Documentation**
  - Updated setup, requirements, CLI reference, README, and changelog documentation with platform details and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->