### PR TITLE
fix(cli): storage get exits 1 on missing key (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `storage get` on a missing key now exits 1, like `assert` and `wait`, so
+  `storage get key || echo absent` works and a missing key is no longer
+  confused with a key holding an empty string. The `(not found)` notice moved
+  to stderr, leaving stdout for the value. `--json` still prints
+  `{"found": false}` and exits 1 too. The JSON-RPC and MCP responses are
+  unchanged. [#160]
+
 - `wait --gone` now returns `{ gone: true }` (`--json`, MCP, JSON-RPC;
   CLI text: `✓ gone`) and times out with
   `Timeout waiting for <selector> to disappear`. Success used to
@@ -782,3 +789,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#156]: https://github.com/mpiton/tauri-pilot/issues/156
 [#157]: https://github.com/mpiton/tauri-pilot/issues/157
 [#159]: https://github.com/mpiton/tauri-pilot/issues/159
+[#160]: https://github.com/mpiton/tauri-pilot/issues/160

--- a/SKILL.md
+++ b/SKILL.md
@@ -145,7 +145,7 @@ Exit code 0 + `ok` on success. Exit code 1 + `FAIL: ...` on failure. Prefer `ass
 
 | Command | Description |
 |---------|-------------|
-| `storage get <key>` | Read from localStorage |
+| `storage get <key>` | Read from localStorage (exits 1 if the key is missing) |
 | `storage set <key> <value>` | Write to localStorage |
 | `storage list` | Dump all key-value pairs |
 | `storage clear` | Clear all storage |

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -141,8 +141,7 @@ async fn main() -> Result<()> {
     }
 
     format_result(output_kind, &result, args.json)?;
-    // Only `storage get` answers with `found`; a missing key exits 1 (#160).
-    if matches!(output_kind, OutputKind::Storage) && result["found"] == false {
+    if matches!(output_kind, OutputKind::StorageGet) && result["found"] == false {
         std::process::exit(1);
     }
     Ok(())
@@ -156,6 +155,7 @@ enum OutputKind {
     Network,
     Watch,
     Storage,
+    StorageGet,
     Forms,
     Windows,
     Record,
@@ -171,6 +171,10 @@ impl From<&Command> for OutputKind {
             Command::Logs { .. } => OutputKind::Logs,
             Command::Network { .. } => OutputKind::Network,
             Command::Watch { .. } => OutputKind::Watch,
+            Command::Storage(StorageArgs {
+                action: StorageAction::Get { .. },
+                ..
+            }) => OutputKind::StorageGet,
             Command::Storage(..) => OutputKind::Storage,
             Command::Forms(..) => OutputKind::Forms,
             Command::Windows => OutputKind::Windows,
@@ -208,12 +212,11 @@ fn format_result(kind: OutputKind, result: &serde_json::Value, emit_json: bool) 
                 output::format_text(result);
             } else if result.get("entries").is_some() {
                 output::format_storage(result);
-            } else if result.get("found").is_some() {
-                output::format_storage_value(result);
             } else {
                 output::format_text(result);
             }
         }
+        OutputKind::StorageGet => output::format_storage_value(result),
         OutputKind::Forms => output::format_forms(result),
         OutputKind::Windows => output::format_windows(result),
         OutputKind::Record => {

--- a/crates/tauri-pilot-cli/src/main.rs
+++ b/crates/tauri-pilot-cli/src/main.rs
@@ -141,6 +141,10 @@ async fn main() -> Result<()> {
     }
 
     format_result(output_kind, &result, args.json)?;
+    // Only `storage get` answers with `found`; a missing key exits 1 (#160).
+    if matches!(output_kind, OutputKind::Storage) && result["found"] == false {
+        std::process::exit(1);
+    }
     Ok(())
 }
 

--- a/crates/tauri-pilot-cli/src/output.rs
+++ b/crates/tauri-pilot-cli/src/output.rs
@@ -232,19 +232,17 @@ pub(crate) fn format_network(value: &serde_json::Value) -> String {
 }
 
 /// Format a single storage value (from `storage get`).
+///
+/// A missing key prints `(not found)` on stderr so stdout only ever carries
+/// the stored value.
 pub(crate) fn format_storage_value(value: &serde_json::Value) {
-    let found = value
-        .get("found")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-    if !found {
-        println!("{}", crate::style::dim("(not found)"));
-        return;
-    }
-    if let Some(val) = value.get("value").and_then(serde_json::Value::as_str) {
-        println!("{}", strip_ansi(val));
-    } else {
-        println!("{}", crate::style::dim("(not found)"));
+    use owo_colors::{OwoColorize, Stream::Stderr};
+    match value.get("value").and_then(serde_json::Value::as_str) {
+        Some(val) if value["found"] == true => println!("{}", strip_ansi(val)),
+        _ => eprintln!(
+            "{}",
+            "(not found)".if_supports_color(Stderr, |t| t.dimmed())
+        ),
     }
 }
 

--- a/crates/tauri-pilot-cli/tests/storage_get_exit.rs
+++ b/crates/tauri-pilot-cli/tests/storage_get_exit.rs
@@ -1,9 +1,10 @@
 //! Regression test for issue #160: `storage get` on a missing key must exit
-//! non-zero, while a key holding an empty string still exits 0.
+//! non-zero, while a key holding a value (even an empty string) exits 0. The
+//! other `storage` subcommands must keep exiting 0.
 //!
 //! Same harness as `snapshot_save_json.rs`: a one-shot mock JSON-RPC unix
-//! socket server answers the single `storage.get` request, then the binary runs
-//! against that socket via `assert_cmd`.
+//! socket server answers the single request, then the binary runs against that
+//! socket via `assert_cmd`.
 
 #![cfg(unix)]
 
@@ -12,9 +13,19 @@ use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::process::Output;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use assert_cmd::Command;
+
+/// How long to wait for the mock server once the binary has exited.
+///
+/// The binary only exits after reading the reply, so the server is done or a
+/// few instructions away from it; the margin covers slow CI hosts. A binary
+/// that exits before connecting leaves the server blocked on `accept()`, and
+/// this bound turns that into a test failure instead of a hung suite.
+const SERVER_DONE_TIMEOUT: Duration = Duration::from_secs(10);
 
 static SOCK_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -28,57 +39,59 @@ fn unique_socket_path(tag: &str) -> PathBuf {
     ))
 }
 
-/// Run `storage get <key>` against a mock server answering with `result`.
-fn run_storage_get(tag: &str, result: serde_json::Value, json: bool) -> Output {
-    let socket = unique_socket_path(tag);
+/// Run `storage <args>` against a mock server that expects `method` and
+/// answers with `result`.
+fn run_storage(args: &[&str], method: &'static str, result: serde_json::Value) -> Output {
+    let socket = unique_socket_path("storage");
     let _ = std::fs::remove_file(&socket);
     let listener = UnixListener::bind(&socket).expect("bind mock socket");
-    let handle = thread::spawn(move || {
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
         let (stream, _) = listener.accept().expect("accept");
         let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
         let mut writer = stream;
         let mut line = String::new();
         reader.read_line(&mut line).expect("read line");
         let req: serde_json::Value = serde_json::from_str(line.trim()).expect("parse request");
-        assert_eq!(req["method"], "storage.get");
+        assert_eq!(req["method"], method);
         let resp = serde_json::json!({"jsonrpc": "2.0", "id": req["id"], "result": result});
         let mut bytes = serde_json::to_vec(&resp).expect("serialize");
         bytes.push(b'\n');
         writer.write_all(&bytes).expect("write");
         writer.flush().expect("flush");
+        let _ = done_tx.send(());
     });
 
-    let mut args = vec!["--socket", socket.to_str().expect("socket path is UTF-8")];
-    if json {
-        args.push("--json");
-    }
-    args.extend(["storage", "get", "some-key"]);
     let output = Command::cargo_bin("tauri-pilot")
         .expect("cargo_bin")
-        .args(&args)
+        .args([
+            "--socket",
+            socket.to_str().expect("socket path is UTF-8"),
+            "storage",
+        ])
+        .args(args)
         .output()
         .expect("run tauri-pilot");
 
-    // The binary connected and sent a request unless it failed before that
-    // (e.g. arg-parse error); do not block on accept() in that case.
-    if output.status.code() == Some(2) {
-        let _ = std::fs::remove_file(&socket);
+    // Disconnected means the server panicked (e.g. wrong method); timeout means
+    // the binary never connected.
+    let done = done_rx.recv_timeout(SERVER_DONE_TIMEOUT);
+    let _ = std::fs::remove_file(&socket);
+    if let Err(err) = done {
         panic!(
-            "binary exited before connecting.\n--- stderr ---\n{}",
+            "mock server did not answer {method}: {err}\n--- stderr ---\n{}",
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    handle.join().expect("mock server join");
-    let _ = std::fs::remove_file(&socket);
     output
 }
 
 #[test]
 fn storage_get_missing_key_exits_1_with_empty_stdout() {
-    let output = run_storage_get(
-        "storage-missing",
+    let output = run_storage(
+        &["get", "some-key"],
+        "storage.get",
         serde_json::json!({"found": false}),
-        false,
     );
 
     assert_eq!(output.status.code(), Some(1), "missing key must exit 1");
@@ -92,10 +105,10 @@ fn storage_get_missing_key_exits_1_with_empty_stdout() {
 
 #[test]
 fn storage_get_missing_key_json_exits_1() {
-    let output = run_storage_get(
-        "storage-missing-json",
+    let output = run_storage(
+        &["get", "some-key", "--json"],
+        "storage.get",
         serde_json::json!({"found": false}),
-        true,
     );
 
     assert_eq!(output.status.code(), Some(1), "missing key must exit 1");
@@ -105,12 +118,57 @@ fn storage_get_missing_key_json_exits_1() {
 
 #[test]
 fn storage_get_empty_value_exits_0() {
-    let output = run_storage_get(
-        "storage-empty",
+    let output = run_storage(
+        &["get", "some-key"],
+        "storage.get",
         serde_json::json!({"found": true, "value": ""}),
-        false,
     );
 
     assert!(output.status.success(), "present-but-empty key must exit 0");
     assert_eq!(output.stdout, b"\n");
+}
+
+#[test]
+fn storage_get_present_value_exits_0() {
+    let output = run_storage(
+        &["get", "some-key"],
+        "storage.get",
+        serde_json::json!({"found": true, "value": "dark"}),
+    );
+
+    assert!(output.status.success(), "present key must exit 0");
+    assert_eq!(output.stdout, b"dark\n");
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("(not found)"));
+}
+
+#[test]
+fn storage_get_present_value_json_exits_0() {
+    let hit = serde_json::json!({"found": true, "value": "dark"});
+    let output = run_storage(&["get", "some-key", "--json"], "storage.get", hit.clone());
+
+    assert!(output.status.success(), "present key must exit 0");
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(stdout, hit);
+}
+
+#[test]
+fn storage_set_exits_0() {
+    let output = run_storage(
+        &["set", "some-key", "dark"],
+        "storage.set",
+        serde_json::json!({"ok": true}),
+    );
+
+    assert!(output.status.success(), "storage set must exit 0");
+}
+
+#[test]
+fn storage_clear_exits_0() {
+    let output = run_storage(
+        &["clear"],
+        "storage.clear",
+        serde_json::json!({"cleared": true}),
+    );
+
+    assert!(output.status.success(), "storage clear must exit 0");
 }

--- a/crates/tauri-pilot-cli/tests/storage_get_exit.rs
+++ b/crates/tauri-pilot-cli/tests/storage_get_exit.rs
@@ -1,0 +1,116 @@
+//! Regression test for issue #160: `storage get` on a missing key must exit
+//! non-zero, while a key holding an empty string still exits 0.
+//!
+//! Same harness as `snapshot_save_json.rs`: a one-shot mock JSON-RPC unix
+//! socket server answers the single `storage.get` request, then the binary runs
+//! against that socket via `assert_cmd`.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::process::Output;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use assert_cmd::Command;
+
+static SOCK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let n = SOCK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!(
+        "/tmp/tauri-pilot-it-{}-{}-{}.sock",
+        tag,
+        std::process::id(),
+        n
+    ))
+}
+
+/// Run `storage get <key>` against a mock server answering with `result`.
+fn run_storage_get(tag: &str, result: serde_json::Value, json: bool) -> Output {
+    let socket = unique_socket_path(tag);
+    let _ = std::fs::remove_file(&socket);
+    let listener = UnixListener::bind(&socket).expect("bind mock socket");
+    let handle = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = stream;
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read line");
+        let req: serde_json::Value = serde_json::from_str(line.trim()).expect("parse request");
+        assert_eq!(req["method"], "storage.get");
+        let resp = serde_json::json!({"jsonrpc": "2.0", "id": req["id"], "result": result});
+        let mut bytes = serde_json::to_vec(&resp).expect("serialize");
+        bytes.push(b'\n');
+        writer.write_all(&bytes).expect("write");
+        writer.flush().expect("flush");
+    });
+
+    let mut args = vec!["--socket", socket.to_str().expect("socket path is UTF-8")];
+    if json {
+        args.push("--json");
+    }
+    args.extend(["storage", "get", "some-key"]);
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .args(&args)
+        .output()
+        .expect("run tauri-pilot");
+
+    // The binary connected and sent a request unless it failed before that
+    // (e.g. arg-parse error); do not block on accept() in that case.
+    if output.status.code() == Some(2) {
+        let _ = std::fs::remove_file(&socket);
+        panic!(
+            "binary exited before connecting.\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    handle.join().expect("mock server join");
+    let _ = std::fs::remove_file(&socket);
+    output
+}
+
+#[test]
+fn storage_get_missing_key_exits_1_with_empty_stdout() {
+    let output = run_storage_get(
+        "storage-missing",
+        serde_json::json!({"found": false}),
+        false,
+    );
+
+    assert_eq!(output.status.code(), Some(1), "missing key must exit 1");
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must carry only the value, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("(not found)"));
+}
+
+#[test]
+fn storage_get_missing_key_json_exits_1() {
+    let output = run_storage_get(
+        "storage-missing-json",
+        serde_json::json!({"found": false}),
+        true,
+    );
+
+    assert_eq!(output.status.code(), Some(1), "missing key must exit 1");
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(stdout, serde_json::json!({"found": false}));
+}
+
+#[test]
+fn storage_get_empty_value_exits_0() {
+    let output = run_storage_get(
+        "storage-empty",
+        serde_json::json!({"found": true, "value": ""}),
+        false,
+    );
+
+    assert!(output.status.success(), "present-but-empty key must exit 0");
+    assert_eq!(output.stdout, b"\n");
+}

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1200,10 +1200,17 @@ tauri-pilot storage <subcommand> [OPTIONS]
 $ tauri-pilot storage get "auth_token"
 eyJhbGciOiJIUzI1NiJ9...
 
-# A missing key prints "(not found)" on stderr and exits 1
+# A missing key prints "(not found)" on stderr and exits 1.
+# Connection and RPC errors exit 1 too, with "Error: ..." on stderr.
 $ tauri-pilot storage get "missing" || echo absent
 (not found)
 absent
+
+# With --json a missing key prints {"found": false} and still exits 1
+$ tauri-pilot storage get "missing" --json
+{
+  "found": false
+}
 
 # Write a key
 $ tauri-pilot storage set "theme" "dark"

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1200,6 +1200,11 @@ tauri-pilot storage <subcommand> [OPTIONS]
 $ tauri-pilot storage get "auth_token"
 eyJhbGciOiJIUzI1NiJ9...
 
+# A missing key prints "(not found)" on stderr and exits 1
+$ tauri-pilot storage get "missing" || echo absent
+(not found)
+absent
+
 # Write a key
 $ tauri-pilot storage set "theme" "dark"
 ✓ ok


### PR DESCRIPTION
• Exit code 1 distinguishes missing key from present-but-empty
• "(not found)" prints to stderr, leaving stdout for the value
• Regression test: missing key, empty value, present value
• `--json` still emits `{found: false}` on missing key
• JSON-RPC and MCP responses unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`storage get` on a missing key now exits 1 instead of 0, so missing keys are no longer confused with present-but-empty values and can be used in shell conditionals. The `(not found)` notice moved to stderr, leaving stdout for the value only.

**Notes**
- Scripts relying on exit 0 for missing keys need to handle exit 1.
- `--json` still prints `{"found": false}` but exits 1; connection and RPC errors exit 1 too.
- The exit is tied to the `storage get` command itself, so `storage set` and `storage clear` still exit 0.
- Regression tests cover missing, empty, and present keys in text and `--json` output.

<sup>Written for commit d9f99ba208d5783bc42507febb4b0ef03b501bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `storage get` now exits with status 1 when a key is missing or a connection/RPC error occurs.
  - Missing-key notices and errors are sent to stderr.
  - JSON output reports missing keys as `{"found": false}` while preserving JSON-RPC/MCP behavior.
  - Existing keys, including empty values, continue to exit successfully.

- **Documentation**
  - Updated CLI and command documentation to describe missing-key, JSON, and error output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->