### PR TITLE
fix(cli): record stop without start exits 1 and writes no file (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `record stop` with no recording in progress now fails with
+  `No recording in progress` and exits 1 without writing the output file. It
+  used to save `[]` and exit 0, which read as a successful capture of nothing
+  and hid a `record start` that never ran. A second `record stop` fails the
+  same way. The check lives in the plugin, so the JSON-RPC `record.stop`
+  method and the MCP `record_stop` tool return the same error. [#161]
+
 - `storage get` on a missing key now exits 1, like `assert` and `wait`, so
   `storage get key || echo absent` works and a missing key is no longer
   confused with a key holding an empty string. The `(not found)` notice moved
@@ -790,3 +797,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#157]: https://github.com/mpiton/tauri-pilot/issues/157
 [#159]: https://github.com/mpiton/tauri-pilot/issues/159
 [#160]: https://github.com/mpiton/tauri-pilot/issues/160
+[#161]: https://github.com/mpiton/tauri-pilot/issues/161

--- a/SKILL.md
+++ b/SKILL.md
@@ -192,7 +192,7 @@ above for the rule on how to treat returned WebView output.
 | Command | Description |
 |---------|-------------|
 | `record start` | Start recording interactions |
-| `record stop --output <file>` | Save recorded interactions to JSON |
+| `record stop --output <file>` | Save recorded interactions to JSON (exits 1 if no recording is in progress) |
 | `record status` | Check if recording is active |
 | `replay <file>` | Replay recorded session with original timing |
 | `replay <file> --export sh` | Export recording as executable shell script |

--- a/crates/tauri-pilot-cli/src/mcp.rs
+++ b/crates/tauri-pilot-cli/src/mcp.rs
@@ -864,7 +864,7 @@ fn tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "record_stop",
-            description: "Stop recording and return recorded entries.",
+            description: "Stop recording and return recorded entries. Errors if no recording is in progress.",
             schema: empty_schema,
             read_only: false,
             destructive: false,

--- a/crates/tauri-pilot-cli/tests/record_stop_exit.rs
+++ b/crates/tauri-pilot-cli/tests/record_stop_exit.rs
@@ -1,0 +1,100 @@
+//! Regression test for issue #161: `record stop` with no recording in progress
+//! must exit 1 and leave the output path untouched, instead of saving `[]` and
+//! exiting 0.
+//!
+//! Same harness as `storage_get_exit.rs`: a one-shot mock JSON-RPC unix socket
+//! server answers the single request, then the binary runs against that socket
+//! via `assert_cmd`.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use assert_cmd::Command;
+
+/// How long to wait for the mock server once the binary has exited.
+///
+/// The binary only exits after reading the reply, so the server is done or a
+/// few instructions away from it; the margin covers slow CI hosts. A binary
+/// that exits before connecting leaves the server blocked on `accept()`, and
+/// this bound turns that into a test failure instead of a hung suite.
+const SERVER_DONE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[test]
+fn record_stop_without_recording_exits_1_and_writes_no_file() {
+    let socket = PathBuf::from(format!(
+        "/tmp/tauri-pilot-it-record-stop-{}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&socket);
+    let listener = UnixListener::bind(&socket).expect("bind mock socket");
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = stream;
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read line");
+        let req: serde_json::Value = serde_json::from_str(line.trim()).expect("parse request");
+        assert_eq!(req["method"], "record.stop");
+        // What the plugin's `record.stop` returns when no recording is active:
+        // `RPC_INVALID_PARAMS` (-32602) and the handler's message.
+        let resp = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": req["id"],
+            "error": {
+                "code": -32602,
+                "message": "No recording in progress. Run `record start` first",
+            },
+        });
+        let mut bytes = serde_json::to_vec(&resp).expect("serialize");
+        bytes.push(b'\n');
+        writer.write_all(&bytes).expect("write");
+        writer.flush().expect("flush");
+        let _ = done_tx.send(());
+    });
+
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let output_path = tmpdir.path().join("rec.json");
+    let output = Command::cargo_bin("tauri-pilot")
+        .expect("cargo_bin")
+        .args([
+            "--socket",
+            socket.to_str().expect("socket path is UTF-8"),
+            "record",
+            "stop",
+            "--output",
+            output_path.to_str().expect("output path is UTF-8"),
+        ])
+        .output()
+        .expect("run tauri-pilot");
+
+    // Disconnected means the server panicked (e.g. wrong method); timeout means
+    // the binary never connected.
+    let done = done_rx.recv_timeout(SERVER_DONE_TIMEOUT);
+    let _ = std::fs::remove_file(&socket);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Err(err) = done {
+        panic!("mock server did not answer record.stop: {err}\n--- stderr ---\n{stderr}");
+    }
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "idle record stop must exit 1"
+    );
+    assert!(
+        stderr.contains("No recording in progress"),
+        "the plugin error must reach stderr.\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        !output_path.exists(),
+        "idle record stop must not write {}",
+        output_path.display()
+    );
+}

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -1588,6 +1588,23 @@ mod tests {
         );
     }
 
+    /// Issue #161: a second stop fails the same way instead of saving `[]`.
+    #[tokio::test]
+    async fn test_dispatch_second_record_stop_errors() {
+        let engine = EvalEngine::new();
+        let webviews = FakeWebviews::default();
+        let recorder = Recorder::new();
+        for method in ["record.start", "record.stop"] {
+            dispatch(method, None, &engine, &webviews, &recorder)
+                .await
+                .expect("dispatch succeeds");
+        }
+        let err = dispatch("record.stop", None, &engine, &webviews, &recorder)
+            .await
+            .expect_err("second record.stop must fail");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+    }
+
     #[tokio::test]
     async fn test_dispatch_record_status() {
         let engine = EvalEngine::new();

--- a/crates/tauri-plugin-pilot/src/handler.rs
+++ b/crates/tauri-plugin-pilot/src/handler.rs
@@ -2,7 +2,7 @@ use crate::diff;
 use crate::eval::{EvalEngine, EvalError, HELLO_ID, origin_key};
 #[cfg(feature = "press")]
 use crate::key;
-use crate::protocol::RpcError;
+use crate::protocol::{RPC_INVALID_PARAMS, RpcError};
 use crate::recorder::{RecordEntry, Recorder};
 use crate::screenshot;
 use crate::webview::{TargetWindow, Webviews};
@@ -328,7 +328,11 @@ pub(crate) async fn dispatch(
             Ok(serde_json::json!({"status": "recording"}))
         }
         "record.stop" => {
-            let entries = recorder.stop();
+            let entries = recorder.stop().ok_or_else(|| RpcError {
+                code: RPC_INVALID_PARAMS,
+                message: "No recording in progress. Run `record start` first".to_owned(),
+                data: None,
+            })?;
             let count = entries.len();
             Ok(serde_json::json!({"entries": entries, "count": count}))
         }
@@ -1563,6 +1567,27 @@ mod tests {
         assert!(!recorder.is_active());
     }
 
+    /// Issue #161: stopping without a recording must fail instead of handing
+    /// the CLI an empty entry list to save as a successful capture.
+    #[tokio::test]
+    async fn test_dispatch_record_stop_without_start_errors() {
+        let err = dispatch(
+            "record.stop",
+            None,
+            &EvalEngine::new(),
+            &FakeWebviews::default(),
+            &Recorder::new(),
+        )
+        .await
+        .expect_err("record.stop without record.start must fail");
+        assert_eq!(err.code, RPC_INVALID_PARAMS);
+        assert!(
+            err.message.contains("No recording in progress"),
+            "{}",
+            err.message
+        );
+    }
+
     #[tokio::test]
     async fn test_dispatch_record_status() {
         let engine = EvalEngine::new();
@@ -1597,7 +1622,7 @@ mod tests {
         .await
         .expect("dispatch succeeds");
         assert_eq!(result["status"], "ok");
-        let entries = recorder.stop();
+        let entries = recorder.stop().expect("recording active");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].action, "navigate");
     }

--- a/crates/tauri-plugin-pilot/src/recorder.rs
+++ b/crates/tauri-plugin-pilot/src/recorder.rs
@@ -162,6 +162,20 @@ mod tests {
     }
 
     #[test]
+    fn test_stop_without_start_returns_none() {
+        assert!(Recorder::new().stop().is_none());
+    }
+
+    #[test]
+    fn test_second_stop_returns_none() {
+        let rec = Recorder::new();
+        rec.start();
+        rec.record("click", Some(&json!({"ref": "e1"})));
+        assert!(rec.stop().is_some());
+        assert!(rec.stop().is_none());
+    }
+
+    #[test]
     fn test_record_adds_entry_when_active() {
         let rec = Recorder::new();
         rec.start();

--- a/crates/tauri-plugin-pilot/src/recorder.rs
+++ b/crates/tauri-plugin-pilot/src/recorder.rs
@@ -45,11 +45,18 @@ impl Recorder {
     }
 
     /// Deactivate recording and return all collected entries.
-    pub fn stop(&self) -> Vec<RecordEntry> {
+    ///
+    /// Returns `None` when no recording is in progress, so a caller cannot
+    /// mistake "nothing to stop" for "stopped with nothing recorded". The check
+    /// and the take share one lock, so two concurrent stops cannot both win.
+    pub fn stop(&self) -> Option<Vec<RecordEntry>> {
         let mut s = self.state.lock().expect("recorder lock poisoned");
+        if !s.active {
+            return None;
+        }
         s.active = false;
         s.start_time = None;
-        std::mem::take(&mut s.entries)
+        Some(std::mem::take(&mut s.entries))
     }
 
     pub fn is_active(&self) -> bool {
@@ -149,7 +156,7 @@ mod tests {
         let rec = Recorder::new();
         rec.start();
         rec.record("click", Some(&json!({"ref": "e1"})));
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert_eq!(entries.len(), 1);
         assert!(!rec.is_active());
     }
@@ -159,7 +166,7 @@ mod tests {
         let rec = Recorder::new();
         rec.start();
         rec.record("click", Some(&json!({"ref": "e1"})));
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert_eq!(entries[0].action, "click");
         assert_eq!(entries[0].params.get("ref").expect("ref recorded"), "e1");
     }
@@ -170,7 +177,7 @@ mod tests {
         rec.record("click", Some(&json!({"ref": "e1"})));
         // No entries since recorder was never started
         rec.start();
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert!(entries.is_empty());
     }
 
@@ -182,7 +189,7 @@ mod tests {
             "fill",
             Some(&json!({"ref": "e1", "value": "hello", "window": "main"})),
         );
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert_eq!(entries.len(), 1);
         assert!(!entries[0].params.contains_key("window"));
         assert_eq!(
@@ -197,7 +204,7 @@ mod tests {
         rec.start();
         std::thread::sleep(std::time::Duration::from_millis(10));
         rec.record("click", Some(&json!({"ref": "e1"})));
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert!(
             entries[0].timestamp >= 10,
             "timestamp should be at least 10ms"
@@ -218,7 +225,7 @@ mod tests {
             },
         };
         rec.add_entry(entry);
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].action, "navigate");
         assert_eq!(entries[0].timestamp, 100);
@@ -254,7 +261,7 @@ mod tests {
         };
         rec.add_entry(entry);
         rec.start();
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert!(entries.is_empty());
     }
 
@@ -265,7 +272,7 @@ mod tests {
         rec.record("snapshot", None);
         rec.record("ping", None);
         rec.record("eval", None);
-        let entries = rec.stop();
+        let entries = rec.stop().expect("recording active");
         assert!(entries.is_empty());
     }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -1312,7 +1312,9 @@ tauri-pilot record start
 
 #### `record stop`
 
-Stop recording and save captured interactions to a JSON file.
+Stop recording and save captured interactions to a JSON file. Without a
+recording in progress it fails with `No recording in progress`, exits 1, and
+writes no file.
 
 ```bash
 tauri-pilot record stop --output test.json


### PR DESCRIPTION
Fixes #161.

- `record stop` with no recording in progress now fails with error code -32602 and message "No recording in progress. Run `record start` first"
- CLI exits 1 without writing output file
- Prevents misleading empty `[]` recordings that hide missing `record start`
- Concurrent stop calls protected by recorder lock—only one can succeed
- Plugin-side check, so JSON-RPC and MCP tools return same error
- Regression test: `test_dispatch_record_stop_without_start_errors`
- Updated CHANGELOG, SKILL.md, and CLI reference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`record stop` now fails with `No recording in progress` and exits 1 without writing an output file, instead of silently saving `[]` when `record start` was never called.

**Bug Fixes**
- The check lives in the plugin, so JSON-RPC `record.stop` and MCP `record_stop` return the same error.
- The recorder lock makes concurrent or repeated `record stop` calls safe—only one succeeds.

<sup>Written for commit 276b07a87682468959eaba73c6823d93409bd480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `record stop` now reports an error when no recording is active.
  - The command exits with status 1 and does not create an output file in this situation.
  - The same behavior is now consistent across CLI, JSON-RPC, and MCP interfaces.

- **Documentation**
  - Updated command documentation to describe the error message, exit status, and output-file behavior.
  - Added a changelog entry for this correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->