### PR TITLE
fix(bridge): snapshot omits value="0" on plain <li> (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `snapshot` no longer prints `value="0"` on every `<li>`. The bridge read
+  `HTMLLIElement.value`, which reflects the `value` attribute and returns `0`
+  when it is absent, in an `<ol>` too. An `<li>` now carries a value only
+  when it has a `value` attribute (`<li value="3">` still shows
+  `value="3"`). `diff --ref` against a file saved with `snapshot --save`
+  before this fix reports every plain `<li>` as a `value` change until the
+  file is saved again. [#162]
+
 - `record stop` with no recording in progress now fails with
   `No recording in progress` and exits 1 without writing the output file. It
   used to save `[]` and exit 0, which read as a successful capture of nothing
@@ -798,3 +806,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#159]: https://github.com/mpiton/tauri-pilot/issues/159
 [#160]: https://github.com/mpiton/tauri-pilot/issues/160
 [#161]: https://github.com/mpiton/tauri-pilot/issues/161
+[#162]: https://github.com/mpiton/tauri-pilot/issues/162

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `snapshot` no longer prints `value="0"` on every `<li>`. The bridge read
   `HTMLLIElement.value`, which reflects the `value` attribute and returns `0`
-  when it is absent, in an `<ol>` too. An `<li>` now carries a value only
-  when it has a `value` attribute (`<li value="3">` still shows
-  `value="3"`). `diff --ref` against a file saved with `snapshot --save`
-  before this fix reports every plain `<li>` as a `value` change until the
-  file is saved again. [#162]
+  when the attribute is absent or does not parse as an integer, in an `<ol>`
+  too. An `<li>` now shows its `value` attribute as written, and no value
+  when the attribute is absent or empty (`<li value="3">` still shows
+  `value="3"`). `value` returns the same string, so `<li value="3">` gives
+  `"3"` instead of the number `3`, which `assert value` rejected with
+  `expected string response from server`. `diff --ref` against a file saved
+  with `snapshot --save` before this fix reports a `value` change on each
+  affected `<li>` until the file is saved again. [#162]
 
 - `record stop` with no recording in progress now fails with
   `No recording in progress` and exits 1 without writing the output file. It

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -455,7 +455,7 @@
         const name = getName(node);
         if (name) entry.name = name;
         // `value` is an IDL property whose type varies by element: a string for
-        // form controls, but a number for `<li>` (ordinal), `<progress>`, and
+        // form controls, but a number for `<li>`, `<progress>`, and
         // `<meter>`. Coerce to string so the wire format matches the plugin's
         // `SnapshotElement.value: Option<String>` contract (#120). Multi-select
         // joins every selected option (#158); a plain `<li>` has none (#162).
@@ -1079,14 +1079,14 @@
 
   // Display value for `value` / `snapshot`. Multi-select joins with `", "`
   // so the string matches the `forms` CLI (`skills = "rust, js"`). An `<li>`
-  // has a value only with a `value` attribute: `HTMLLIElement.value` reflects
-  // it and reads `0` when it is absent, even in an `<ol>` (#162). Other
-  // elements keep their IDL `.value`.
+  // reports its `value` attribute as written: `HTMLLIElement.value` reflects
+  // it as a `long` and reads `0` when it is absent, empty, or not an integer,
+  // even in an `<ol>` (#162). Other elements keep their IDL `.value`.
   function elementValue(el) {
     if (!el) return undefined;
     const tag = String(el.tagName || "").toLowerCase();
     if (tag === "select" && el.multiple) return selectedOptionValues(el).join(", ");
-    if (tag === "li" && !el.hasAttribute("value")) return undefined;
+    if (tag === "li") return el.getAttribute("value") || undefined;
     return el.value;
   }
 

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -458,7 +458,7 @@
         // form controls, but a number for `<li>` (ordinal), `<progress>`, and
         // `<meter>`. Coerce to string so the wire format matches the plugin's
         // `SnapshotElement.value: Option<String>` contract (#120). Multi-select
-        // joins every selected option (#158).
+        // joins every selected option (#158); a plain `<li>` has none (#162).
         const nodeVal = elementValue(node);
         if (nodeVal !== undefined && nodeVal !== "") entry.value = String(nodeVal);
         if (node.tagName === "INPUT") {
@@ -1078,13 +1078,16 @@
   }
 
   // Display value for `value` / `snapshot`. Multi-select joins with `", "`
-  // so the string matches the `forms` CLI (`skills = "rust, js"`). Other
-  // elements keep their IDL `.value` (including numeric `<li>` ordinals).
+  // so the string matches the `forms` CLI (`skills = "rust, js"`). An `<li>`
+  // has a value only with a `value` attribute: `HTMLLIElement.value` reflects
+  // it and reads `0` when it is absent, even in an `<ol>` (#162). Other
+  // elements keep their IDL `.value`.
   function elementValue(el) {
-    if (el && el.tagName && el.tagName.toLowerCase() === "select" && el.multiple) {
-      return selectedOptionValues(el).join(", ");
-    }
-    return el ? el.value : undefined;
+    if (!el) return undefined;
+    const tag = String(el.tagName || "").toLowerCase();
+    if (tag === "select" && el.multiple) return selectedOptionValues(el).join(", ");
+    if (tag === "li" && !el.hasAttribute("value")) return undefined;
+    return el.value;
   }
 
   function value(params) {

--- a/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
@@ -122,6 +122,20 @@ test("snapshot coerces an author-set <li value> to a string, 0 included", () => 
   assert.equal(named(elements, "second").value, "2");
 });
 
+test("snapshot reads <li value> as written, not the reflected long (#162)", () => {
+  // `.value` reads 0 when the attribute is empty or not an integer.
+  const blank = makeEl("li", { text: "blank", value: 0, attrs: { value: "" } });
+  const lang = makeEl("li", { text: "french", value: 0, attrs: { value: "fr" } });
+  const list = makeEl("ul", { children: [blank, lang] });
+  const body = makeEl("body", { children: [list] });
+  const pilot = loadBridge(body);
+
+  const { elements } = pilot.snapshot();
+
+  assert.equal("value" in named(elements, "blank"), false);
+  assert.equal(named(elements, "french").value, "fr");
+});
+
 test("snapshot preserves a genuine string value unchanged", () => {
   const input = makeEl("input", { value: "hello", attrs: { type: "text" } });
   const body = makeEl("body", { children: [input] });

--- a/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.snapshot.test.mjs
@@ -1,12 +1,15 @@
-// Dependency-free behavioural tests for the bridge `snapshot` (#120, #155).
+// Dependency-free behavioural tests for the bridge `snapshot` (#120, #155, #162).
 //
 // bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
 // *real* file into a minimal global mock so these tests exercise the shipping
 // code, not a re-implementation. The mock reproduces the DOM quirk behind #120:
-// `HTMLLIElement.value` is an IDL `long` (a number, the item's ordinal, default
-// `0`), so every `<li>` makes the bridge capture a JSON integer while the plugin
-// types `SnapshotElement.value` as `Option<String>` — `diff` then aborts with
+// `HTMLLIElement.value` is an IDL `long` (a number, default `0`), so every
+// `<li>` makes the bridge capture a JSON integer while the plugin types
+// `SnapshotElement.value` as `Option<String>` — `diff` then aborts with
 // `invalid type: integer 0, expected a string`.
+//
+// #162: that `0` is the default of the reflected `value` attribute, not the
+// item's ordinal, so the string fix printed `value="0"` on every plain `<li>`.
 //
 // #155: walk() only emits a node when getRole() is non-null, and ROLE_MAP has
 // no DIV entry. Interactive divs (draggable, contenteditable, click handlers)
@@ -88,11 +91,13 @@ function loadBridge(body) {
   return globalThis.window.__PILOT__;
 }
 
-test("snapshot never emits a numeric value for <li> items (#120)", () => {
-  // Every <li> outside an <ol> reports `.value === 0` (a number) per the DOM spec.
+test("snapshot omits value for an <li> without a value attribute (#120, #162)", () => {
+  // `HTMLLIElement.value` reflects the `value` attribute and reads `0` (a
+  // number) when it is absent, in a <ul> and in an <ol> alike.
   const li = (text) => makeEl("li", { text, value: 0 });
-  const list = makeEl("ul", { children: [li("a"), li("b"), li("c"), li("d")] });
-  const body = makeEl("body", { children: [list] });
+  const ul = makeEl("ul", { children: [li("a"), li("b")] });
+  const ol = makeEl("ol", { children: [li("c"), li("d")] });
+  const body = makeEl("body", { children: [ul, ol] });
   const pilot = loadBridge(body);
 
   const { elements } = pilot.snapshot();
@@ -100,27 +105,21 @@ test("snapshot never emits a numeric value for <li> items (#120)", () => {
 
   assert.equal(items.length, 4, "all four <li> should be captured");
   for (const item of items) {
-    assert.notEqual(
-      typeof item.value,
-      "number",
-      "value must serialise as a string, never a JSON number",
-    );
-    if (item.value !== undefined) {
-      assert.equal(typeof item.value, "string");
-    }
+    assert.equal("value" in item, false, `${item.name} must carry no value key`);
   }
 });
 
-test("snapshot coerces a numeric ordinal (<ol> <li value>) to a string", () => {
-  const li = makeEl("li", { text: "second", value: 2 });
-  const list = makeEl("ol", { children: [li] });
+test("snapshot coerces an author-set <li value> to a string, 0 included", () => {
+  const zero = makeEl("li", { text: "zeroth", value: 0, attrs: { value: "0" } });
+  const two = makeEl("li", { text: "second", value: 2, attrs: { value: "2" } });
+  const list = makeEl("ol", { children: [zero, two] });
   const body = makeEl("body", { children: [list] });
   const pilot = loadBridge(body);
 
   const { elements } = pilot.snapshot();
-  const item = elements.find((e) => e.role === "listitem");
 
-  assert.equal(item.value, "2");
+  assert.equal(named(elements, "zeroth").value, "0");
+  assert.equal(named(elements, "second").value, "2");
 });
 
 test("snapshot preserves a genuine string value unchanged", () => {

--- a/crates/tauri-plugin-pilot/js/bridge.value.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.value.test.mjs
@@ -180,3 +180,16 @@ test("value of a multi-select with one option has no separator", () => {
   const pilot = loadBridge({ queryResult: el });
   assert.equal(pilot.value({ selector: "select[name=skills]" }), "js");
 });
+
+// `HTMLLIElement.value` is a `long`: 3 for `value="3"`, 0 when absent (#162).
+function makeLi(_attrs, value) {
+  const el = { tagName: "LI", nodeType: 1, children: [], textContent: "", value, _attrs };
+  return Object.assign(el, attrs(el));
+}
+
+test("value of an <li> is its value attribute as a string (#162)", () => {
+  const liValue = (el) => loadBridge({ queryResult: el }).value({ selector: "li" });
+  assert.equal(liValue(makeLi({ value: "3" }, 3)), "3");
+  assert.equal(liValue(makeLi({ value: "0" }, 0)), "0");
+  assert.equal(liValue(makeLi({}, 0)), "");
+});

--- a/crates/tauri-plugin-pilot/src/diff.rs
+++ b/crates/tauri-plugin-pilot/src/diff.rs
@@ -167,8 +167,9 @@ mod tests {
 
     #[test]
     fn test_snapshot_element_deserializes_string_value() {
-        // Regression for #120: the bridge emits `value` as a string ("0" for a
-        // bare <li>), and the reference-snapshot parse in `diff` must accept it.
+        // Regression for #120: the bridge emits `value` as a string, and the
+        // reference-snapshot parse in `diff` must accept it. Reference files
+        // saved before #162 still carry "0" on every bare <li>.
         let json =
             r#"{"ref":"e31","role":"listitem","depth":3,"name":"single hyphen value","value":"0"}"#;
         let el: SnapshotElement =


### PR DESCRIPTION
snapshot emitted `value="0"` on every plain `<li>` because HTMLLIElement.value reflects the value attribute and returns 0 when it is absent or not an integer.

## Changes

- elementValue() reads an `<li>` value attribute as written; absent or empty gives no value
- snapshot no longer carries a value key for plain list items; `<li value="fr">` shows `fr`
- value command on a plain `<li>` still returns an empty string; `<li value="3">` now returns the string "3" instead of the number 3 that assert value rejected
- Tests: no value key for bare or empty `<li value>`, attribute kept as written when set, value command cases in bridge.value.test.mjs

## Notes

- diff --ref on pre-fix snapshot files reports each affected `<li>` as changed once
- Save reference again with updated bridge code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `snapshot` printing `value="0"` on every plain `<li>` because `HTMLLIElement.value` reflects the missing attribute as 0. `snapshot` and `value` now read the `value` attribute as written.

- `snapshot` omits the `value` key for `<li>` without a `value` attribute; `<li value="3">` still carries `value="3"`.
- `value` returns the attribute string (`"3"`, `"0"`), and an empty string for bare `<li>`.
- `diff --ref` against files saved before this fix reports each plain `<li>` as changed until the reference is saved again.

<sup>Written for commit 29a56f7e93b2c685c573fc264a8007cecb7f1223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshots incorrectly reporting `value="0"` for list items without an explicit `value` attribute.
  * Preserved explicit numeric list-item values, including `0`, as strings.
  * Maintained existing value handling for multi-select controls and other elements.

* **Documentation**
  * Added an unreleased changelog entry documenting the fix and related regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
