### PR TITLE
fix(bridge): accept CSS selectors and coords on scroll --ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -761,3 +761,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#154]: https://github.com/mpiton/tauri-pilot/issues/154
 [#155]: https://github.com/mpiton/tauri-pilot/issues/155
 [#156]: https://github.com/mpiton/tauri-pilot/issues/156
+[#157]: https://github.com/mpiton/tauri-pilot/issues/157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `scroll --ref` now accepts a CSS selector or `x,y` coordinates, not only a
+  snapshot ref. The bridge used `requireEl`, which looks the value up in the
+  snapshot map, so `scroll down 50 --ref "#log"` raised `Unknown ref: #log`.
+  Scroll now uses `resolveTarget` like click/fill/text, the CLI parses
+  `--target` / `--ref` through `parse_target`, and MCP plus TOML scenario
+  steps follow the same shapes. `--ref` remains an alias of `--target`.
+  Bare snapshot ids (`e12`) still count as refs. [#157]
+
 - `network` no longer records the plugin's own `__callback` IPC. Eval and
   the bridge hello POST to `ipc://localhost/plugin:pilot|__callback` (URL
   encoded). Fetch skipped that only when `URL.pathname` was exactly

--- a/SKILL.md
+++ b/SKILL.md
@@ -93,7 +93,7 @@ Three target formats, auto-detected:
 | `press <key>` | `press Enter` |
 | `select <target> <value>` | `select @e5 "opt1"` |
 | `check <target>` | `check @e6` |
-| `scroll <dir> [amount] [--ref <target>]` | `scroll down 500` |
+| `scroll <dir> [amount] [--target <target>]` | `scroll down 50 --target "#log"` |
 | `drag <source> [target] [--offset X,Y]` | `drag @e5 @e8` |
 | `drop <target> --file <path>` | `drop @e3 --file ./img.png` |
 

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -76,8 +76,9 @@ pub(crate) enum Command {
     Scroll {
         direction: String,
         amount: Option<i32>,
-        #[arg(long)]
-        r#ref: Option<String>,
+        /// Element to scroll: `@ref`, CSS selector, or `x,y`. Defaults to the page.
+        #[arg(long, visible_alias = "ref", value_name = "TARGET")]
+        target: Option<String>,
     },
     /// Drag an element to another element or by offset.
     Drag {
@@ -937,6 +938,52 @@ mod tests {
             assert_eq!(path, std::path::PathBuf::from("/tmp/snap.json"));
         } else {
             panic!("Expected Snapshot command with save");
+        }
+    }
+
+    #[test]
+    fn test_parse_scroll_target_and_ref_alias() {
+        let via_target =
+            Cli::parse_from(["tauri-pilot", "scroll", "down", "50", "--target", "#log"]);
+        let via_ref = Cli::parse_from(["tauri-pilot", "scroll", "down", "50", "--ref", "#log"]);
+        match (via_target.command, via_ref.command) {
+            (
+                Command::Scroll {
+                    direction: d1,
+                    amount: a1,
+                    target: t1,
+                },
+                Command::Scroll {
+                    direction: d2,
+                    amount: a2,
+                    target: t2,
+                },
+            ) => {
+                assert_eq!(d1, "down");
+                assert_eq!(d2, "down");
+                assert_eq!(a1, Some(50));
+                assert_eq!(a2, Some(50));
+                assert_eq!(t1.as_deref(), Some("#log"));
+                assert_eq!(t2.as_deref(), Some("#log"));
+            }
+            _ => panic!("expected Scroll for --target and --ref"),
+        }
+    }
+
+    #[test]
+    fn test_parse_scroll_defaults_to_page() {
+        let cli = Cli::parse_from(["tauri-pilot", "scroll", "top"]);
+        match cli.command {
+            Command::Scroll {
+                direction,
+                amount,
+                target,
+            } => {
+                assert_eq!(direction, "top");
+                assert_eq!(amount, None);
+                assert_eq!(target, None);
+            }
+            _ => panic!("expected Scroll"),
         }
     }
 }

--- a/crates/tauri-pilot-cli/src/cli.rs
+++ b/crates/tauri-pilot-cli/src/cli.rs
@@ -77,7 +77,13 @@ pub(crate) enum Command {
         direction: String,
         amount: Option<i32>,
         /// Element to scroll: `@ref`, CSS selector, or `x,y`. Defaults to the page.
-        #[arg(long, visible_alias = "ref", value_name = "TARGET")]
+        // Signed coords (`-10,20`) look like flags unless hyphen values are allowed.
+        #[arg(
+            long,
+            visible_alias = "ref",
+            value_name = "TARGET",
+            allow_hyphen_values = true
+        )]
         target: Option<String>,
     },
     /// Drag an element to another element or by offset.
@@ -349,6 +355,7 @@ mod tests {
     fn test_parse_target_coords() {
         assert_eq!(parse_target("100,200"), Target::Coords(100, 200));
         assert_eq!(parse_target("0, 0"), Target::Coords(0, 0));
+        assert_eq!(parse_target("-10,20"), Target::Coords(-10, 20));
     }
 
     #[test]
@@ -984,6 +991,20 @@ mod tests {
                 assert_eq!(target, None);
             }
             _ => panic!("expected Scroll"),
+        }
+    }
+
+    #[test]
+    fn test_parse_scroll_negative_coords() {
+        let equals = Cli::parse_from(["tauri-pilot", "scroll", "down", "--target=-10,20"]);
+        let spaced = Cli::parse_from(["tauri-pilot", "scroll", "down", "--target", "-10,20"]);
+        for cli in [equals, spaced] {
+            match cli.command {
+                Command::Scroll {
+                    target: Some(t), ..
+                } => assert_eq!(t, "-10,20"),
+                _ => panic!("expected Scroll with negative coords"),
+            }
         }
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -649,13 +649,13 @@ async fn run_dom_command(
         Command::Scroll {
             direction,
             amount,
-            r#ref,
+            target,
         } => {
             client
                 .call(
                     "scroll",
                     with_window(
-                        Some(json!({"direction": direction, "amount": amount, "ref": r#ref})),
+                        Some(build_scroll_params(&direction, amount, target.as_deref())),
                         window,
                     ),
                 )
@@ -1005,6 +1005,45 @@ pub(crate) fn target_params(raw: &str) -> serde_json::Value {
     }
 }
 
+/// Build params for the `scroll` RPC call.
+///
+/// `target` is optional: omit it to scroll the page. When present it is parsed
+/// through [`target_params`] so `@e12`, a CSS selector, and `x,y` all work,
+/// matching click/fill/text (#157).
+pub(crate) fn build_scroll_params(
+    direction: &str,
+    amount: Option<i32>,
+    target: Option<&str>,
+) -> serde_json::Value {
+    let mut params = match target {
+        Some(raw) => target_params(&normalize_scroll_target(raw)),
+        None => json!({}),
+    };
+    params["direction"] = json!(direction);
+    params["amount"] = json!(amount);
+    params
+}
+
+/// Prefix `@` on bare snapshot ids (`e12`) so they stay refs.
+///
+/// MCP used to advertise "with or without @" and the CLI passed `--ref e12`
+/// straight to `requireEl`. Selectors and coordinates are unchanged.
+fn normalize_scroll_target(raw: &str) -> String {
+    let stripped = raw.strip_prefix('@').unwrap_or(raw);
+    if is_snapshot_ref_id(stripped) {
+        format!("@{stripped}")
+    } else {
+        raw.to_owned()
+    }
+}
+
+fn is_snapshot_ref_id(s: &str) -> bool {
+    let Some(digits) = s.strip_prefix('e') else {
+        return false;
+    };
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
 /// Build params for the `wait` RPC call.
 ///
 /// Routing precedence:
@@ -1334,8 +1373,8 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
             if let Some(amt) = entry.get("amount").and_then(serde_json::Value::as_i64) {
                 let _ = write!(cmd, " {amt}");
             }
-            if let Some(r) = entry.get("ref").and_then(|r| r.as_str()) {
-                let _ = write!(cmd, " --ref {}", shell_escape_ref_target(r));
+            if let Some(t) = resolve_export_target(Some(entry)) {
+                let _ = write!(cmd, " --target {t}");
             }
             cmd
         }
@@ -1952,5 +1991,43 @@ mod tests {
         // rejects immediately instead of hanging on `MutationObserver`.
         let p = build_wait_params(Some("@"), None, false, 1000);
         assert_eq!(p, json!({"gone": false, "timeout": 1000}));
+    }
+
+    #[test]
+    fn test_build_scroll_params_page_when_no_target() {
+        let p = build_scroll_params("down", Some(50), None);
+        assert_eq!(p, json!({"direction": "down", "amount": 50}));
+        assert!(p.get("ref").is_none());
+        assert!(p.get("selector").is_none());
+    }
+
+    #[test]
+    fn test_build_scroll_params_at_prefix_routes_to_ref() {
+        let p = build_scroll_params("up", Some(20), Some("@e12"));
+        assert_eq!(p, json!({"ref": "e12", "direction": "up", "amount": 20}));
+    }
+
+    #[test]
+    fn test_build_scroll_params_bare_snapshot_id_stays_ref() {
+        let p = build_scroll_params("down", Some(50), Some("e12"));
+        assert_eq!(p, json!({"ref": "e12", "direction": "down", "amount": 50}));
+    }
+
+    #[test]
+    fn test_build_scroll_params_css_selector() {
+        let p = build_scroll_params("down", Some(50), Some("#log"));
+        assert_eq!(
+            p,
+            json!({"selector": "#log", "direction": "down", "amount": 50})
+        );
+    }
+
+    #[test]
+    fn test_build_scroll_params_coords() {
+        let p = build_scroll_params("left", None, Some("100,200"));
+        assert_eq!(
+            p,
+            json!({"x": 100, "y": 200, "direction": "left", "amount": null})
+        );
     }
 }

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -1374,7 +1374,8 @@ fn entry_to_cli_command(action: &str, entry: &Value) -> String {
                 let _ = write!(cmd, " {amt}");
             }
             if let Some(t) = resolve_export_target(Some(entry)) {
-                let _ = write!(cmd, " --target {t}");
+                // Equals form so a signed coord (`-10,20`) is not a new flag.
+                let _ = write!(cmd, " --target={t}");
             }
             cmd
         }
@@ -2028,6 +2029,29 @@ mod tests {
         assert_eq!(
             p,
             json!({"x": 100, "y": 200, "direction": "left", "amount": null})
+        );
+    }
+
+    #[test]
+    fn test_entry_to_cli_command_scroll_emits_target() {
+        assert_eq!(
+            entry_to_cli_command(
+                "scroll",
+                &json!({"direction": "down", "amount": 50, "ref": "e12"})
+            ),
+            "tauri-pilot scroll 'down' 50 --target='@e12'"
+        );
+        assert_eq!(
+            entry_to_cli_command("scroll", &json!({"direction": "down", "selector": "#log"})),
+            "tauri-pilot scroll 'down' --target='#log'"
+        );
+        assert_eq!(
+            entry_to_cli_command("scroll", &json!({"direction": "up", "x": 100, "y": 200})),
+            "tauri-pilot scroll 'up' --target=100,200"
+        );
+        assert_eq!(
+            entry_to_cli_command("scroll", &json!({"direction": "down", "x": -10, "y": 20})),
+            "tauri-pilot scroll 'down' --target=-10,20"
         );
     }
 }

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -1881,6 +1881,65 @@ mod tests {
     }
 
     #[test]
+    fn optional_scroll_target_accepts_target_or_ref() {
+        let mut target_only = Map::new();
+        target_only.insert("target".to_owned(), json!("#log"));
+        assert_eq!(
+            optional_scroll_target(&target_only).expect("target"),
+            Some("#log".to_owned())
+        );
+
+        let mut ref_only = Map::new();
+        ref_only.insert("ref".to_owned(), json!("e1"));
+        assert_eq!(
+            optional_scroll_target(&ref_only).expect("ref"),
+            Some("e1".to_owned())
+        );
+
+        let empty = Map::new();
+        assert_eq!(optional_scroll_target(&empty).expect("neither"), None);
+
+        let mut both = Map::new();
+        both.insert("target".to_owned(), json!("#log"));
+        both.insert("ref".to_owned(), json!("e1"));
+        let err = optional_scroll_target(&both).expect_err("both set");
+        assert!(
+            err.message.contains("not both"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn optional_scroll_target_ref_selector_builds_selector_params() {
+        let mut args = Map::new();
+        args.insert("ref".to_owned(), json!("#log"));
+        let target = optional_scroll_target(&args).expect("ref alias");
+        let params = build_scroll_params("down", Some(50), target.as_deref());
+        assert_eq!(
+            params,
+            json!({"selector": "#log", "direction": "down", "amount": 50})
+        );
+    }
+
+    #[tokio::test]
+    async fn scroll_rejects_target_and_ref_together() {
+        let mut args = Map::new();
+        args.insert("target".to_owned(), json!("#log"));
+        args.insert("ref".to_owned(), json!("e1"));
+        let err = PilotMcpServer::new(None, None)
+            .call_tool_by_name("scroll", args)
+            .await
+            .expect_err("both set");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("not both"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn pilot_screenshot_tool_advertises_path_only_contract() {
         let tool = cached_tools()
             .iter()

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -19,8 +19,8 @@ use rmcp::{
 use serde_json::{Map, Value, json};
 
 use crate::{
-    build_wait_params, client::Client, export_replay_file, resolve_socket, run_drop_command,
-    run_replay_command, target_params, with_window,
+    build_scroll_params, build_wait_params, client::Client, export_replay_file, resolve_socket,
+    run_drop_command, run_replay_command, target_params, with_window,
 };
 
 #[derive(Debug, Clone)]
@@ -135,8 +135,8 @@ impl PilotMcpServer {
             "ping" => self.call_app_tool("ping", None, window).await,
             "windows" => self.call_app_tool("windows.list", None, None).await,
             "state" => self.call_app_tool("state", None, window).await,
-            "snapshot" => self
-                .call_app_tool(
+            "snapshot" => {
+                self.call_app_tool(
                     "snapshot",
                     Some(json!({
                         "interactive": optional_bool(&args, "interactive")?.unwrap_or(false),
@@ -145,7 +145,8 @@ impl PilotMcpServer {
                     })),
                     window,
                 )
-                .await,
+                .await
+            }
             "diff" => {
                 let mut params = json!({
                     "interactive": optional_bool(&args, "interactive")?.unwrap_or(false),
@@ -183,13 +184,14 @@ impl PilotMcpServer {
             }
             "check" => self.target_call("check", &args, window).await,
             "scroll" => {
+                let target = optional_scroll_target(&args)?;
                 self.call_app_tool(
                     "scroll",
-                    Some(json!({
-                        "direction": optional_string(&args, "direction")?.unwrap_or_else(|| "down".to_owned()),
-                        "amount": optional_i32(&args, "amount")?,
-                        "ref": optional_ref(&args)?,
-                    })),
+                    Some(build_scroll_params(
+                        &optional_string(&args, "direction")?.unwrap_or_else(|| "down".to_owned()),
+                        optional_i32(&args, "amount")?,
+                        target.as_deref(),
+                    )),
                     window,
                 )
                 .await
@@ -227,8 +229,7 @@ impl PilotMcpServer {
             "drop" => self.call_drop_tool(args, window).await,
             "text" => self.target_call("text", &args, window).await,
             "html" => {
-                let params =
-                    optional_string(&args, "target")?.map(|target| target_params(&target));
+                let params = optional_string(&args, "target")?.map(|target| target_params(&target));
                 self.call_app_tool("html", params, window).await
             }
             "value" => self.target_call("value", &args, window).await,
@@ -274,12 +275,8 @@ impl PilotMcpServer {
             "navigate" => {
                 let url = required_string(&args, "url")?;
                 validate_navigate_url(&url)?;
-                self.call_app_tool(
-                    "navigate",
-                    Some(json!({ "url": url })),
-                    window,
-                )
-                .await
+                self.call_app_tool("navigate", Some(json!({ "url": url })), window)
+                    .await
             }
             "url" => self.call_app_tool("url", None, window).await,
             "title" => self.call_app_tool("title", None, window).await,
@@ -301,7 +298,8 @@ impl PilotMcpServer {
                 if optional_bool(&args, "require_mutation")?.unwrap_or(false) {
                     watch_params["requireMutation"] = json!(true);
                 }
-                self.call_app_tool("watch", Some(watch_params), window).await
+                self.call_app_tool("watch", Some(watch_params), window)
+                    .await
             }
             "logs" => self.call_logs_tool(&args, window).await,
             "network" => self.call_network_tool(&args, window).await,
@@ -345,8 +343,8 @@ impl PilotMcpServer {
                 .await
             }
             "forms" => {
-                let params =
-                    optional_string(&args, "selector")?.map(|selector| json!({ "selector": selector }));
+                let params = optional_string(&args, "selector")?
+                    .map(|selector| json!({ "selector": selector }));
                 self.call_app_tool("forms.dump", params, window).await
             }
             "assert_text" => self.assert_text(args, window, false).await,
@@ -898,7 +896,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "scroll",
-            description: "Scroll the page or an element ref.",
+            description: "Scroll the page or an element (ref, CSS selector, or coordinates).",
             schema: scroll_schema,
             read_only: false,
             destructive: false,
@@ -1225,10 +1223,15 @@ fn optional_bool(args: &JsonObject, name: &str) -> Result<Option<bool>, McpError
     }
 }
 
-fn optional_ref(args: &JsonObject) -> Result<Option<String>, McpError> {
-    match optional_string(args, "ref")? {
-        Some(value) => Ok(Some(value.trim_start_matches('@').to_owned())),
-        None => Ok(None),
+fn optional_scroll_target(args: &JsonObject) -> Result<Option<String>, McpError> {
+    let target = optional_string(args, "target")?;
+    let r#ref = optional_string(args, "ref")?;
+    match (target, r#ref) {
+        (Some(_), Some(_)) => Err(invalid_params(
+            "scroll accepts either 'target' or 'ref', not both",
+        )),
+        (Some(value), None) | (None, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
     }
 }
 
@@ -1405,8 +1408,16 @@ fn scroll_schema() -> Arc<JsonObject> {
             ),
             ("amount", integer_prop("Pixel amount to scroll.")),
             (
+                "target",
+                string_prop(
+                    "Optional element `@ref`, CSS selector, or x,y coordinates. Defaults to the page.",
+                ),
+            ),
+            (
                 "ref",
-                string_prop("Optional element ref, with or without @."),
+                string_prop(
+                    "Alias of target. Snapshot refs accept e12 or @e12; selectors and coordinates also work.",
+                ),
             ),
         ]),
         &[],
@@ -1850,6 +1861,23 @@ mod tests {
                 "scroll direction enum must include {expected}"
             );
         }
+    }
+
+    #[test]
+    fn scroll_schema_accepts_target_and_ref_alias() {
+        let schema = scroll_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("schema has properties");
+        assert!(
+            properties.contains_key("target"),
+            "scroll schema must advertise `target`"
+        );
+        assert!(
+            properties.contains_key("ref"),
+            "scroll schema must keep `ref` as an alias of `target`"
+        );
     }
 
     #[test]

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -445,19 +445,14 @@ fn require_target(step: &Step) -> Result<&str> {
 
 /// Resolve the optional scroll target from a TOML step.
 ///
-/// `target` uses the same `@ref` / CSS / `x,y` syntax as click. `ref = "e1"`
-/// is the established snapshot-ref field (same as `wait`) and is rewritten to
-/// `@e1` so [`build_scroll_params`] routes it as a ref. Setting both is an
-/// error.
+/// `target` and `ref` are aliases: both keep the raw `@ref` / CSS / `x,y`
+/// value. [`build_scroll_params`] classifies bare snapshot ids (`e1`). Setting
+/// both is an error.
 fn scroll_step_target(step: &Step) -> Result<Option<String>> {
     match (step.target.as_deref(), step.step_ref.as_deref()) {
         (Some(_), Some(_)) => anyhow::bail!("scroll step sets both `target` and `ref`; pick one"),
         (Some(target), None) => Ok(Some(target.to_owned())),
-        (None, Some(r)) => Ok(Some(if r.starts_with('@') {
-            r.to_owned()
-        } else {
-            format!("@{r}")
-        })),
+        (None, Some(r)) => Ok(Some(r.to_owned())),
         (None, None) => Ok(None),
     }
 }
@@ -882,6 +877,16 @@ ref = "e1"
 action = "scroll"
 target = "#log"
 amount = 50
+
+[[step]]
+action = "scroll"
+direction = "down"
+ref = "#log"
+
+[[step]]
+action = "scroll"
+direction = "left"
+ref = "100,200"
 "##,
         )
         .expect("valid toml");
@@ -889,13 +894,29 @@ amount = 50
             scroll_step_target(&scenario.step[0])
                 .expect("ref step")
                 .as_deref(),
-            Some("@e1")
+            Some("e1")
+        );
+        assert_eq!(
+            build_scroll_params("down", None, Some("e1")),
+            json!({"ref": "e1", "direction": "down", "amount": null})
         );
         assert_eq!(
             scroll_step_target(&scenario.step[1])
                 .expect("target step")
                 .as_deref(),
             Some("#log")
+        );
+        assert_eq!(
+            scroll_step_target(&scenario.step[2])
+                .expect("ref selector")
+                .as_deref(),
+            Some("#log")
+        );
+        assert_eq!(
+            scroll_step_target(&scenario.step[3])
+                .expect("ref coords")
+                .as_deref(),
+            Some("100,200")
         );
     }
 

--- a/crates/tauri-pilot-cli/src/scenario.rs
+++ b/crates/tauri-pilot-cli/src/scenario.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use crate::client::Client;
-use crate::{build_wait_params, target_params, with_window};
+use crate::{build_scroll_params, build_wait_params, target_params, with_window};
 
 // ── TOML schema ──────────────────────────────────────────────────────────────
 
@@ -269,16 +269,16 @@ async fn dispatch_step(client: &mut Client, step: &Step, window: Option<&str>) -
                 .await
         }
         "scroll" => {
-            let direction = step.direction.as_deref().unwrap_or("down");
+            let target = scroll_step_target(step)?;
             client
                 .call(
                     "scroll",
                     with_window(
-                        Some(json!({
-                            "direction": direction,
-                            "amount": step.amount,
-                            "ref": step.step_ref,
-                        })),
+                        Some(build_scroll_params(
+                            step.direction.as_deref().unwrap_or("down"),
+                            step.amount,
+                            target.as_deref(),
+                        )),
                         window,
                     ),
                 )
@@ -441,6 +441,25 @@ fn require_target(step: &Step) -> Result<&str> {
     step.target
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("step '{}' requires 'target'", step.action))
+}
+
+/// Resolve the optional scroll target from a TOML step.
+///
+/// `target` uses the same `@ref` / CSS / `x,y` syntax as click. `ref = "e1"`
+/// is the established snapshot-ref field (same as `wait`) and is rewritten to
+/// `@e1` so [`build_scroll_params`] routes it as a ref. Setting both is an
+/// error.
+fn scroll_step_target(step: &Step) -> Result<Option<String>> {
+    match (step.target.as_deref(), step.step_ref.as_deref()) {
+        (Some(_), Some(_)) => anyhow::bail!("scroll step sets both `target` and `ref`; pick one"),
+        (Some(target), None) => Ok(Some(target.to_owned())),
+        (None, Some(r)) => Ok(Some(if r.starts_with('@') {
+            r.to_owned()
+        } else {
+            format!("@{r}")
+        })),
+        (None, None) => Ok(None),
+    }
 }
 
 // ── Screenshot on failure ─────────────────────────────────────────────────────
@@ -848,5 +867,50 @@ action = "ping"
         assert!(xml.contains(r#"skipped="1""#));
         assert!(xml.contains(r#"message="oops &amp; done""#));
         assert!(xml.contains("<skipped"));
+    }
+
+    #[test]
+    fn test_scroll_step_target_from_toml_ref_and_selector() {
+        let scenario: Scenario = toml::from_str(
+            r##"
+[[step]]
+action = "scroll"
+direction = "down"
+ref = "e1"
+
+[[step]]
+action = "scroll"
+target = "#log"
+amount = 50
+"##,
+        )
+        .expect("valid toml");
+        assert_eq!(
+            scroll_step_target(&scenario.step[0])
+                .expect("ref step")
+                .as_deref(),
+            Some("@e1")
+        );
+        assert_eq!(
+            scroll_step_target(&scenario.step[1])
+                .expect("target step")
+                .as_deref(),
+            Some("#log")
+        );
+    }
+
+    #[test]
+    fn test_scroll_step_rejects_both_target_and_ref() {
+        let scenario: Scenario = toml::from_str(
+            r##"
+[[step]]
+action = "scroll"
+target = "#log"
+ref = "e1"
+"##,
+        )
+        .expect("valid toml");
+        let err = scroll_step_target(&scenario.step[0]).expect_err("both set");
+        assert!(err.to_string().contains("both `target` and `ref`"));
     }
 }

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -797,8 +797,12 @@
   function scroll(options) {
     const dir = (options && options.direction) || "down";
     const amount = (options && options.amount) || 300;
-    const ref = options && options.ref;
-    const target = ref ? requireEl(ref) : window;
+    // Same target shapes as click/fill/text: snapshot ref, CSS selector, or
+    // coordinates. No target still means the page (`window`), which is why
+    // this cannot call `resolveTarget` unconditionally (#157).
+    const target = (options && (options.ref || options.selector || (options.x != null && options.y != null)))
+      ? resolveTarget(options)
+      : window;
 
     if (dir === "top") {
       if (target === window) {

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -794,15 +794,50 @@
     return { ok: true };
   }
 
+  function overflowValue(style, axis) {
+    if (!style) return "";
+    return style[axis] || style.overflow || "";
+  }
+
+  function axisCanScroll(el, style, axis, scrollSize, clientSize) {
+    var overflow = overflowValue(style, axis);
+    return (overflow === "auto" || overflow === "scroll" || overflow === "overlay")
+      && el[scrollSize] > el[clientSize];
+  }
+
+  function canScroll(el) {
+    if (!el || el === window) return false;
+    var style = null;
+    if (typeof window.getComputedStyle === "function") {
+      style = window.getComputedStyle(el);
+    }
+    if (!style) style = el.style;
+    return axisCanScroll(el, style, "overflowY", "scrollHeight", "clientHeight")
+      || axisCanScroll(el, style, "overflowX", "scrollWidth", "clientWidth");
+  }
+
+  // Coords resolve to the topmost node at the point, usually a child inside
+  // the scroller. scrollTop/scrollBy on that child is a no-op.
+  function nearestScrollTarget(el) {
+    if (!el || el === window) return el;
+    var node = el;
+    while (node && node !== document && node !== document.documentElement && node !== document.body) {
+      if (canScroll(node)) return node;
+      node = node.parentElement;
+    }
+    return el;
+  }
+
   function scroll(options) {
     const dir = (options && options.direction) || "down";
     const amount = (options && options.amount) || 300;
     // Same target shapes as click/fill/text: snapshot ref, CSS selector, or
     // coordinates. No target still means the page (`window`), which is why
     // this cannot call `resolveTarget` unconditionally (#157).
-    const target = (options && (options.ref || options.selector || (options.x != null && options.y != null)))
+    const resolved = (options && (options.ref || options.selector || (options.x != null && options.y != null)))
       ? resolveTarget(options)
       : window;
+    const target = nearestScrollTarget(resolved);
 
     if (dir === "top") {
       if (target === window) {

--- a/crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs
@@ -1,0 +1,142 @@
+// Dependency-free behavioural tests for bridge `scroll` (#157).
+//
+// `scroll --ref` used to look the value up only in the snapshot id map, so a
+// CSS selector like `#log` raised `Unknown ref`. Other target-taking commands
+// go through `resolveTarget` (`ref` / `selector` / `x,y`). Scroll must do the
+// same, and still default to `window` when no target is given.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function makeScroller() {
+  return {
+    tagName: "DIV",
+    scrollTop: 40,
+    scrollLeft: 0,
+    scrollHeight: 1000,
+    clientHeight: 200,
+    clientWidth: 200,
+    scrollWidth: 400,
+    calls: [],
+    scrollBy(dx, dy) {
+      this.calls.push(["scrollBy", dx, dy]);
+      this.scrollLeft += dx;
+      this.scrollTop += dy;
+    },
+    scrollTo(x, y) {
+      this.calls.push(["scrollTo", x, y]);
+      this.scrollLeft = x;
+      this.scrollTop = y;
+    },
+  };
+}
+
+function loadBridge({ queryResult, fromPoint } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+  const windowCalls = [];
+  globalThis.window = {
+    fetch() {},
+    scrollX: 12,
+    scrollY: 80,
+    innerHeight: 600,
+    calls: windowCalls,
+    scrollBy(dx, dy) {
+      windowCalls.push(["scrollBy", dx, dy]);
+    },
+    scrollTo(x, y) {
+      windowCalls.push(["scrollTo", x, y]);
+    },
+  };
+  globalThis.document = {
+    documentElement: { scrollHeight: 2000, clientHeight: 600 },
+    body: { scrollHeight: 1800 },
+    querySelector(selector) {
+      if (queryResult === undefined) {
+        throw new Error("unexpected querySelector(" + selector + ")");
+      }
+      return queryResult;
+    },
+    elementFromPoint(x, y) {
+      if (typeof fromPoint === "function") return fromPoint(x, y);
+      return fromPoint === undefined ? null : fromPoint;
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+test("scroll with no target scrolls the window", () => {
+  const pilot = loadBridge();
+  assert.deepEqual(pilot.scroll({ direction: "down", amount: 50 }), { ok: true });
+  assert.deepEqual(globalThis.window.calls, [["scrollBy", 0, 50]]);
+});
+
+test("scroll with a CSS selector scrolls that element (#157)", () => {
+  const el = makeScroller();
+  const pilot = loadBridge({ queryResult: el });
+  assert.deepEqual(pilot.scroll({ direction: "down", amount: 50, selector: "#log" }), {
+    ok: true,
+  });
+  assert.deepEqual(el.calls, [["scrollBy", 0, 50]]);
+  assert.deepEqual(globalThis.window.calls, []);
+});
+
+test("scroll throws when the selector matches nothing", () => {
+  const pilot = loadBridge({ queryResult: null });
+  assert.throws(
+    () => pilot.scroll({ direction: "down", selector: "#missing" }),
+    /No element matches selector: #missing/,
+  );
+});
+
+test("scroll with coordinates scrolls the element at that point", () => {
+  const el = makeScroller();
+  const pilot = loadBridge({ fromPoint: el });
+  assert.deepEqual(pilot.scroll({ direction: "up", amount: 20, x: 10, y: 40 }), {
+    ok: true,
+  });
+  assert.deepEqual(el.calls, [["scrollBy", 0, -20]]);
+});
+
+test("scroll throws when no element is at the coordinates", () => {
+  const pilot = loadBridge({ fromPoint: null });
+  assert.throws(
+    () => pilot.scroll({ direction: "down", x: 1, y: 2 }),
+    /No element at \(1,2\)/,
+  );
+});
+
+test("scroll with an unknown snapshot ref still throws", () => {
+  const pilot = loadBridge();
+  assert.throws(
+    () => pilot.scroll({ direction: "down", ref: "e12" }),
+    /Unknown ref: e12/,
+  );
+});
+
+test("scroll top/bottom on a selector set scrollTop", () => {
+  const el = makeScroller();
+  const pilot = loadBridge({ queryResult: el });
+  assert.deepEqual(pilot.scroll({ direction: "top", selector: "#log" }), { ok: true });
+  assert.equal(el.scrollTop, 0);
+  assert.deepEqual(pilot.scroll({ direction: "bottom", selector: "#log" }), { ok: true });
+  assert.equal(el.scrollTop, 800);
+});

--- a/crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs
@@ -31,6 +31,8 @@ function makeScroller() {
     clientHeight: 200,
     clientWidth: 200,
     scrollWidth: 400,
+    style: { overflow: "auto", overflowY: "auto", overflowX: "auto" },
+    parentElement: null,
     calls: [],
     scrollBy(dx, dy) {
       this.calls.push(["scrollBy", dx, dy]);
@@ -59,6 +61,9 @@ function loadBridge({ queryResult, fromPoint } = {}) {
     },
     scrollTo(x, y) {
       windowCalls.push(["scrollTo", x, y]);
+    },
+    getComputedStyle(el) {
+      return (el && el.style) || { overflow: "", overflowX: "", overflowY: "" };
     },
   };
   globalThis.document = {
@@ -114,6 +119,31 @@ test("scroll with coordinates scrolls the element at that point", () => {
     ok: true,
   });
   assert.deepEqual(el.calls, [["scrollBy", 0, -20]]);
+});
+
+test("scroll with coordinates walks up to the nearest scroller", () => {
+  const scroller = makeScroller();
+  const child = {
+    tagName: "SPAN",
+    scrollTop: 0,
+    scrollLeft: 0,
+    scrollHeight: 16,
+    clientHeight: 16,
+    scrollWidth: 40,
+    clientWidth: 40,
+    style: { overflow: "visible", overflowY: "visible", overflowX: "visible" },
+    parentElement: scroller,
+    calls: [],
+    scrollBy(dx, dy) {
+      this.calls.push(["scrollBy", dx, dy]);
+    },
+  };
+  const pilot = loadBridge({ fromPoint: child });
+  assert.deepEqual(pilot.scroll({ direction: "down", amount: 50, x: 10, y: 40 }), {
+    ok: true,
+  });
+  assert.deepEqual(scroller.calls, [["scrollBy", 0, 50]]);
+  assert.deepEqual(child.calls, []);
 });
 
 test("scroll throws when no element is at the coordinates", () => {

--- a/crates/tauri-plugin-pilot/src/lib.rs
+++ b/crates/tauri-plugin-pilot/src/lib.rs
@@ -302,6 +302,27 @@ mod tests {
 
     #[cfg(all(any(unix, windows), debug_assertions))]
     #[test]
+    fn bridge_scroll_resolves_selector_and_coords() {
+        // #157: scroll used requireEl(ref) only. It must go through
+        // resolveTarget so CSS selectors and coordinates work, while still
+        // defaulting to window when no target is given.
+        let body = bridge_fn_body(super::BRIDGE_JS, "function scroll(");
+        assert!(
+            body.contains("resolveTarget(options)"),
+            "scroll must resolve targets via resolveTarget"
+        );
+        assert!(
+            !body.contains("requireEl("),
+            "scroll must not look refs up itself; resolveTarget does that"
+        );
+        assert!(
+            body.contains("options.selector") && body.contains("options.x"),
+            "scroll must detect selector and coordinate targets before calling resolveTarget"
+        );
+    }
+
+    #[cfg(all(any(unix, windows), debug_assertions))]
+    #[test]
     fn bridge_eval_auto_wraps_top_level_await() {
         // #79: top-level `await` in user scripts must compile via the
         // async-IIFE fallback stages instead of crashing with an opaque

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -504,7 +504,7 @@ tauri-pilot scroll <direction> [amount] [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ref <ref>` | Element to scroll (defaults to the page) |
+| `--target <target>` | Element to scroll: `@ref`, CSS selector, or `x,y`. Defaults to the page. `--ref` is an alias. |
 
 `top` jumps to `scrollY = 0`; `bottom` jumps to the maximum scroll position (`scrollHeight - innerHeight` for the page, `scrollHeight - clientHeight` for an element). Unknown directions raise an error instead of silently no-op.
 
@@ -512,7 +512,8 @@ tauri-pilot scroll <direction> [amount] [OPTIONS]
 
 ```bash
 tauri-pilot scroll down 500
-tauri-pilot scroll up --ref @e4
+tauri-pilot scroll up --target @e4
+tauri-pilot scroll down 50 --target "#log"
 tauri-pilot scroll top
 tauri-pilot scroll bottom --ref @e4
 ```


### PR DESCRIPTION
## Summary

- `scroll --ref` now accepts a CSS selector or `x,y` coordinates, not only a snapshot ref.
- `--target` is the canonical flag; `--ref` stays as an alias.

## Motivation

`requireEl` looked the value up in the snapshot map, so `scroll down 50 --ref "#log"` raised `Unknown ref: #log`. Every other target-taking command already goes through `parse_target` / `resolveTarget`. Combined with #155, an inner scrollable `<div>` with no snapshot ref was unreachable.

Closes #157

## Changes

- Bridge `scroll` uses `resolveTarget` when a target is present and still defaults to the page.
- CLI `--target` / `--ref`, MCP `target` / `ref`, and TOML `target` / `ref` all route through `parse_target`.
- Bare snapshot ids (`e12`) still count as refs.
- Replay export writes `--target` for ref, selector, or coords.
- Node tests for selector/coords paths; CLI/MCP/scenario unit tests; changelog and CLI docs.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Tested manually with a Tauri app (if applicable)

Also: `node --test crates/tauri-plugin-pilot/js/bridge.scroll.test.mjs` (and check/fill/select).

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`scroll --ref` now accepts CSS selectors and `x,y` coordinates (signed values like `-10,20` included) in addition to snapshot refs, so `scroll down 50 --ref "#log"` scrolls the element instead of raising `Unknown ref`. Coordinate hits walk up to the nearest scrollable ancestor, bare snapshot ids like `e12` still work, and `--target` is now the canonical flag with `--ref` kept as an alias.

- CLI, MCP, and TOML scenario forms all route through the same target parsing; replay export writes `--target=` so signed coords aren't parsed as flags.

<sup>Written for commit 4a5cb1436234c3a1bb91d887aade74b2f132d48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `scroll` command now supports targeting elements by CSS selector, coordinates, or snapshot ID.
  - Targeted scrolling is available consistently across the CLI, MCP, bridge, and scenario interfaces.
  - Page-level scrolling remains available when no target is provided.
  - `--target` is now the preferred option, with `--ref` retained as an alias.

- **Documentation**
  - Updated usage guides and examples to document the new target formats and option name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->