### PR TITLE
fix(bridge): report all selected options of a multi-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `value` and `snapshot` now report every selected option of a
+  `<select multiple>`, joined with `", "` like the `forms` CLI
+  (`skills = "rust, js"`). Both used `HTMLSelectElement.value`, which is
+  only the first selected option, so a multi-select with `rust` and `js`
+  selected looked like `rust`. `forms.dump` still returns the JSON array.
+  [#158]
+
 - `scroll --ref` now accepts a CSS selector or `x,y` coordinates, not only a
   snapshot ref. The bridge used `requireEl`, which looks the value up in the
   snapshot map, so `scroll down 50 --ref "#log"` raised `Unknown ref: #log`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,7 +80,7 @@ Three target formats, auto-detected:
 | `diff --ref file.snap` | Diff against a saved snapshot |
 | `text <target>` | Get text content |
 | `html [target]` | Get innerHTML (page if no target) |
-| `value <target>` | Get input value |
+| `value <target>` | Get input/select value (multi-select: all selected, joined with `, `) |
 | `attrs <target>` | Get all attributes |
 
 ### Interaction

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -457,8 +457,10 @@
         // `value` is an IDL property whose type varies by element: a string for
         // form controls, but a number for `<li>` (ordinal), `<progress>`, and
         // `<meter>`. Coerce to string so the wire format matches the plugin's
-        // `SnapshotElement.value: Option<String>` contract (#120).
-        if (node.value !== undefined && node.value !== "") entry.value = String(node.value);
+        // `SnapshotElement.value: Option<String>` contract (#120). Multi-select
+        // joins every selected option (#158).
+        const nodeVal = elementValue(node);
+        if (nodeVal !== undefined && nodeVal !== "") entry.value = String(nodeVal);
         if (node.tagName === "INPUT") {
           var inputType = (node.getAttribute("type") || "text").toLowerCase();
           if (inputType === "checkbox" || inputType === "radio") {
@@ -1063,8 +1065,30 @@
     return document.documentElement.innerHTML;
   }
 
+  // Selected option values in tree order. `HTMLSelectElement.value` is only
+  // the first; `forms.dump` already walks `.options` this way (#158).
+  function selectedOptionValues(el) {
+    const selected = [];
+    const options = el && el.options;
+    if (!options) return selected;
+    for (let k = 0; k < options.length; k++) {
+      if (options[k].selected) selected.push(options[k].value);
+    }
+    return selected;
+  }
+
+  // Display value for `value` / `snapshot`. Multi-select joins with `", "`
+  // so the string matches the `forms` CLI (`skills = "rust, js"`). Other
+  // elements keep their IDL `.value` (including numeric `<li>` ordinals).
+  function elementValue(el) {
+    if (el && el.tagName && el.tagName.toLowerCase() === "select" && el.multiple) {
+      return selectedOptionValues(el).join(", ");
+    }
+    return el ? el.value : undefined;
+  }
+
   function value(params) {
-    return resolveTarget(params).value || "";
+    return elementValue(resolveTarget(params)) || "";
   }
 
   function attrs(params) {
@@ -1597,13 +1621,7 @@
         var elType = el.type || null;
         var fieldVal;
         if (tag === "select" && el.multiple) {
-          var selected = [];
-          for (var k = 0; k < el.options.length; k++) {
-            if (el.options[k].selected) {
-              selected.push(el.options[k].value);
-            }
-          }
-          fieldVal = selected;
+          fieldVal = selectedOptionValues(el);
         } else {
           fieldVal = el.value;
         }

--- a/crates/tauri-plugin-pilot/js/bridge.value.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.value.test.mjs
@@ -1,0 +1,182 @@
+// Dependency-free behavioural tests for bridge `value` / `snapshot` on
+// `<select multiple>` (#158).
+//
+// `HTMLSelectElement.value` is the first selected option only. `forms.dump`
+// already walks selected options; `value` and `snapshot` used the IDL
+// property, so a multi-select with `rust` and `js` both selected reported
+// only `rust`. The three commands must agree: `value` and `snapshot` join
+// selected option values with `", "`, matching the `forms` CLI display.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.value.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function attrs(el) {
+  return {
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(el._attrs, name)
+        ? el._attrs[name]
+        : null;
+    },
+    hasAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(el._attrs, name);
+    },
+  };
+}
+
+// Spec-faithful `.value`: first selected option, or "" if none. That is the
+// IDL getter the bug was reading. Selected options live on `.options`.
+function makeSelect({ multiple, options, name = "skills" }) {
+  const opts = options.map((o) => ({ value: o.value, selected: !!o.selected }));
+  const el = {
+    tagName: "SELECT",
+    nodeType: 1,
+    children: [],
+    textContent: opts.map((o) => o.value).join(" "),
+    name,
+    type: multiple ? "select-multiple" : "select-one",
+    multiple: !!multiple,
+    _attrs: { name },
+    get options() {
+      return opts;
+    },
+    get value() {
+      const sel = opts.find((o) => o.selected);
+      return sel ? sel.value : "";
+    },
+  };
+  return Object.assign(el, attrs(el));
+}
+
+function makeForm(fields) {
+  return {
+    tagName: "FORM",
+    id: "",
+    name: "",
+    action: "",
+    method: "get",
+    getAttribute(name) {
+      return this[name] || "";
+    },
+    querySelectorAll() {
+      return fields;
+    },
+  };
+}
+
+function makeBody(children) {
+  return {
+    tagName: "BODY",
+    nodeType: 1,
+    children,
+    getAttribute() {
+      return null;
+    },
+    hasAttribute() {
+      return false;
+    },
+  };
+}
+
+function loadBridge({ body, queryResult, forms } = {}) {
+  Object.assign(console, REAL_CONSOLE);
+  globalThis.Node = { ELEMENT_NODE: 1, TEXT_NODE: 3 };
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    body: body || makeBody([]),
+    getElementById() {
+      return null;
+    },
+    querySelector() {
+      return queryResult ?? null;
+    },
+    querySelectorAll(selector) {
+      if (selector === "form") return forms || [];
+      return [];
+    },
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  (0, eval)(BRIDGE_SRC);
+  return globalThis.window.__PILOT__;
+}
+
+function skillsSelect(selected) {
+  return makeSelect({
+    multiple: true,
+    options: [
+      { value: "rust", selected: selected.includes("rust") },
+      { value: "js", selected: selected.includes("js") },
+      { value: "go", selected: selected.includes("go") },
+    ],
+  });
+}
+
+test("value reports every selected option of a multi-select (#158)", () => {
+  const el = skillsSelect(["rust", "js"]);
+  const pilot = loadBridge({ queryResult: el });
+  assert.equal(pilot.value({ selector: "select[name=skills]" }), "rust, js");
+});
+
+test("snapshot reports every selected option of a multi-select (#158)", () => {
+  const el = skillsSelect(["rust", "js"]);
+  const { elements } = loadBridge({ body: makeBody([el]) }).snapshot();
+  const combobox = elements.find((e) => e.role === "combobox");
+  assert.ok(combobox, "the <select> must appear in the snapshot");
+  assert.equal(typeof combobox.value, "string");
+  assert.equal(combobox.value, "rust, js");
+});
+
+test("value and snapshot match the forms dump of a multi-select (#158)", () => {
+  const el = skillsSelect(["rust", "js"]);
+  const pilot = loadBridge({
+    body: makeBody([el]),
+    queryResult: el,
+    forms: [makeForm([el])],
+  });
+  const field = pilot.formDump().forms[0].fields[0];
+  assert.deepEqual(field.value, ["rust", "js"]);
+  const joined = field.value.join(", ");
+  assert.equal(pilot.value({ selector: "select[name=skills]" }), joined);
+  const snap = pilot.snapshot().elements.find((e) => e.role === "combobox");
+  assert.equal(snap.value, joined);
+});
+
+test("value of a single-select is still the selected option", () => {
+  const el = makeSelect({
+    multiple: false,
+    options: [
+      { value: "rust", selected: true },
+      { value: "js", selected: false },
+    ],
+  });
+  const pilot = loadBridge({ queryResult: el });
+  assert.equal(pilot.value({ selector: "select" }), "rust");
+});
+
+test("value of a multi-select with nothing selected is empty", () => {
+  const el = skillsSelect([]);
+  const pilot = loadBridge({ queryResult: el });
+  assert.equal(pilot.value({ selector: "select[name=skills]" }), "");
+});
+
+test("value of a multi-select with one option has no separator", () => {
+  const el = skillsSelect(["js"]);
+  const pilot = loadBridge({ queryResult: el });
+  assert.equal(pilot.value({ selector: "select[name=skills]" }), "js");
+});

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -731,6 +731,9 @@ tauri-pilot html
 
 Get the current value of an input, textarea, or select element.
 
