### PR TITLE
fix(bridge): report wait --gone as gone, not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `wait --gone` now prints `✓ gone` on success and times out with
+- `wait --gone` now returns `{ gone: true }` (`--json`, MCP, JSON-RPC;
+  CLI text: `✓ gone`) and times out with
   `Timeout waiting for <selector> to disappear`. Success used to
   return `{ found: true }` (CLI: `✓ found`) and the timeout said
   `Timeout waiting for <selector>`, both of which describe the
-  opposite of waiting for an element to disappear. [#159]
+  opposite of waiting for an element to disappear. Callers that
+  parsed `found` on the gone path must switch to `gone`. [#159]
 
 - `value` and `snapshot` now report every selected option of a
   `<select multiple>`, joined with `", "` like the `forms` CLI
@@ -775,3 +777,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#155]: https://github.com/mpiton/tauri-pilot/issues/155
 [#156]: https://github.com/mpiton/tauri-pilot/issues/156
 [#157]: https://github.com/mpiton/tauri-pilot/issues/157
+[#159]: https://github.com/mpiton/tauri-pilot/issues/159

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `wait --gone` now prints `✓ gone` on success and times out with
+  `Timeout waiting for <selector> to disappear`. Success used to
+  return `{ found: true }` (CLI: `✓ found`) and the timeout said
+  `Timeout waiting for <selector>`, both of which describe the
+  opposite of waiting for an element to disappear. [#159]
+
 - `value` and `snapshot` now report every selected option of a
   `<select multiple>`, joined with `", "` like the `forms` CLI
   (`skills = "rust, js"`). Both used `HTMLSelectElement.value`, which is

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -32,12 +32,10 @@ pub(crate) fn format_text(value: &serde_json::Value) {
         }
         return;
     }
-    // {ok: true} → "✓ ok", {found: true} → "✓ found"
-    for key in ["ok", "found", "cleared"] {
-        if value.get(key).and_then(serde_json::Value::as_bool) == Some(true) {
-            println!("{}", crate::style::success(key));
-            return;
-        }
+    // {ok: true} → "✓ ok", {gone: true} → "✓ gone", {found: true} → "✓ found"
+    if let Some(key) = text_status_flag(value) {
+        println!("{}", crate::style::success(key));
+        return;
     }
     // {status: "ok"} → "✓ ok", {status: "error"} → "✗ error"
     if let Some(status) = value.get("status").and_then(serde_json::Value::as_str) {
@@ -53,6 +51,14 @@ pub(crate) fn format_text(value: &serde_json::Value) {
         serde_json::Value::Null => {}
         other => println!("{other}"),
     }
+}
+
+/// First true flag printed as `✓ <key>`. `gone` precedes `found` so
+/// `wait --gone` prints `✓ gone` even if both flags are set (issue #159).
+fn text_status_flag(value: &serde_json::Value) -> Option<&'static str> {
+    ["ok", "gone", "found", "cleared"]
+        .into_iter()
+        .find(|key| value.get(*key).and_then(serde_json::Value::as_bool) == Some(true))
 }
 
 /// Format a snapshot result as an indented accessibility tree.
@@ -832,6 +838,16 @@ mod tests {
     #[test]
     fn test_format_text_found_does_not_panic() {
         format_text(&json!({"found": true}));
+    }
+
+    #[test]
+    fn test_text_status_flag_gone_is_gone_not_found() {
+        assert_eq!(text_status_flag(&json!({"gone": true})), Some("gone"));
+        assert_eq!(text_status_flag(&json!({"found": true})), Some("found"));
+        assert_eq!(
+            text_status_flag(&json!({"found": true, "gone": true})),
+            Some("gone")
+        );
     }
 
     #[test]

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -1290,13 +1290,19 @@
         return null;
       }
 
+      var result = gone ? { gone: true } : { found: true };
+      var target = selector || ref;
+      var timeoutMsg = gone
+        ? "Timeout waiting for " + target + " to disappear"
+        : "Timeout waiting for " + target;
+
       var el = check();
-      if (!gone && el) return res({ found: true });
-      if (gone && !el) return res({ found: true });
+      if (!gone && el) return res(result);
+      if (gone && !el) return res(result);
 
       var timer = setTimeout(function () {
         observer.disconnect();
-        rej(new Error("Timeout waiting for " + (selector || ref)));
+        rej(new Error(timeoutMsg));
       }, timeout);
 
       var observer = new MutationObserver(function () {
@@ -1304,11 +1310,11 @@
         if (!gone && found) {
           observer.disconnect();
           clearTimeout(timer);
-          res({ found: true });
+          res(result);
         } else if (gone && !found) {
           observer.disconnect();
           clearTimeout(timer);
-          res({ found: true });
+          res(result);
         }
       });
 

--- a/crates/tauri-plugin-pilot/js/bridge.wait.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.wait.test.mjs
@@ -83,6 +83,15 @@ test("wait for an existing element still reports found", async () => {
   });
 });
 
+test("wait reports found after the element is inserted", async () => {
+  let el = null;
+  const { pilot, fireMutation } = loadBridge(() => el);
+  const pending = pilot.wait({ selector: ".loaded", timeout: 1000 });
+  el = { tagName: "DIV" };
+  fireMutation();
+  assert.deepEqual(await pending, { found: true });
+});
+
 test("wait times out without a disappear suffix when the element never appears", async () => {
   const { pilot } = loadBridge(null);
   await assert.rejects(

--- a/crates/tauri-plugin-pilot/js/bridge.wait.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.wait.test.mjs
@@ -1,0 +1,96 @@
+// Dependency-free behavioural tests for bridge `wait` (#159).
+//
+// `wait --gone` used to resolve `{ found: true }` and reject with
+// `Timeout waiting for <sel>`, both of which describe the opposite of
+// waiting for an element to disappear.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.wait.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+function loadBridge(query) {
+  Object.assign(console, REAL_CONSOLE);
+  let observerCb;
+  globalThis.window = { fetch() {} };
+  globalThis.document = {
+    querySelector(selector) {
+      return typeof query === "function" ? query(selector) : query;
+    },
+    body: {},
+  };
+  globalThis.MutationObserver = class {
+    constructor(cb) {
+      observerCb = cb;
+    }
+    observe() {}
+    disconnect() {}
+  };
+  function XMLHttpRequestStub() {}
+  XMLHttpRequestStub.prototype.open = function () {};
+  XMLHttpRequestStub.prototype.send = function () {};
+  globalThis.XMLHttpRequest = XMLHttpRequestStub;
+  (0, eval)(BRIDGE_SRC);
+  return {
+    pilot: globalThis.window.__PILOT__,
+    fireMutation() {
+      if (observerCb) observerCb();
+    },
+  };
+}
+
+test("wait --gone on a missing element reports gone, not found (#159)", async () => {
+  const { pilot } = loadBridge(null);
+  assert.deepEqual(
+    await pilot.wait({ selector: "#already-removed", gone: true }),
+    { gone: true },
+  );
+});
+
+test("wait --gone times out with a disappear message (#159)", async () => {
+  const { pilot } = loadBridge({ tagName: "DIV" });
+  await assert.rejects(
+    () => pilot.wait({ selector: "#permanent-element", gone: true, timeout: 0 }),
+    /Timeout waiting for #permanent-element to disappear/,
+  );
+});
+
+test("wait --gone reports gone after the element is removed (#159)", async () => {
+  let el = { tagName: "DIV" };
+  const { pilot, fireMutation } = loadBridge(() => el);
+  const pending = pilot.wait({ selector: "#x", gone: true, timeout: 1000 });
+  el = null;
+  fireMutation();
+  assert.deepEqual(await pending, { gone: true });
+});
+
+test("wait for an existing element still reports found", async () => {
+  const { pilot } = loadBridge({ tagName: "DIV" });
+  assert.deepEqual(await pilot.wait({ selector: "#already-there" }), {
+    found: true,
+  });
+});
+
+test("wait times out without a disappear suffix when the element never appears", async () => {
+  const { pilot } = loadBridge(null);
+  await assert.rejects(
+    () => pilot.wait({ selector: "#missing", timeout: 0 }),
+    (err) => {
+      assert.match(err.message, /Timeout waiting for #missing/);
+      assert.doesNotMatch(err.message, /disappear/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- `wait --gone` now prints `✓ gone` on success and times out with `Timeout waiting for <selector> to disappear`.
- Appear waits are unchanged (`✓ found` / `Timeout waiting for <selector>`).

## Motivation

Success returned `{ found: true }` (CLI: `✓ found`) and the timeout said `Timeout waiting for <selector>`, both of which describe the opposite of waiting for an element to disappear.

Closes #159

## Changes

- Bridge `waitFor` resolves `{ gone: true }` on the gone path and appends `to disappear` to the timeout.
- CLI `format_text` treats `gone` as a status flag (before `found`) so `{ gone: true }` prints `✓ gone`.
- Node tests for immediate gone, mutation gone, gone timeout, and the appear regressions.
- Changelog updated.

`--json` and MCP now return `{ "gone": true }` instead of `{ "found": true }` for gone success.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Tested manually with a Tauri app (if applicable)

Also: `node --test crates/tauri-plugin-pilot/js/*.test.mjs` (79 passed).

## Checklist

- [x] No `.unwrap()` outside of tests
- [x] All new files are under 150 lines
- [x] Error handling uses `thiserror` (plugin) or `anyhow` (CLI)
- [x] Commit messages follow conventional commits (`feat:`, `fix:`, `refactor:`, etc.)

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `wait --gone` so success and timeout messages describe waiting for an element to disappear instead of appear, closing #159.

- `wait --gone` now resolves `{ gone: true }` and prints `✓ gone`; timeouts report `Timeout waiting for <selector> to disappear`.
- `--json`, MCP, and JSON-RPC responses change from `{ found: true }` to `{ gone: true }` on gone success — a breaking shape change for consumers parsing those fields.
- Adds behavioral tests for immediate gone, mutation gone, gone timeout, appear via mutation, appear timeout, and the unchanged appear path.

<sup>Written for commit 4e5b8feef2ab1de5b4ff923432442ecbd285826f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `wait --gone` success messages to clearly report when an element has disappeared.
  - Improved timeout messages to distinguish between waiting for an element to appear and waiting for it to disappear.
  - Preserved existing behavior and messaging for standard element-appearance waits.
  - Improved status reporting so disappearance results are shown accurately and consistently.
  - JSON, MCP, and JSON-RPC responses now report successful disappearance waits as `{ gone: true }`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->