### PR TITLE
fix(bridge): reject fill, type and check on non-editable targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fill`, `type`, and `check` no longer report ok on an element that cannot
   take the write. Assigning `.value` or `.checked` on a plain `<div>` created
   an expando and left the visible text unchanged, which is the same silent
-  no-op `select` was hardened against. `fill` and `type` now accept
-  `<input>`, `<textarea>`, `<select>`, and contenteditable hosts (including
-  Tiptap / ProseMirror-style editors, via `insertText`), and throw on
-  anything else. `check` accepts only checkbox and radio inputs. [#154]
+  no-op `select` was hardened against. `fill` accepts `<input>`,
+  `<textarea>`, `<select>`, and contenteditable hosts (including Tiptap /
+  ProseMirror-style editors, via `insertText` with a `textContent`
+  fallback). `fill` on `<select>` matches an option by value then label and
+  throws if none match. `type` accepts `<input>`, `<textarea>`, and
+  contenteditable hosts, and rejects `<select>` (use `fill` or `select`).
+  Both throw on anything else. `check` accepts only checkbox and radio
+  inputs. [#154]
 
 - Without `--window` and without a `main` window, commands now target the
   first window by label, and `windows.list` sorts by label. Both used Tauri's
@@ -730,3 +734,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#149]: https://github.com/mpiton/tauri-pilot/issues/149
 [#152]: https://github.com/mpiton/tauri-pilot/issues/152
 [#153]: https://github.com/mpiton/tauri-pilot/issues/153
+[#154]: https://github.com/mpiton/tauri-pilot/issues/154

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fill`, `type`, and `check` no longer report ok on an element that cannot
+  take the write. Assigning `.value` or `.checked` on a plain `<div>` created
+  an expando and left the visible text unchanged, which is the same silent
+  no-op `select` was hardened against. `fill` and `type` now accept
+  `<input>`, `<textarea>`, `<select>`, and contenteditable hosts (including
+  Tiptap / ProseMirror-style editors, via `insertText`), and throw on
+  anything else. `check` accepts only checkbox and radio inputs. [#154]
+
 - Without `--window` and without a `main` window, commands now target the
   first window by label, and `windows.list` sorts by label. Both used Tauri's
   hash order, which changes from run to run.

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ the JavaScript do not need escaping.
 | `snapshot` | Accessibility tree with refs (`--save` to persist) |
 | `diff` | Compare snapshots, show only changes |
 | `click` | Click an element |
-| `fill` | Clear + type in an input |
+| `fill` | Clear + type in an input, textarea, select, or contenteditable |
 | `type` | Type without clearing |
 | `press` | Send a keystroke |
 | `select` | Select a dropdown option |
-| `check` | Toggle a checkbox |
+| `check` | Toggle a checkbox or radio |
 | `scroll` | Scroll page or element |
 | `drag` | Drag element to element or by offset (drives HTML5 *and* dnd-kit-style libraries) |
 | `drop` | Simulate file drop on element |

--- a/SKILL.md
+++ b/SKILL.md
@@ -97,6 +97,10 @@ Three target formats, auto-detected:
 | `drag <source> [target] [--offset X,Y]` | `drag @e5 @e8` |
 | `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 
+`fill` / `type` accept `<input>`, `<textarea>`, `<select>`, and contenteditable
+elements, and error on anything else. `check` accepts only checkbox and radio
+inputs. `ok` means the value actually landed.
+
 `drag` emits an HTML5 drag sequence *and* a real press → interpolated
 `pointermove`/`mousemove` stream → release, so it drives both native
 `draggable="true"` handlers and libraries like dnd-kit or sortable.js. Its `ok`

--- a/SKILL.md
+++ b/SKILL.md
@@ -97,9 +97,15 @@ Three target formats, auto-detected:
 | `drag <source> [target] [--offset X,Y]` | `drag @e5 @e8` |
 | `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 
-`fill` / `type` accept `<input>`, `<textarea>`, `<select>`, and contenteditable
-elements, and error on anything else. `check` accepts only checkbox and radio
-inputs. `ok` means the value actually landed.
+`fill` accepts `<input>`, `<textarea>`, `<select>`, and contenteditable
+elements. `type` accepts the same except `<select>` (use `fill` or `select`).
+Both error on anything else. `check` accepts only checkbox and radio inputs.
+For fill and type, ok means the value landed; for check, confirm with
+`assert checked`.
+
+On contenteditable, fill/type try `insertText` first so Tiptap/ProseMirror
+see the write, then fall back to `textContent`. Read the result with `text`
+/ `assert text`, not `value`.
 
 `drag` emits an HTML5 drag sequence *and* a real press → interpolated
 `pointermove`/`mousemove` stream → release, so it drives both native

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -62,15 +62,15 @@ pub(crate) enum Command {
     },
     /// Click an element.
     Click { target: String },
-    /// Clear and fill an input with a value.
+    /// Clear and fill an input, textarea, select, or contenteditable element.
     Fill { target: String, value: String },
-    /// Type text character by character.
+    /// Type text character by character into an editable element.
     Type { target: String, text: String },
     /// Press a keyboard key.
     Press { key: String },
     /// Select an option in a <select>.
     Select { target: String, value: String },
-    /// Toggle a checkbox.
+    /// Toggle a checkbox or radio input.
     Check { target: String },
     /// Scroll the page or an element.
     Scroll {

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -978,7 +978,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "type",
-            description: "Type text into an input, textarea, select, or contenteditable target without clearing it first. Errors if the target cannot take a value.",
+            description: "Type text into an input, textarea, or contenteditable target without clearing it first. Errors on <select> and on any target that cannot take a value.",
             schema: type_schema,
             read_only: false,
             destructive: false,

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -730,7 +730,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "check",
-            description: "Toggle a checkbox or radio element.",
+            description: "Toggle an <input type=checkbox> or <input type=radio>. Errors on any other element.",
             schema: target_schema,
             read_only: false,
             destructive: false,
@@ -778,7 +778,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "fill",
-            description: "Clear and fill an input target with a value.",
+            description: "Clear and fill an input, textarea, select, or contenteditable target. Errors if the target cannot take a value.",
             schema: fill_schema,
             read_only: false,
             destructive: false,
@@ -978,7 +978,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "type",
-            description: "Type text into an element target without clearing it first.",
+            description: "Type text into an input, textarea, select, or contenteditable target without clearing it first. Errors if the target cannot take a value.",
             schema: type_schema,
             read_only: false,
             destructive: false,

--- a/crates/tauri-plugin-pilot/js/bridge.check.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.check.test.mjs
@@ -61,6 +61,8 @@ test("check toggles checkbox and radio inputs", () => {
     assert.deepEqual(pilot.check({ selector: "input" }), { ok: true });
     assert.equal(el.checked, true);
     assert.ok(el.events.includes("change"));
+    assert.deepEqual(pilot.check({ selector: "input" }), { ok: true });
+    assert.equal(el.checked, false);
   }
 });
 

--- a/crates/tauri-plugin-pilot/js/bridge.check.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.check.test.mjs
@@ -1,0 +1,85 @@
+// Dependency-free behavioural tests for the bridge `check` action (#154).
+//
+// `check` used to assign `el.checked = !el.checked` on any target. On a <div>
+// that creates an expando and reports ok. It must accept only checkbox and
+// radio inputs, using a realm-safe tag+type guard (not `instanceof`).
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.check.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function makeInput(type, checked = false) {
+  return {
+    tagName: "INPUT",
+    type,
+    checked,
+    events: [],
+    focus() {},
+    dispatchEvent(event) {
+      this.events.push(event.type);
+      return true;
+    },
+  };
+}
+
+function loadBridge(queryResult) {
+  Object.assign(console, REAL_CONSOLE);
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    querySelector(selector) {
+      if (queryResult === undefined) {
+        throw new Error("unexpected querySelector(" + selector + ")");
+      }
+      return queryResult;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("check toggles checkbox and radio inputs", () => {
+  for (const type of ["checkbox", "radio"]) {
+    const el = makeInput(type, false);
+    const pilot = loadBridge(el);
+    assert.deepEqual(pilot.check({ selector: "input" }), { ok: true });
+    assert.equal(el.checked, true);
+    assert.ok(el.events.includes("change"));
+  }
+});
+
+test("check throws on a non-input target", () => {
+  const el = { tagName: "DIV", checked: false, dispatchEvent() { return true; } };
+  const pilot = loadBridge(el);
+  assert.throws(
+    () => pilot.check({ selector: "#qa-div" }),
+    /checkbox|radio/i,
+  );
+  assert.equal(el.checked, false);
+});
+
+test("check throws on a non-checkable input", () => {
+  const el = makeInput("text", false);
+  const pilot = loadBridge(el);
+  assert.throws(
+    () => pilot.check({ selector: "input[name=q]" }),
+    /checkbox|radio/i,
+  );
+  assert.equal(el.checked, false);
+});

--- a/crates/tauri-plugin-pilot/js/bridge.fill.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.fill.test.mjs
@@ -1,0 +1,136 @@
+// Dependency-free behavioural tests for bridge `fill` / `type` (#154).
+//
+// Those actions used to assign `el.value` on any target. On a <div> that
+// creates an expando and reports ok while the visible text is unchanged.
+// They must reject non-editable targets and actually edit contenteditable hosts.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.fill.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function makeValueEl(tag, value = "") {
+  const proto = {};
+  Object.defineProperty(proto, "value", {
+    get() { return this._value; },
+    set(v) { this._value = String(v); },
+  });
+  const el = Object.create(proto);
+  el.tagName = tag;
+  el._value = value;
+  el.events = [];
+  el.focus = function () {};
+  el.dispatchEvent = function (event) {
+    this.events.push(event.type);
+    return true;
+  };
+  return el;
+}
+
+function makeHost({ tag = "DIV", editable = false, text = "original text" } = {}) {
+  return {
+    tagName: tag,
+    textContent: text,
+    isContentEditable: editable,
+    contentEditable: editable ? "true" : "false",
+    events: [],
+    focus() {},
+    dispatchEvent(event) {
+      this.events.push(event.type);
+      return true;
+    },
+  };
+}
+
+function loadBridge({ queryResult, execCommand } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+  class FakeEvent {
+    constructor(type, init) {
+      this.type = type;
+      Object.assign(this, init || {});
+    }
+  }
+  globalThis.KeyboardEvent = class KeyboardEvent extends FakeEvent {};
+  globalThis.InputEvent = class InputEvent extends FakeEvent {};
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    querySelector(selector) {
+      if (queryResult === undefined) {
+        throw new Error("unexpected querySelector(" + selector + ")");
+      }
+      return queryResult;
+    },
+  };
+  if (execCommand) globalThis.document.execCommand = execCommand;
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("fill sets value on input, textarea, and select", () => {
+  for (const tag of ["INPUT", "TEXTAREA", "SELECT"]) {
+    const el = makeValueEl(tag);
+    const pilot = loadBridge({ queryResult: el });
+    assert.deepEqual(pilot.fill({ selector: tag.toLowerCase(), value: "x" }), { ok: true });
+    assert.equal(el.value, "x");
+    assert.ok(el.events.includes("input") && el.events.includes("change"));
+  }
+});
+
+test("fill and type throw on a non-editable target", () => {
+  const el = makeHost();
+  const pilot = loadBridge({ queryResult: el });
+  assert.throws(() => pilot.fill({ selector: "#qa-div", value: "SHOULD-FAIL" }), /contenteditable/i);
+  assert.throws(() => pilot.type({ selector: "#qa-div", text: "SHOULD-FAIL" }), /contenteditable/i);
+  assert.equal(el.textContent, "original text");
+  assert.equal(el.value, undefined);
+});
+
+test("fill replaces contenteditable text when execCommand is unavailable", () => {
+  const el = makeHost({ editable: true });
+  const pilot = loadBridge({ queryResult: el });
+  assert.deepEqual(pilot.fill({ selector: "#editor", value: "hello" }), { ok: true });
+  assert.equal(el.textContent, "hello");
+  assert.ok(el.events.includes("input") && el.events.includes("change"));
+});
+
+test("fill uses insertText on contenteditable when execCommand works", () => {
+  const calls = [];
+  const el = makeHost({ editable: true });
+  const execCommand = (cmd, _ui, value) => {
+    calls.push([cmd, value]);
+    if (cmd === "insertText") el.textContent = value;
+    return true;
+  };
+  const pilot = loadBridge({ queryResult: el, execCommand });
+  assert.deepEqual(pilot.fill({ selector: "#editor", value: "hello" }), { ok: true });
+  assert.deepEqual(calls, [["selectAll", undefined], ["insertText", "hello"]]);
+  assert.equal(el.textContent, "hello");
+});
+
+test("type appends on input and contenteditable", () => {
+  const input = makeValueEl("INPUT", "ab");
+  const pilotIn = loadBridge({ queryResult: input });
+  assert.deepEqual(pilotIn.type({ selector: "input", text: "c" }), { ok: true });
+  assert.equal(input.value, "abc");
+
+  const host = makeHost({ editable: true, text: "ab" });
+  const pilotEd = loadBridge({ queryResult: host });
+  assert.deepEqual(pilotEd.type({ selector: "#editor", text: "c" }), { ok: true });
+  assert.equal(host.textContent, "abc");
+});

--- a/crates/tauri-plugin-pilot/js/bridge.fill.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.fill.test.mjs
@@ -39,12 +39,19 @@ function makeValueEl(tag, value = "") {
   return el;
 }
 
-function makeHost({ tag = "DIV", editable = false, text = "original text" } = {}) {
-  return {
+function makeHost({
+  tag = "DIV",
+  editable = false,
+  text = "original text",
+  isContentEditable,
+  contentEditable,
+  ownerDocument,
+} = {}) {
+  const el = {
     tagName: tag,
     textContent: text,
-    isContentEditable: editable,
-    contentEditable: editable ? "true" : "false",
+    isContentEditable: isContentEditable ?? editable,
+    contentEditable: contentEditable ?? (editable ? "true" : "false"),
     events: [],
     focus() {},
     dispatchEvent(event) {
@@ -52,9 +59,31 @@ function makeHost({ tag = "DIV", editable = false, text = "original text" } = {}
       return true;
     },
   };
+  if (ownerDocument) el.ownerDocument = ownerDocument;
+  return el;
 }
 
-function loadBridge({ queryResult, execCommand } = {}) {
+function makeEditingDocument(execCommand, onSelectNodeContents) {
+  const selection = {
+    removeAllRanges() {},
+    addRange() {},
+  };
+  const view = { getSelection() { return selection; } };
+  return {
+    createRange() {
+      return {
+        selectNodeContents(node) {
+          if (onSelectNodeContents) onSelectNodeContents(node);
+        },
+        collapse() {},
+      };
+    },
+    defaultView: view,
+    execCommand,
+  };
+}
+
+function loadBridge({ queryResult, execCommand, onSelectNodeContents } = {}) {
   Object.assign(console, REAL_CONSOLE);
   class FakeEvent {
     constructor(type, init) {
@@ -64,7 +93,14 @@ function loadBridge({ queryResult, execCommand } = {}) {
   }
   globalThis.KeyboardEvent = class KeyboardEvent extends FakeEvent {};
   globalThis.InputEvent = class InputEvent extends FakeEvent {};
-  globalThis.window = { fetch() {} };
+  const selection = {
+    removeAllRanges() {},
+    addRange() {},
+  };
+  globalThis.window = {
+    fetch() {},
+    getSelection() { return selection; },
+  };
   globalThis.document = {
     querySelector(selector) {
       if (queryResult === undefined) {
@@ -72,6 +108,15 @@ function loadBridge({ queryResult, execCommand } = {}) {
       }
       return queryResult;
     },
+    createRange() {
+      return {
+        selectNodeContents(node) {
+          if (onSelectNodeContents) onSelectNodeContents(node);
+        },
+        collapse() {},
+      };
+    },
+    defaultView: globalThis.window,
   };
   if (execCommand) globalThis.document.execCommand = execCommand;
   function XMLHttpRequestStub() {}
@@ -82,8 +127,8 @@ function loadBridge({ queryResult, execCommand } = {}) {
   return globalThis.window.__PILOT__;
 }
 
-test("fill sets value on input, textarea, and select", () => {
-  for (const tag of ["INPUT", "TEXTAREA", "SELECT"]) {
+test("fill sets value on input and textarea", () => {
+  for (const tag of ["INPUT", "TEXTAREA"]) {
     const el = makeValueEl(tag);
     const pilot = loadBridge({ queryResult: el });
     assert.deepEqual(pilot.fill({ selector: tag.toLowerCase(), value: "x" }), { ok: true });
@@ -111,16 +156,80 @@ test("fill replaces contenteditable text when execCommand is unavailable", () =>
 
 test("fill uses insertText on contenteditable when execCommand works", () => {
   const calls = [];
+  const selected = [];
   const el = makeHost({ editable: true });
   const execCommand = (cmd, _ui, value) => {
     calls.push([cmd, value]);
     if (cmd === "insertText") el.textContent = value;
     return true;
   };
-  const pilot = loadBridge({ queryResult: el, execCommand });
+  const pilot = loadBridge({
+    queryResult: el,
+    execCommand,
+    onSelectNodeContents: (node) => selected.push(node),
+  });
   assert.deepEqual(pilot.fill({ selector: "#editor", value: "hello" }), { ok: true });
-  assert.deepEqual(calls, [["selectAll", undefined], ["insertText", "hello"]]);
+  assert.deepEqual(calls, [["insertText", "hello"]]);
+  assert.deepEqual(selected, [el]);
   assert.equal(el.textContent, "hello");
+});
+
+test("type uses insertText on contenteditable when execCommand works", () => {
+  const calls = [];
+  const el = makeHost({ editable: true, text: "ab" });
+  const execCommand = (cmd, _ui, value) => {
+    calls.push([cmd, value]);
+    if (cmd === "insertText") el.textContent = (el.textContent || "") + value;
+    return true;
+  };
+  const pilot = loadBridge({ queryResult: el, execCommand });
+  assert.deepEqual(pilot.type({ selector: "#editor", text: "cd" }), { ok: true });
+  assert.deepEqual(calls, [["insertText", "c"], ["insertText", "d"]]);
+  assert.equal(el.textContent, "abcd");
+});
+
+test("fill and type accept plaintext-only and IDL-true contenteditable hosts", () => {
+  for (const hostOpts of [
+    { isContentEditable: false, contentEditable: "plaintext-only" },
+    { isContentEditable: false, contentEditable: "true" },
+  ]) {
+    const filled = makeHost({ text: "ab", ...hostOpts });
+    const fillPilot = loadBridge({ queryResult: filled });
+    assert.deepEqual(fillPilot.fill({ selector: "#editor", value: "hello" }), { ok: true });
+    assert.equal(filled.textContent, "hello");
+
+    const typed = makeHost({ text: "ab", ...hostOpts });
+    const typePilot = loadBridge({ queryResult: typed });
+    assert.deepEqual(typePilot.type({ selector: "#editor", text: "c" }), { ok: true });
+    assert.equal(typed.textContent, "abc");
+  }
+});
+
+test("fill and type run insertText on the target ownerDocument", () => {
+  const parentCalls = [];
+  const ownerCalls = [];
+  const ownerDoc = makeEditingDocument((cmd, _ui, value) => {
+    ownerCalls.push([cmd, value]);
+    return true;
+  });
+  const el = makeHost({ editable: true, text: "ab", ownerDocument: ownerDoc });
+  const parentExec = (cmd, _ui, value) => {
+    parentCalls.push([cmd, value]);
+    return true;
+  };
+
+  const fillPilot = loadBridge({ queryResult: el, execCommand: parentExec });
+  assert.deepEqual(fillPilot.fill({ selector: "#editor", value: "hello" }), { ok: true });
+  assert.deepEqual(parentCalls, []);
+  assert.deepEqual(ownerCalls, [["insertText", "hello"]]);
+
+  parentCalls.length = 0;
+  ownerCalls.length = 0;
+  const typed = makeHost({ editable: true, text: "ab", ownerDocument: ownerDoc });
+  const typePilot = loadBridge({ queryResult: typed, execCommand: parentExec });
+  assert.deepEqual(typePilot.type({ selector: "#editor", text: "c" }), { ok: true });
+  assert.deepEqual(parentCalls, []);
+  assert.deepEqual(ownerCalls, [["insertText", "c"]]);
 });
 
 test("type appends on input and contenteditable", () => {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -540,14 +540,91 @@
     return desc && typeof desc.set === "function" ? desc.set : null;
   }
 
+  function elementTag(el) {
+    return el && el.tagName ? String(el.tagName).toLowerCase() : "";
+  }
+
+  function isValueElement(el) {
+    const tag = elementTag(el);
+    return tag === "input" || tag === "textarea" || tag === "select";
+  }
+
+  // Realm-safe: `isContentEditable` is an instance property, not a constructor
+  // check, so a contenteditable node from another window/iframe still matches.
+  // Fall back to the contentEditable IDL string for hosts that only expose that.
+  function isContentEditable(el) {
+    if (!el) return false;
+    if (el.isContentEditable === true) return true;
+    const mode = el.contentEditable != null ? String(el.contentEditable).toLowerCase() : "";
+    return mode === "true" || mode === "plaintext-only";
+  }
+
+  function requireEditable(el, action) {
+    if (isValueElement(el) || isContentEditable(el)) return;
+    const reported = (elementTag(el) || String(el)).slice(0, 64);
+    throw new Error(action + " requires an <input>, <textarea>, <select>, or contenteditable element, got: " + reported);
+  }
+
+  function requireCheckable(el) {
+    const tag = elementTag(el);
+    const type = el && el.type != null ? String(el.type).toLowerCase() : "";
+    if (tag === "input" && (type === "checkbox" || type === "radio")) return;
+    const reported = (tag === "input" ? "input type=" + type : tag || String(el)).slice(0, 64);
+    throw new Error('check requires an <input type="checkbox"> or <input type="radio">, got: ' + reported);
+  }
+
+  function tryExecCommand(command, value) {
+    try {
+      return typeof document.execCommand === "function" && document.execCommand(command, false, value);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function collapseToEnd(el) {
+    try {
+      const doc = el.ownerDocument || document;
+      const range = doc.createRange();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      const view = doc.defaultView || window;
+      const sel = view.getSelection && view.getSelection();
+      if (!sel) return;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch (_) {}
+  }
+
+  function fillContentEditable(el, value) {
+    if (tryExecCommand("selectAll") && tryExecCommand("insertText", value)) return;
+    el.textContent = value;
+  }
+
+  function typeContentEditable(el, text) {
+    collapseToEnd(el);
+    for (const ch of text) {
+      el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
+      if (!tryExecCommand("insertText", ch)) {
+        el.textContent = (el.textContent || "") + ch;
+        el.dispatchEvent(new InputEvent("input", { data: ch, inputType: "insertText", bubbles: true }));
+      }
+      el.dispatchEvent(new KeyboardEvent("keyup", { key: ch, bubbles: true }));
+    }
+  }
+
   function fill(params) {
     const el = resolveTarget(params);
+    requireEditable(el, "fill");
     el.focus();
-    const setter = nativeValueSetter(el);
-    if (setter) {
-      setter.call(el, params.value);
+    if (isValueElement(el)) {
+      const setter = nativeValueSetter(el);
+      if (setter) {
+        setter.call(el, params.value);
+      } else {
+        el.value = params.value;
+      }
     } else {
-      el.value = params.value;
+      fillContentEditable(el, params.value);
     }
     el.dispatchEvent(new Event("input", { bubbles: true }));
     el.dispatchEvent(new Event("change", { bubbles: true }));
@@ -556,7 +633,12 @@
 
   function typeText(params) {
     const el = resolveTarget(params);
+    requireEditable(el, "type");
     el.focus();
+    if (!isValueElement(el)) {
+      typeContentEditable(el, params.text);
+      return { ok: true };
+    }
     const setter = nativeValueSetter(el);
     for (const ch of params.text) {
       el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
@@ -615,6 +697,7 @@
 
   function check(params) {
     const el = resolveTarget(params);
+    requireCheckable(el);
     el.checked = !el.checked;
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -546,7 +546,7 @@
 
   function isValueElement(el) {
     const tag = elementTag(el);
-    return tag === "input" || tag === "textarea" || tag === "select";
+    return tag === "input" || tag === "textarea";
   }
 
   // Realm-safe: `isContentEditable` is an instance property, not a constructor
@@ -561,8 +561,12 @@
 
   function requireEditable(el, action) {
     if (isValueElement(el) || isContentEditable(el)) return;
+    if (action === "fill" && elementTag(el) === "select") return;
     const reported = (elementTag(el) || String(el)).slice(0, 64);
-    throw new Error(action + " requires an <input>, <textarea>, <select>, or contenteditable element, got: " + reported);
+    if (action === "fill") {
+      throw new Error("fill requires an <input>, <textarea>, <select>, or contenteditable element, got: " + reported);
+    }
+    throw new Error(action + " requires an <input>, <textarea>, or contenteditable element, got: " + reported);
   }
 
   function requireCheckable(el) {
@@ -573,9 +577,14 @@
     throw new Error('check requires an <input type="checkbox"> or <input type="radio">, got: ' + reported);
   }
 
-  function tryExecCommand(command, value) {
+  function ownerDoc(el) {
+    return (el && el.ownerDocument) || document;
+  }
+
+  function tryExecCommand(el, command, value) {
     try {
-      return typeof document.execCommand === "function" && document.execCommand(command, false, value);
+      const doc = ownerDoc(el);
+      return typeof doc.execCommand === "function" && doc.execCommand(command, false, value);
     } catch (_) {
       return false;
     }
@@ -583,7 +592,7 @@
 
   function collapseToEnd(el) {
     try {
-      const doc = el.ownerDocument || document;
+      const doc = ownerDoc(el);
       const range = doc.createRange();
       range.selectNodeContents(el);
       range.collapse(false);
@@ -596,15 +605,27 @@
   }
 
   function fillContentEditable(el, value) {
-    if (tryExecCommand("selectAll") && tryExecCommand("insertText", value)) return;
+    try {
+      const doc = ownerDoc(el);
+      const range = doc.createRange();
+      range.selectNodeContents(el);
+      const view = doc.defaultView || window;
+      const sel = view.getSelection && view.getSelection();
+      if (sel) {
+        sel.removeAllRanges();
+        sel.addRange(range);
+        if (tryExecCommand(el, "insertText", value)) return true;
+      }
+    } catch (_) {}
     el.textContent = value;
+    return false;
   }
 
   function typeContentEditable(el, text) {
     collapseToEnd(el);
     for (const ch of text) {
       el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
-      if (!tryExecCommand("insertText", ch)) {
+      if (!tryExecCommand(el, "insertText", ch)) {
         el.textContent = (el.textContent || "") + ch;
         el.dispatchEvent(new InputEvent("input", { data: ch, inputType: "insertText", bubbles: true }));
       }
@@ -612,11 +633,37 @@
     }
   }
 
+  function applySelectOption(el, wantedRaw) {
+    // Resolve the target option before mutating anything. Setting
+    // `HTMLSelectElement.value` to a string that matches no option `value`
+    // silently yields `value=""` / `selectedIndex=-1` per the DOM spec, so
+    // "set then trust" reports success on a no-op (#113). Match the option
+    // first — by `value`, then by visible label — and error if none matches so
+    // a reported `ok` always means an option was actually selected.
+    const wanted = String(wantedRaw);
+    const options = Array.from(el.options || []);
+    const matched =
+      options.find((o) => o.value === wanted) ||
+      options.find((o) => (o.text || "").trim() === wanted.trim());
+    if (!matched) {
+      throw new Error("select: no option matches " + JSON.stringify(wantedRaw));
+    }
+    const setter = nativeValueSetter(el);
+    if (setter) {
+      setter.call(el, matched.value);
+    } else {
+      el.value = matched.value;
+    }
+  }
+
   function fill(params) {
     const el = resolveTarget(params);
     requireEditable(el, "fill");
     el.focus();
-    if (isValueElement(el)) {
+    let wroteViaExec = false;
+    if (elementTag(el) === "select") {
+      applySelectOption(el, params.value);
+    } else if (isValueElement(el)) {
       const setter = nativeValueSetter(el);
       if (setter) {
         setter.call(el, params.value);
@@ -624,15 +671,22 @@
         el.value = params.value;
       }
     } else {
-      fillContentEditable(el, params.value);
+      wroteViaExec = fillContentEditable(el, params.value);
     }
-    el.dispatchEvent(new Event("input", { bubbles: true }));
-    el.dispatchEvent(new Event("change", { bubbles: true }));
+    // insertText already fires a native `input` event. Dispatching again
+    // would double-notify listeners; the textContent fallback does not.
+    if (!wroteViaExec) {
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    }
     return { ok: true };
   }
 
   function typeText(params) {
     const el = resolveTarget(params);
+    if (elementTag(el) === "select") {
+      throw new Error("type cannot target a <select>; use fill or select");
+    }
     requireEditable(el, "type");
     el.focus();
     if (!isValueElement(el)) {
@@ -671,26 +725,7 @@
       const reported = (tag || String(el)).slice(0, 64);
       throw new Error("select requires a <select> element, got: " + reported);
     }
-    // Resolve the target option before mutating anything. Setting
-    // `HTMLSelectElement.value` to a string that matches no option `value`
-    // silently yields `value=""` / `selectedIndex=-1` per the DOM spec, so
-    // "set then trust" reports success on a no-op (#113). Match the option
-    // first — by `value`, then by visible label — and error if none matches so
-    // a reported `ok` always means an option was actually selected.
-    const wanted = String(params.value);
-    const options = Array.from(el.options || []);
-    const matched =
-      options.find((o) => o.value === wanted) ||
-      options.find((o) => (o.text || "").trim() === wanted.trim());
-    if (!matched) {
-      throw new Error("select: no option matches " + JSON.stringify(params.value));
-    }
-    const setter = nativeValueSetter(el);
-    if (setter) {
-      setter.call(el, matched.value);
-    } else {
-      el.value = matched.value;
-    }
+    applySelectOption(el, params.value);
     el.dispatchEvent(new Event("change", { bubbles: true }));
     return { ok: true };
   }

--- a/crates/tauri-plugin-pilot/js/bridge.select.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.select.test.mjs
@@ -147,3 +147,40 @@ test("select still rejects a non-<select> target", () => {
     /<select>/i,
   );
 });
+
+test("fill on select uses option matching and throws when nothing matches", () => {
+  const el = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+  ]);
+  const pilot = loadBridge({ queryResult: el });
+
+  assert.deepEqual(pilot.fill({ selector: "select[name=role]", value: "admin" }), { ok: true });
+  assert.equal(el.value, "admin");
+  assert.ok(el.events.includes("change"));
+
+  const unmatched = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+  ]);
+  const fillPilot = loadBridge({ queryResult: unmatched });
+  assert.throws(
+    () => fillPilot.fill({ selector: "select[name=role]", value: "zzz" }),
+    /no option/i,
+  );
+  assert.equal(unmatched.selectedIndex, -1);
+});
+
+test("type rejects a select target", () => {
+  const el = makeSelect([
+    { value: "user", text: "User" },
+    { value: "admin", text: "Admin" },
+  ]);
+  const pilot = loadBridge({ queryResult: el });
+
+  assert.throws(
+    () => pilot.type({ selector: "select[name=role]", text: "admin" }),
+    /select/i,
+  );
+  assert.equal(el.selectedIndex, -1);
+});

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -152,6 +152,22 @@ fn sanitize_identifier(raw: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    // Bound each function body by the start of the next `function ` declaration
+    // (or end-of-string), so the slice is immune to brace indentation changes
+    // and to nested blocks closing with the same brace pattern.
+    // ASCII needles → `find()` returns offsets that are valid UTF-8 char boundaries.
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    fn bridge_fn_body<'a>(js: &'a str, fn_decl: &str) -> &'a str {
+        let start = js
+            .find(fn_decl)
+            .unwrap_or_else(|| panic!("{fn_decl} missing"));
+        let after = start + fn_decl.len();
+        let end = js[after..]
+            .find("\n  function ")
+            .map_or(js.len(), |off| after + off);
+        &js[start..end]
+    }
+
     #[cfg(all(any(unix, windows), debug_assertions))]
     #[test]
     fn bridge_js_contains_html_to_image_and_pilot() {
@@ -382,24 +398,9 @@ mod tests {
             "fill/typeText must not use the `HTMLInputElement.prototype || HTMLTextAreaElement.prototype` short-circuit (#85)"
         );
 
-        // Bound each function body by the start of the next `function ` declaration
-        // (or end-of-string), so the slice is immune to brace indentation changes
-        // and to nested blocks closing with the same brace pattern.
-        // ASCII needles → `find()` returns offsets that are valid UTF-8 char boundaries.
-        let body_of = |fn_decl: &str| -> &str {
-            let start = js
-                .find(fn_decl)
-                .unwrap_or_else(|| panic!("{fn_decl} missing"));
-            let after = start + fn_decl.len();
-            let end = js[after..]
-                .find("\n  function ")
-                .map_or(js.len(), |off| after + off);
-            &js[start..end]
-        };
-
-        let fill_body = body_of("function fill(params)");
-        let type_body = body_of("function typeText(params)");
-        let select_body = body_of("function select(params)");
+        let fill_body = bridge_fn_body(js, "function fill(params)");
+        let type_body = bridge_fn_body(js, "function typeText(params)");
+        let select_body = bridge_fn_body(js, "function select(params)");
 
         assert!(
             fill_body.contains("nativeValueSetter("),
@@ -410,8 +411,12 @@ mod tests {
             "typeText must call nativeValueSetter (#85)"
         );
         assert!(
-            select_body.contains("nativeValueSetter("),
-            "select must call nativeValueSetter (#85) so a future textarea-style brand-check bug cannot reappear in any setter handler"
+            select_body.contains("applySelectOption("),
+            "select must apply a matched option (#85)"
+        );
+        assert!(
+            bridge_fn_body(js, "function applySelectOption(").contains("nativeValueSetter("),
+            "applySelectOption must call nativeValueSetter (#85) so a future textarea-style brand-check bug cannot reappear in any setter handler"
         );
 
         // The pre-refactor `select` relied on the WebIDL brand check to reject
@@ -453,22 +458,11 @@ mod tests {
         // after nativeValueSetter: a reported ok must mean the action landed.
         let js = super::BRIDGE_JS;
 
-        let body_of = |fn_decl: &str| -> &str {
-            let start = js
-                .find(fn_decl)
-                .unwrap_or_else(|| panic!("{fn_decl} missing"));
-            let after = start + fn_decl.len();
-            let end = js[after..]
-                .find("\n  function ")
-                .map_or(js.len(), |off| after + off);
-            &js[start..end]
-        };
-
-        let fill_body = body_of("function fill(params)");
-        let type_body = body_of("function typeText(params)");
-        let check_body = body_of("function check(params)");
-        let editable_body = body_of("function requireEditable(");
-        let checkable_body = body_of("function requireCheckable(");
+        let fill_body = bridge_fn_body(js, "function fill(params)");
+        let type_body = bridge_fn_body(js, "function typeText(params)");
+        let check_body = bridge_fn_body(js, "function check(params)");
+        let editable_body = bridge_fn_body(js, "function requireEditable(");
+        let checkable_body = bridge_fn_body(js, "function requireCheckable(");
 
         assert!(
             fill_body.contains("requireEditable(el, \"fill\")"),
@@ -497,12 +491,28 @@ mod tests {
             "fill/type/check guards must be realm-safe — no instanceof (#154)"
         );
         assert!(
-            body_of("function fillContentEditable(").contains("insertText"),
+            bridge_fn_body(js, "function fillContentEditable(").contains("insertText"),
             "fill must edit contenteditable via insertText so rich-text editors see the write (#154)"
         );
         assert!(
-            body_of("function isContentEditable(").contains("plaintext-only"),
+            !bridge_fn_body(js, "function fillContentEditable(").contains("selectAll"),
+            "fill must not selectAll the editing host; that replaces the whole editor (#154)"
+        );
+        assert!(
+            bridge_fn_body(js, "function typeContentEditable(").contains("insertText"),
+            "type must edit contenteditable via insertText so rich-text editors see the write (#154)"
+        );
+        assert!(
+            bridge_fn_body(js, "function isContentEditable(").contains("plaintext-only"),
             "contenteditable detection must accept plaintext-only hosts (#154)"
+        );
+        assert!(
+            type_body.contains("type cannot target a <select>"),
+            "type must reject <select> instead of writing a raw value (#154)"
+        );
+        assert!(
+            fill_body.contains("applySelectOption("),
+            "fill must select an option rather than writing a raw value (#154)"
         );
     }
 

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -444,6 +444,68 @@ mod tests {
         );
     }
 
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
+    fn bridge_fill_type_check_reject_non_editable_targets() {
+        // #154: fill/type/check used to assign `.value` / `.checked` on any
+        // element. On a <div> that creates an expando and reports ok while
+        // nothing visible changed. Same failure class as the select guard
+        // after nativeValueSetter: a reported ok must mean the action landed.
+        let js = super::BRIDGE_JS;
+
+        let body_of = |fn_decl: &str| -> &str {
+            let start = js
+                .find(fn_decl)
+                .unwrap_or_else(|| panic!("{fn_decl} missing"));
+            let after = start + fn_decl.len();
+            let end = js[after..]
+                .find("\n  function ")
+                .map_or(js.len(), |off| after + off);
+            &js[start..end]
+        };
+
+        let fill_body = body_of("function fill(params)");
+        let type_body = body_of("function typeText(params)");
+        let check_body = body_of("function check(params)");
+        let editable_body = body_of("function requireEditable(");
+        let checkable_body = body_of("function requireCheckable(");
+
+        assert!(
+            fill_body.contains("requireEditable(el, \"fill\")"),
+            "fill must reject non-editable targets before writing (#154)"
+        );
+        assert!(
+            type_body.contains("requireEditable(el, \"type\")"),
+            "typeText must reject non-editable targets before writing (#154)"
+        );
+        assert!(
+            check_body.contains("requireCheckable("),
+            "check must reject non-checkbox/radio targets before toggling (#154)"
+        );
+        assert!(
+            editable_body
+                .contains("requires an <input>, <textarea>, <select>, or contenteditable element"),
+            "fill/type error must name the accepted elements (#154)"
+        );
+        assert!(
+            checkable_body
+                .contains("check requires an <input type=\"checkbox\"> or <input type=\"radio\">"),
+            "check error must name checkbox and radio (#154)"
+        );
+        assert!(
+            !editable_body.contains("instanceof") && !checkable_body.contains("instanceof"),
+            "fill/type/check guards must be realm-safe — no instanceof (#154)"
+        );
+        assert!(
+            body_of("function fillContentEditable(").contains("insertText"),
+            "fill must edit contenteditable via insertText so rich-text editors see the write (#154)"
+        );
+        assert!(
+            body_of("function isContentEditable(").contains("plaintext-only"),
+            "contenteditable detection must accept plaintext-only hosts (#154)"
+        );
+    }
+
     #[cfg(all(unix, not(target_os = "android"), debug_assertions))]
     #[test]
     fn second_instance_starts_when_socket_already_bound() {

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -119,7 +119,7 @@ Key internals:
 
 - **Snapshot**: Uses a manual recursive traversal over `node.children` to walk the DOM. A `ROLE_MAP` maps implicit HTML element roles (e.g. `<button>` → `"button"`, `<a>` → `"link"`) for elements without an explicit ARIA role.
 - **Actions**: Dispatch realistic DOM event sequences — `focus → mousedown → mouseup → click` — ensuring compatibility with React, Vue, and other frameworks that rely on synthetic events.
-- **`fill`**: Uses the native `HTMLInputElement` value setter via `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` to trigger React's synthetic change events correctly.
+- **`fill` / `type`**: On `<input>`, `<textarea>`, and `<select>`, write through the element's own prototype `value` setter so React sees the change. On contenteditable hosts, replace or insert via `document.execCommand("insertText")`. Anything else throws. A reported `ok` means the value landed.
 - **Console capture**: Monkey-patches `console.log/warn/error/info`, stores entries in a 500-entry ring buffer with `id`, `timestamp`, `level`, `args`, and `source`. Exposed via `consoleLogs(options)` and `clearLogs()`.
 
 ## Project Structure

--- a/docs/src/content/docs/guides/architecture.md
+++ b/docs/src/content/docs/guides/architecture.md
@@ -119,7 +119,7 @@ Key internals:
 
 - **Snapshot**: Uses a manual recursive traversal over `node.children` to walk the DOM. A `ROLE_MAP` maps implicit HTML element roles (e.g. `<button>` → `"button"`, `<a>` → `"link"`) for elements without an explicit ARIA role.
 - **Actions**: Dispatch realistic DOM event sequences — `focus → mousedown → mouseup → click` — ensuring compatibility with React, Vue, and other frameworks that rely on synthetic events.
-- **`fill` / `type`**: On `<input>`, `<textarea>`, and `<select>`, write through the element's own prototype `value` setter so React sees the change. On contenteditable hosts, replace or insert via `document.execCommand("insertText")`. Anything else throws. A reported `ok` means the value landed.
+- **`fill` / `type`**: On `<input>` and `<textarea>`, write through the element's own prototype `value` setter so React sees the change. `fill` on `<select>` uses the same value-then-label matcher as `select` and throws if no option matches; `type` rejects `<select>`. On contenteditable hosts, select the target's contents (not the whole document) and call `insertText` on the element's `ownerDocument`. If that fails, assign `textContent`, which does not update Tiptap/ProseMirror. Anything else throws. A reported `ok` means the value landed. Read contenteditable results with `text` / `assert text`, not `value`.
 - **Console capture**: Monkey-patches `console.log/warn/error/info`, stores entries in a 500-entry ring buffer with `id`, `timestamp`, `level`, `args`, and `source`. Exposed via `consoleLogs(options)` and `clearLogs()`.
 
 ## Project Structure

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -352,8 +352,14 @@ tauri-pilot click 100,200
 
 Clear an `<input>`, `<textarea>`, `<select>`, or contenteditable element and
 set a new value. Form controls use the native value setter so React and similar
-frameworks see the change. Contenteditable hosts (Tiptap, ProseMirror, and the
-like) are filled via `insertText` so the editor document updates.
+frameworks see the change. On `<select>`, the value is matched like `select`
+(option value, then visible label) and fill throws if nothing matches.
+
+Contenteditable hosts (Tiptap, ProseMirror, and the like) are filled by
+selecting the target's contents and calling `insertText` so the editor
+document updates. If `insertText` is unavailable, fill assigns `textContent`
+instead, which does not update those editors. Read the result with `text` /
+`assert text`, not `value`.
 
 Throws if the target cannot take a value (for example a plain `<div>`). A
 reported `ok` means the value was written.
@@ -374,8 +380,11 @@ tauri-pilot fill ".ProseMirror" "hello from the editor"
 
 ### `type`
 
-Type text into an `<input>`, `<textarea>`, `<select>`, or contenteditable
-element without clearing existing content first. Same target rules as `fill`.
+Type text into an `<input>`, `<textarea>`, or contenteditable element without
+clearing existing content first. Same target rules as `fill`, except
+`<select>` is rejected — use `fill` or `select`. Contenteditable typing also
+tries `insertText` first and falls back to `textContent`; read the result
+with `text` / `assert text`.
 
 ```bash
 tauri-pilot type <target> <text>

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -350,7 +350,13 @@ tauri-pilot click 100,200
 
 ### `fill`
 
-Clear an input field and type a new value. Uses the native setter to trigger synthetic React events.
+Clear an `<input>`, `<textarea>`, `<select>`, or contenteditable element and
+set a new value. Form controls use the native value setter so React and similar
+frameworks see the change. Contenteditable hosts (Tiptap, ProseMirror, and the
+like) are filled via `insertText` so the editor document updates.
+
+Throws if the target cannot take a value (for example a plain `<div>`). A
+reported `ok` means the value was written.
 
 ```bash
 tauri-pilot fill <target> <value>
@@ -361,13 +367,15 @@ tauri-pilot fill <target> <value>
 ```bash
 tauri-pilot fill @e2 "my-feature-branch"
 tauri-pilot fill "#search" "open issues"
+tauri-pilot fill ".ProseMirror" "hello from the editor"
 ```
 
 ---
 
 ### `type`
 
-Type text into a focused element without clearing existing content first.
+Type text into an `<input>`, `<textarea>`, `<select>`, or contenteditable
+element without clearing existing content first. Same target rules as `fill`.
 
 ```bash
 tauri-pilot type <target> <text>
@@ -452,7 +460,8 @@ tauri-pilot select @e5 "closed"
 
 ### `check`
 
-Toggle a checkbox (check if unchecked, uncheck if checked).
+Toggle an `<input type="checkbox">` or `<input type="radio">` (check if
+unchecked, uncheck if checked). Throws on any other element.
 
 ```bash
 tauri-pilot check <target>


### PR DESCRIPTION
## Summary

- `fill`, `type` and `check` now throw on targets that cannot take the write, instead of assigning an expando and reporting `ok`.
- `fill` / `type` accept `<input>`, `<textarea>`, `<select>` and contenteditable; `check` accepts only checkbox and radio.

## Motivation

A misrouted selector against a plain `<div>` reported success while the visible text never changed. The same silent no-op hit contenteditable hosts (Tiptap, ProseMirror, and similar). `select` already had this guard; these three actions did not.

Closes #154

## Changes

- Realm-safe tag/type guards in `bridge.js` (`requireEditable`, `requireCheckable`). No `instanceof`, so cross-realm/iframe nodes still match.
- Contenteditable writes go through `document.execCommand("insertText")`, with a `textContent` fallback.
- Behavioural Node tests for fill/type/check, plus a Rust source-inspection test that the guards stay in the shipped bridge.
- CLI help, MCP tool blurbs, changelog, SKILL.md and docs updated to match.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Tested manually with a Tauri app (if applicable)

Also: `node --test crates/tauri-plugin-pilot/js/*.test.mjs` (43 passed).

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`fill`, `type`, and `check` now throw on targets that can't take the write, instead of assigning an expando and reporting `ok`. Closes #154.

- `fill` accepts `<input>`, `<textarea>`, `<select>`, and contenteditable elements; `type` accepts the same except `<select>`.
- Contenteditable writes go through `insertText` with a `textContent` fallback.
- `check` accepts only checkbox and radio inputs.
- `<select>` option matching is shared between `fill` and `select`.
- Guards are realm-safe (no `instanceof`), so cross-window/iframe nodes still match.
- Added behavioural tests and updated CLI help, MCP tool descriptions, and docs.

<sup>Written for commit 8676ec8c219c3e36b558d19fcfaadc3e6e6fc1e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `fill` now supports inputs, textareas, selects, and contenteditable elements.
  * Select values are matched to available options, with clear errors for unmatched values.
  * Contenteditable interactions support native insertion with text-based fallback behavior.
  * `check` supports checkbox and radio inputs with state verification.

* **Bug Fixes**
  * `type` now rejects select elements instead of modifying them.
  * Invalid targets are rejected without changing their state.
  * Interactions avoid duplicate input events after successful native editing.

* **Documentation**
  * Updated CLI, MCP, architecture, and interaction guidance for the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->