+For a `<select multiple>`, every selected option is joined with `", "`
+(the same display `forms` uses). A single-select is unchanged.
+
 ```bash
 tauri-pilot value <target>
 ```
@@ -740,6 +743,9 @@ tauri-pilot value <target>
 ```bash
 $ tauri-pilot value "#search"
 my-feature-branch
+
+$ tauri-pilot value 'select[name=skills]'
+rust, js
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `value` and `snapshot` now report every selected option of a `<select multiple>`, joined with `", "` like the `forms` CLI (`skills = "rust, js"`).
- `forms.dump` JSON is unchanged: it still returns the array.

## Motivation

`HTMLSelectElement.value` is only the first selected option. `forms` already walked `.options`, so a multi-select with `rust` and `js` both selected looked like `rust` from `value` / `snapshot`. Snapshot `value` stays a string (`Option<String>`, #120), so this joins rather than returning a JSON array.

Closes #158

## Changes

- Shared `selectedOptionValues` / `elementValue` in `bridge.js`, used by `value`, `snapshot`, and `forms.dump`.
- Node tests for two selected, one selected, none selected, single-select, and agreement with `forms.dump`.
- Changelog, CLI docs, and SKILL.md updated.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Tested manually with a Tauri app (if applicable)

Also: `node --test crates/tauri-plugin-pilot/js/*.test.mjs` (74 passed).

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `value` and `snapshot` so `<select multiple>` reports every selected option, joined with `", "` like the `forms` CLI, instead of only the first option from `HTMLSelectElement.value`. `forms.dump` still returns the JSON array. Closes #158.

<sup>Written for commit fa373d1ea8f71ee0faaafb79aa235bc11a96be10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Multi-select values reported by `value` and `snapshot` now include all selected options as a comma-separated string.
  - Single-select values and numeric value handling remain unchanged.
  - Form dumps continue returning multi-select values as an array.

- **Documentation**
  - Updated CLI and command reference documentation with multi-select behavior and examples.

- **Tests**
  - Added coverage for multi-select, single-selection, empty-selection, and single-option scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->