### PR TITLE
fix(bridge): omit plugin __callback IPC from the network log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `network` no longer records the plugin's own `__callback` IPC. Eval and
+  the bridge hello POST to `ipc://localhost/plugin:pilot|__callback` (URL
+  encoded). Fetch skipped that only when `URL.pathname` was exactly
+  `/plugin:pilot|__callback`, which WebKit does not produce for the `ipc:`
+  scheme, and XHR was never skipped. The skip now matches Tauri's IPC URL
+  shapes on both fetch and XHR. [#156]
+
 - `snapshot` and `snapshot -i` now list div-based interactive elements.
   Hosts with `draggable="true"`, `contenteditable`, an `onclick` attribute or
   property, or `tabindex` were dropped because `ROLE_MAP` has no `DIV` entry,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -752,3 +752,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#153]: https://github.com/mpiton/tauri-pilot/issues/153
 [#154]: https://github.com/mpiton/tauri-pilot/issues/154
 [#155]: https://github.com/mpiton/tauri-pilot/issues/155
+[#156]: https://github.com/mpiton/tauri-pilot/issues/156

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -137,23 +137,37 @@
   // Unix/macOS and `http(s)://ipc.localhost/<cmd>` on Windows/Android.
   // WebKit treats `ipc:` as a non-special scheme, so URL.pathname is
   // `//localhost/<cmd>` rather than `/<cmd>` and an exact-path check misses
-  // the eval/hello callback (#156).
-  function isPilotIpcUrl(url) {
-    const text = String(url);
+  // the eval/hello callback (#156). Match the raw ipc:// string (do not
+  // decode first, do not use URL()) and parse http(s) with URL so a
+  // userinfo form like `https://ipc.localhost@attacker/...` is not skipped.
+  function isPilotCallbackCommand(cmd) {
     let decoded;
     try {
-      decoded = decodeURIComponent(text);
+      decoded = decodeURIComponent(cmd);
     } catch (_) {
-      decoded = text;
+      decoded = cmd;
     }
-    const isIpc =
-      /^ipc:\/\//i.test(decoded) ||
-      /^https?:\/\/ipc\.localhost(?:[:/]|$)/i.test(decoded);
-    if (!isIpc) return false;
-    const path = decoded.split("#")[0].split("?")[0];
-    const slash = path.lastIndexOf("/");
-    const cmd = slash === -1 ? path : path.slice(slash + 1);
-    return cmd === "plugin:pilot|__callback" || cmd === "plugin:pilot|callback";
+    return decoded === "plugin:pilot|__callback" || decoded === "plugin:pilot|callback";
+  }
+
+  function isPilotIpcUrl(url) {
+    const text = String(url);
+    if (/^ipc:/i.test(text)) {
+      const match = text.match(/^ipc:\/\/localhost\/([^/?#]+)(?:[?#]|$)/i);
+      return !!match && isPilotCallbackCommand(match[1]);
+    }
+    if (/^https?:/i.test(text)) {
+      let parsed;
+      try {
+        parsed = new URL(text);
+      } catch (_) {
+        return false;
+      }
+      if (parsed.hostname !== "ipc.localhost") return false;
+      const segments = parsed.pathname.split("/").filter(Boolean);
+      return segments.length === 1 && isPilotCallbackCommand(segments[0]);
+    }
+    return false;
   }
 
   const _originalFetch = window.fetch.bind(window);

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -133,24 +133,27 @@
     return 0;
   }
 
+  // Tauri convertFileSrc(cmd, "ipc") produces `ipc://localhost/<cmd>` on
+  // Unix/macOS and `http(s)://ipc.localhost/<cmd>` on Windows/Android.
+  // WebKit treats `ipc:` as a non-special scheme, so URL.pathname is
+  // `//localhost/<cmd>` rather than `/<cmd>` and an exact-path check misses
+  // the eval/hello callback (#156).
   function isPilotIpcUrl(url) {
     const text = String(url);
-    let path;
-    try {
-      const base = (window.location && window.location.href) || "http://localhost/";
-      path = new URL(text, base).pathname;
-    } catch (_) {
-      const q = text.indexOf("?");
-      path = q === -1 ? text : text.slice(0, q);
-    }
     let decoded;
     try {
-      decoded = decodeURIComponent(path);
+      decoded = decodeURIComponent(text);
     } catch (_) {
-      decoded = path;
+      decoded = text;
     }
-    // Exact IPC path for the two callback commands, not a substring match.
-    return decoded === "/plugin:pilot|callback" || decoded === "/plugin:pilot|__callback";
+    const isIpc =
+      /^ipc:\/\//i.test(decoded) ||
+      /^https?:\/\/ipc\.localhost(?:[:/]|$)/i.test(decoded);
+    if (!isIpc) return false;
+    const path = decoded.split("#")[0].split("?")[0];
+    const slash = path.lastIndexOf("/");
+    const cmd = slash === -1 ? path : path.slice(slash + 1);
+    return cmd === "plugin:pilot|__callback" || cmd === "plugin:pilot|callback";
   }
 
   const _originalFetch = window.fetch.bind(window);
@@ -208,6 +211,9 @@
   };
 
   XMLHttpRequest.prototype.send = function(body) {
+    if (this._pilot && isPilotIpcUrl(this._pilot.url)) {
+      return _origXhrSend.apply(this, arguments);
+    }
     if (this._pilot) {
       const pilot = this._pilot;
       const timestamp = Date.now();

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -164,8 +164,8 @@
         return false;
       }
       if (parsed.hostname !== "ipc.localhost") return false;
-      const segments = parsed.pathname.split("/").filter(Boolean);
-      return segments.length === 1 && isPilotCallbackCommand(segments[0]);
+      const match = parsed.pathname.match(/^\/([^/]+)$/);
+      return !!match && isPilotCallbackCommand(match[1]);
     }
     return false;
   }

--- a/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
@@ -14,7 +14,6 @@ import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
-const OriginalURL = globalThis.URL;
 
 const REAL_CONSOLE = {
   log: console.log.bind(console),
@@ -61,20 +60,8 @@ function makeXhrClass() {
   return XMLHttpRequestStub;
 }
 
-// JSC/WebKit treats `ipc:` as a non-special scheme: `new URL(...).pathname`
-// is `//localhost/plugin:...`, not `/plugin:...`. That is the #156 miss.
-function WebKitIpcURL(text, base) {
-  const raw = String(text);
-  if (/^ipc:/i.test(raw)) {
-    this.pathname = raw.replace(/^ipc:/i, "");
-    return;
-  }
-  this.pathname = new OriginalURL(raw, base).pathname;
-}
-
-function loadBridge({ fetchImpl, URLCtor } = {}) {
+function loadBridge({ fetchImpl } = {}) {
   Object.assign(console, REAL_CONSOLE);
-  if (URLCtor) globalThis.URL = URLCtor;
 
   globalThis.location = { href: "https://app.example/" };
   globalThis.window = {
@@ -93,10 +80,6 @@ function loadBridge({ fetchImpl, URLCtor } = {}) {
   return globalThis.window.__PILOT__;
 }
 
-function restoreGlobals() {
-  globalThis.URL = OriginalURL;
-}
-
 function sendXhr(url, { status = 200, errorEvent } = {}) {
   const xhr = new XMLHttpRequest();
   xhr.open("POST", url);
@@ -109,112 +92,103 @@ function sendXhr(url, { status = 200, errorEvent } = {}) {
 }
 
 test("plugin IPC fetch is omitted from networkRequests", async () => {
-  try {
-    const pilot = loadBridge();
-    for (const url of PILOT_IPC_URLS) {
-      await window.fetch(url);
-    }
-    await window.fetch("https://app.example/api");
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, ["https://app.example/api"]);
-  } finally {
-    restoreGlobals();
+  const pilot = loadBridge();
+  for (const url of PILOT_IPC_URLS) {
+    await window.fetch(url);
   }
-});
-
-test("plugin IPC fetch is omitted when URL.pathname looks like WebKit ipc:", async () => {
-  try {
-    const pilot = loadBridge({ URLCtor: WebKitIpcURL });
-    const ipc = "ipc://localhost/plugin%3Apilot%7C__callback";
-    await window.fetch(ipc);
-    await window.fetch("https://app.example/api");
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, ["https://app.example/api"]);
-  } finally {
-    restoreGlobals();
-  }
+  await window.fetch("https://app.example/api");
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, ["https://app.example/api"]);
 });
 
 test("failed plugin IPC fetch is omitted from failed-only results", async () => {
-  try {
-    const ipc = "ipc://localhost/plugin%3Apilot%7C__callback";
-    const pilot = loadBridge({
-      fetchImpl(input) {
-        if (String(input).includes("plugin")) {
-          return Promise.reject(new Error("denied"));
-        }
-        return Promise.resolve({
-          status: 200,
-          headers: { get() { return "0"; } },
-        });
-      },
-    });
-    await window.fetch(ipc).catch(() => {});
-    assert.deepEqual(pilot.networkRequests(), []);
-    assert.deepEqual(pilot.networkRequests({ failedOnly: true }), []);
-  } finally {
-    restoreGlobals();
-  }
+  const ipc = "ipc://localhost/plugin%3Apilot%7C__callback";
+  const pilot = loadBridge({
+    fetchImpl(input) {
+      if (String(input).includes("plugin")) {
+        return Promise.reject(new Error("denied"));
+      }
+      return Promise.resolve({
+        status: 200,
+        headers: { get() { return "0"; } },
+      });
+    },
+  });
+  await window.fetch(ipc).catch(() => {});
+  assert.deepEqual(pilot.networkRequests(), []);
+  assert.deepEqual(pilot.networkRequests({ failedOnly: true }), []);
 });
 
 test("plugin IPC XHR is omitted from networkRequests", () => {
-  try {
-    const pilot = loadBridge();
-    for (const url of PILOT_IPC_URLS) {
-      sendXhr(url);
-    }
-    sendXhr("https://app.example/api");
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, ["https://app.example/api"]);
-  } finally {
-    restoreGlobals();
+  const pilot = loadBridge();
+  for (const url of PILOT_IPC_URLS) {
+    sendXhr(url);
   }
+  sendXhr("https://app.example/api");
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, ["https://app.example/api"]);
 });
 
 test("failed plugin IPC XHR is omitted from failed-only results", () => {
-  try {
-    const pilot = loadBridge();
-    sendXhr("ipc://localhost/plugin%3Apilot%7C__callback", { errorEvent: "error" });
-    sendXhr("https://app.example/api", { status: 500 });
-    const failed = pilot.networkRequests({ failedOnly: true }).map((e) => e.url);
-    assert.deepEqual(failed, ["https://app.example/api"]);
-  } finally {
-    restoreGlobals();
+  const pilot = loadBridge();
+  sendXhr("ipc://localhost/plugin%3Apilot%7C__callback", { errorEvent: "error" });
+  sendXhr("https://app.example/api", { status: 500 });
+  const failed = pilot.networkRequests({ failedOnly: true }).map((e) => e.url);
+  assert.deepEqual(failed, ["https://app.example/api"]);
+});
+
+test("non-callback IPC URLs stay in the network log", async () => {
+  const pilot = loadBridge();
+  const keep = [
+    "ipc://localhost/plugin%3Aevent%7Cemit",
+    "http://ipc.localhost/plugin%3Afoo%7Cbar",
+    "https://app.example/api",
+  ];
+  for (const url of keep) {
+    await window.fetch(url);
   }
+  for (const url of keep) {
+    sendXhr(url);
+  }
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, keep.concat(keep));
+});
+
+test("userinfo, nested, and encoded-relative callback URLs stay in the log", async () => {
+  const pilot = loadBridge();
+  const keep = [
+    "https://ipc.localhost:443@attacker.example/plugin:pilot|__callback",
+    "https://ipc.localhost/nested/plugin:pilot|__callback",
+    "ipc://evil.example/plugin:pilot|__callback",
+    "ipc%3A%2F%2Flocalhost%2Fplugin%3Apilot%7C__callback",
+  ];
+  for (const url of keep) {
+    await window.fetch(url);
+  }
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, keep);
 });
 
 test("an app URL whose query contains the IPC substring is still recorded", async () => {
-  try {
-    const pilot = loadBridge();
-    const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";
-    await window.fetch(app);
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, [app]);
-  } finally {
-    restoreGlobals();
-  }
+  const pilot = loadBridge();
+  const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";
+  await window.fetch(app);
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, [app]);
 });
 
 test("an app path that only contains the IPC substring is still recorded", async () => {
-  try {
-    const pilot = loadBridge();
-    const app = "https://app.example/api/plugin%3Apilot%7C__callback";
-    await window.fetch(app);
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, [app]);
-  } finally {
-    restoreGlobals();
-  }
+  const pilot = loadBridge();
+  const app = "https://app.example/api/plugin%3Apilot%7C__callback";
+  await window.fetch(app);
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, [app]);
 });
 
 test("an app URL whose path is exactly the IPC command is still recorded", async () => {
-  try {
-    const pilot = loadBridge();
-    const app = "https://app.example/plugin%3Apilot%7C__callback";
-    await window.fetch(app);
-    const urls = pilot.networkRequests().map((e) => e.url);
-    assert.deepEqual(urls, [app]);
-  } finally {
-    restoreGlobals();
-  }
+  const pilot = loadBridge();
+  const app = "https://app.example/plugin%3Apilot%7C__callback";
+  await window.fetch(app);
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, [app]);
 });

--- a/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
@@ -1,4 +1,4 @@
-// Dependency-free tests for network capture skipping Pilot IPC (#153).
+// Dependency-free tests for network capture skipping Pilot IPC (#153, #156).
 //
 // bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
 // real file into a minimal global mock so these tests exercise the shipping
@@ -14,6 +14,7 @@ import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const OriginalURL = globalThis.URL;
 
 const REAL_CONSOLE = {
   log: console.log.bind(console),
@@ -22,12 +23,62 @@ const REAL_CONSOLE = {
   info: console.info.bind(console),
 };
 
-function loadBridge() {
+// Tauri convertFileSrc(cmd, "ipc") shapes. Unix/macOS uses the ipc: scheme;
+// Windows/Android rewrite it to http(s)://ipc.localhost/.
+const PILOT_IPC_URLS = [
+  "ipc://localhost/plugin%3Apilot%7C__callback",
+  "ipc://localhost/plugin%3Apilot%7Ccallback",
+  "ipc://localhost/plugin:pilot|__callback",
+  "http://ipc.localhost/plugin%3Apilot%7C__callback",
+  "https://ipc.localhost/plugin%3Apilot%7C__callback",
+];
+
+function makeXhrClass() {
+  function XMLHttpRequestStub() {
+    this._listeners = Object.create(null);
+    this.status = 0;
+    this.response = "";
+    this.responseType = "";
+  }
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  XMLHttpRequestStub.prototype.addEventListener = function (type, fn) {
+    (this._listeners[type] || (this._listeners[type] = [])).push(fn);
+  };
+  XMLHttpRequestStub.prototype.removeEventListener = function (type, fn) {
+    const list = this._listeners[type];
+    if (!list) return;
+    this._listeners[type] = list.filter((listener) => listener !== fn);
+  };
+  XMLHttpRequestStub.prototype.getResponseHeader = function () {
+    return "0";
+  };
+  XMLHttpRequestStub.prototype.dispatchEvent = function (event) {
+    const list = this._listeners[event.type] || [];
+    for (const listener of list) listener.call(this, event);
+    return true;
+  };
+  return XMLHttpRequestStub;
+}
+
+// JSC/WebKit treats `ipc:` as a non-special scheme: `new URL(...).pathname`
+// is `//localhost/plugin:...`, not `/plugin:...`. That is the #156 miss.
+function WebKitIpcURL(text, base) {
+  const raw = String(text);
+  if (/^ipc:/i.test(raw)) {
+    this.pathname = raw.replace(/^ipc:/i, "");
+    return;
+  }
+  this.pathname = new OriginalURL(raw, base).pathname;
+}
+
+function loadBridge({ fetchImpl, URLCtor } = {}) {
   Object.assign(console, REAL_CONSOLE);
+  if (URLCtor) globalThis.URL = URLCtor;
 
   globalThis.location = { href: "https://app.example/" };
   globalThis.window = {
-    fetch(input) {
+    fetch: fetchImpl || function () {
       return Promise.resolve({
         status: 200,
         headers: { get() { return "0"; } },
@@ -35,36 +86,135 @@ function loadBridge() {
     },
     location: globalThis.location,
   };
-  function XMLHttpRequestStub() {}
-  XMLHttpRequestStub.prototype.open = function () {};
-  XMLHttpRequestStub.prototype.send = function () {};
-  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  globalThis.XMLHttpRequest = makeXhrClass();
   globalThis.document = { querySelector() { return null; } };
 
   (0, eval)(BRIDGE_SRC);
   return globalThis.window.__PILOT__;
 }
 
+function restoreGlobals() {
+  globalThis.URL = OriginalURL;
+}
+
+function sendXhr(url, { status = 200, errorEvent } = {}) {
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", url);
+  xhr.status = status;
+  xhr.responseType = "";
+  xhr.response = "";
+  xhr.send();
+  xhr.dispatchEvent({ type: errorEvent || "load" });
+  return xhr;
+}
+
 test("plugin IPC fetch is omitted from networkRequests", async () => {
-  const pilot = loadBridge();
-  await window.fetch("http://ipc.localhost/plugin%3Apilot%7C__callback");
-  await window.fetch("https://app.example/api");
-  const urls = pilot.networkRequests().map((e) => e.url);
-  assert.deepEqual(urls, ["https://app.example/api"]);
+  try {
+    const pilot = loadBridge();
+    for (const url of PILOT_IPC_URLS) {
+      await window.fetch(url);
+    }
+    await window.fetch("https://app.example/api");
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, ["https://app.example/api"]);
+  } finally {
+    restoreGlobals();
+  }
+});
+
+test("plugin IPC fetch is omitted when URL.pathname looks like WebKit ipc:", async () => {
+  try {
+    const pilot = loadBridge({ URLCtor: WebKitIpcURL });
+    const ipc = "ipc://localhost/plugin%3Apilot%7C__callback";
+    await window.fetch(ipc);
+    await window.fetch("https://app.example/api");
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, ["https://app.example/api"]);
+  } finally {
+    restoreGlobals();
+  }
+});
+
+test("failed plugin IPC fetch is omitted from failed-only results", async () => {
+  try {
+    const ipc = "ipc://localhost/plugin%3Apilot%7C__callback";
+    const pilot = loadBridge({
+      fetchImpl(input) {
+        if (String(input).includes("plugin")) {
+          return Promise.reject(new Error("denied"));
+        }
+        return Promise.resolve({
+          status: 200,
+          headers: { get() { return "0"; } },
+        });
+      },
+    });
+    await window.fetch(ipc).catch(() => {});
+    assert.deepEqual(pilot.networkRequests(), []);
+    assert.deepEqual(pilot.networkRequests({ failedOnly: true }), []);
+  } finally {
+    restoreGlobals();
+  }
+});
+
+test("plugin IPC XHR is omitted from networkRequests", () => {
+  try {
+    const pilot = loadBridge();
+    for (const url of PILOT_IPC_URLS) {
+      sendXhr(url);
+    }
+    sendXhr("https://app.example/api");
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, ["https://app.example/api"]);
+  } finally {
+    restoreGlobals();
+  }
+});
+
+test("failed plugin IPC XHR is omitted from failed-only results", () => {
+  try {
+    const pilot = loadBridge();
+    sendXhr("ipc://localhost/plugin%3Apilot%7C__callback", { errorEvent: "error" });
+    sendXhr("https://app.example/api", { status: 500 });
+    const failed = pilot.networkRequests({ failedOnly: true }).map((e) => e.url);
+    assert.deepEqual(failed, ["https://app.example/api"]);
+  } finally {
+    restoreGlobals();
+  }
 });
 
 test("an app URL whose query contains the IPC substring is still recorded", async () => {
-  const pilot = loadBridge();
-  const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";
-  await window.fetch(app);
-  const urls = pilot.networkRequests().map((e) => e.url);
-  assert.deepEqual(urls, [app]);
+  try {
+    const pilot = loadBridge();
+    const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";
+    await window.fetch(app);
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, [app]);
+  } finally {
+    restoreGlobals();
+  }
 });
 
 test("an app path that only contains the IPC substring is still recorded", async () => {
-  const pilot = loadBridge();
-  const app = "https://app.example/api/plugin%3Apilot%7C__callback";
-  await window.fetch(app);
-  const urls = pilot.networkRequests().map((e) => e.url);
-  assert.deepEqual(urls, [app]);
+  try {
+    const pilot = loadBridge();
+    const app = "https://app.example/api/plugin%3Apilot%7C__callback";
+    await window.fetch(app);
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, [app]);
+  } finally {
+    restoreGlobals();
+  }
+});
+
+test("an app URL whose path is exactly the IPC command is still recorded", async () => {
+  try {
+    const pilot = loadBridge();
+    const app = "https://app.example/plugin%3Apilot%7C__callback";
+    await window.fetch(app);
+    const urls = pilot.networkRequests().map((e) => e.url);
+    assert.deepEqual(urls, [app]);
+  } finally {
+    restoreGlobals();
+  }
 });

--- a/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.network.test.mjs
@@ -169,6 +169,23 @@ test("userinfo, nested, and encoded-relative callback URLs stay in the log", asy
   assert.deepEqual(urls, keep);
 });
 
+test("double-slash and trailing-slash callback URLs stay in the network log", async () => {
+  const pilot = loadBridge();
+  const keep = [
+    "https://ipc.localhost//plugin:pilot|__callback",
+    "https://ipc.localhost/plugin:pilot|__callback/",
+    "http://ipc.localhost/plugin%3Apilot%7C__callback/",
+  ];
+  for (const url of keep) {
+    await window.fetch(url);
+  }
+  for (const url of keep) {
+    sendXhr(url);
+  }
+  const urls = pilot.networkRequests().map((e) => e.url);
+  assert.deepEqual(urls, keep.concat(keep));
+});
+
 test("an app URL whose query contains the IPC substring is still recorded", async () => {
   const pilot = loadBridge();
   const app = "https://app.example/search?q=plugin%3Apilot%7C__callback";

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1108,7 +1108,7 @@ $ tauri-pilot logs --clear
 
 Display or stream captured network requests (`fetch` and `XMLHttpRequest`).
 
-The JS bridge monkey-patches `fetch` and `XMLHttpRequest` and stores entries in a 200-entry ring buffer with timestamp, method, URL, status code, duration, and error details.
+The JS bridge monkey-patches `fetch` and `XMLHttpRequest` and stores entries in a 200-entry ring buffer with timestamp, method, URL, status code, duration, and error details. The plugin's own `__callback` IPC (`ipc://localhost/plugin:pilot|__callback` and the Windows `http(s)://ipc.localhost/...` form) is not recorded.
 
 ```bash
 tauri-pilot network [OPTIONS]


### PR DESCRIPTION
## Summary

- `network` no longer records the plugin's own `__callback` IPC (`ipc://localhost/plugin:pilot|__callback` and the Windows `ipc.localhost` form).
- App requests whose path or query happens to contain that string are still logged.

## Motivation

Every eval and the bridge hello POST to `plugin:pilot|__callback`. Fetch skipped those URLs only when `URL.pathname` was exactly `/plugin:pilot|__callback`. WebKit treats `ipc:` as a non-special scheme, so that pathname is `//localhost/plugin:...` and every observation of the log added another row. XHR was never skipped, and `--failed` treated a callback error as an application failure.

Closes #156

## Changes

- `isPilotIpcUrl` matches Tauri's `convertFileSrc` shapes (`ipc://localhost/<cmd>`, `http(s)://ipc.localhost/<cmd>`) and only the `callback` / `__callback` commands, without using `URL.pathname`.
- The same skip is applied to `XMLHttpRequest`.
- Node tests cover the issue URL, a WebKit-style `URL` mock, XHR, failed IPC, and app URLs that look similar.
- Changelog and CLI reference updated.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Tested manually with a Tauri app (if applicable)

Also: `node --test crates/tauri-plugin-pilot/js/*.test.mjs` (58 passed).

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the network log so the plugin's own `__callback` IPC no longer records entries. Fetch previously skipped these URLs only when `URL.pathname` was exactly `/plugin:pilot|__callback`, which WebKit never produces for the `ipc:` scheme, so every eval and bridge hello POST was logged; XHR was never skipped. The skip now matches only the actual Tauri callback shapes (`ipc://localhost/<cmd>` and `http(s)://ipc.localhost/<cmd>`) for both Fetch and XHR, and failed callback IPC no longer appears under `network --failed`. Look-alikes — other hosts, userinfo tricks, nested paths, double-slash/trailing-slash forms, or app URLs that merely contain the callback string — are still logged. Closes #156.

<sup>Written for commit 39b04685d61b2d793cb534829b36082a137c7fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal IPC callback requests are excluded from captured network results for Fetch and XMLHttpRequest requests.
  * Improved handling of valid, malformed, encoded, and lookalike callback URLs.

* **Documentation**
  * Clarified that internal callback requests are excluded from `network` command results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->