### PR TITLE
fix(bridge): capture uncaught errors and unhandled rejections (#188)

### DIFF
--- a/crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
@@ -1,0 +1,133 @@
+// Uncaught errors and unhandled rejections must reach the log buffer (#188).
+//
+// README step 6 of the AI-agent workflow is `tauri-pilot logs --level error`
+// to "check for JS errors", but the bridge only wrapped console.*. A page that
+// throws never calls console.error itself — the browser prints that — so the
+// one command documented for finding JS errors could not see them.
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// real file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// The bridge wraps fetch/XHR on load, so the mock has to carry both even
+// though these tests only care about the error listeners.
+function baseGlobals() {
+  Object.assign(console, REAL_CONSOLE);
+  globalThis.location = { href: "https://app.example/" };
+  globalThis.XMLHttpRequest = function () {};
+  globalThis.XMLHttpRequest.prototype.open = function () {};
+  globalThis.XMLHttpRequest.prototype.send = function () {};
+  globalThis.XMLHttpRequest.prototype.addEventListener = function () {};
+  globalThis.XMLHttpRequest.prototype.removeEventListener = function () {};
+  globalThis.document = { querySelector() { return null; } };
+  return {
+    fetch() { return Promise.resolve({ status: 200, headers: { get() { return "0"; } } }); },
+    location: globalThis.location,
+  };
+}
+
+function loadBridge() {
+  const listeners = Object.create(null);
+  globalThis.window = Object.assign(baseGlobals(), {
+    addEventListener(type, handler) {
+      (listeners[type] || (listeners[type] = [])).push(handler);
+    },
+    dispatch(type, event) {
+      for (const handler of listeners[type] || []) handler(event);
+    },
+  });
+
+  (0, eval)(BRIDGE_SRC);
+  return { pilot: globalThis.window.__PILOT__, win: globalThis.window };
+}
+
+test("an uncaught error lands in the log buffer at level error", () => {
+  const { pilot, win } = loadBridge();
+  win.dispatch("error", {
+    message: "Uncaught TypeError: x is not a function",
+    filename: "https://app.example/main.js",
+    lineno: 42,
+    colno: 7,
+  });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].args[0], "Uncaught TypeError: x is not a function");
+  assert.match(errors[0].source, /main\.js:42:7/);
+});
+
+test("an unhandled rejection lands in the log buffer at level error", () => {
+  const { pilot, win } = loadBridge();
+  const reason = new Error("boom");
+  reason.stack = "Error: boom\n    at https://app.example/main.js:9:1";
+  win.dispatch("unhandledrejection", { reason });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].args[0], /Unhandled rejection: .*boom/);
+});
+
+test("a rejection with a non-Error reason is still recorded", () => {
+  const { pilot, win } = loadBridge();
+  win.dispatch("unhandledrejection", { reason: "plain string" });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].args[0], /Unhandled rejection: plain string/);
+});
+
+test("a failed resource load is not reported as a JS error", () => {
+  const { pilot, win } = loadBridge();
+  // Resource errors (img/script 404) fire the same event type on window but
+  // carry no `message`; they are not JS errors and would be noise in `logs`.
+  win.dispatch("error", { target: { tagName: "IMG" } });
+
+  assert.deepEqual(pilot.consoleLogs({ level: "error" }), []);
+});
+
+test("uncaught errors share the id sequence with console entries", () => {
+  const { pilot, win } = loadBridge();
+  console.log("first");
+  win.dispatch("error", { message: "Uncaught Error: second", filename: "a.js", lineno: 1, colno: 1 });
+
+  const all = pilot.consoleLogs({});
+  assert.equal(all.length, 2);
+  assert.ok(all[1].id > all[0].id, "ids must stay monotonic across sources");
+  // sinceId polling must not skip the uncaught error
+  assert.equal(pilot.consoleLogs({ sinceId: all[0].id }).length, 1);
+});
+
+test("the bridge still loads when window has no addEventListener", () => {
+  globalThis.window = baseGlobals();
+
+  (0, eval)(BRIDGE_SRC);
+  assert.ok(globalThis.window.__PILOT__, "bridge must not throw without addEventListener");
+});
+
+test("console entries still record the calling site", () => {
+  // pushLog() is shared with the error listeners, but extractSource() skips a
+  // fixed frame count, so the console wrapper must keep calling it directly.
+  const { pilot } = loadBridge();
+  console.log("hello");
+
+  const [entry] = pilot.consoleLogs({});
+  assert.match(entry.source, /bridge\.errors\.test\.mjs/);
+});

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -86,20 +86,75 @@
     info: console.info.bind(console),
   };
 
+  function pushLog(level, args, source) {
+    const entry = {
+      id: ++_logIdCounter,
+      timestamp: Date.now(),
+      level: level,
+      args: args.map(serializeArg),
+      source: source || null,
+    };
+    _logs.push(entry);
+    if (_logs.length > MAX_LOGS) _logs.shift();
+    return entry;
+  }
+
   ['log', 'warn', 'error', 'info'].forEach(level => {
     console[level] = function(...args) {
-      const entry = {
-        id: ++_logIdCounter,
-        timestamp: Date.now(),
-        level: level,
-        args: args.map(serializeArg),
-        source: extractSource(),
-      };
-      _logs.push(entry);
-      if (_logs.length > MAX_LOGS) _logs.shift();
+      // extractSource() must be called from this frame: it skips a fixed
+      // number of stack frames to reach the caller.
+      pushLog(level, args, extractSource());
       _originalConsole[level].apply(console, args);
     };
   });
+
+  function describeReason(reason) {
+    if (reason instanceof Error) {
+      // The stack goes in `source`; keep the message readable in `args`.
+      return reason.name + ': ' + reason.message;
+    }
+    if (typeof reason === 'string') return reason;
+    try {
+      return JSON.stringify(reason);
+    } catch (_) {
+      return String(reason);
+    }
+  }
+
+  function stackSource(error) {
+    if (!error || typeof error.stack !== 'string') return null;
+    const lines = error.stack.split('\n');
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (line && line.trim() && !line.includes('__PILOT__')) return line.trim();
+    }
+    return null;
+  }
+
+  // Uncaught errors and unhandled rejections never pass through console.* --
+  // the browser prints those itself. Without these listeners the documented
+  // `logs --level error` workflow cannot see the failures it exists to find.
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('error', event => {
+      // Only script errors carry a message. Failed resource loads (<img>,
+      // <script> 404) raise a bare Event that does not bubble to window, but
+      // guard anyway rather than logging an empty entry.
+      if (!event || typeof event.message !== 'string') return;
+      const where = event.filename
+        ? event.filename + ':' + (event.lineno || 0) + ':' + (event.colno || 0)
+        : null;
+      pushLog('error', [event.message], stackSource(event.error) || where);
+    });
+
+    window.addEventListener('unhandledrejection', event => {
+      const reason = event && event.reason;
+      pushLog(
+        'error',
+        ['Unhandled rejection: ' + describeReason(reason)],
+        stackSource(reason)
+      );
+    });
+  }
 
   function consoleLogs(options) {
     let result = _logs.slice();


### PR DESCRIPTION
Fixes #188.

## Problem

The bridge builds its log buffer by wrapping `console.log/warn/error/info`, and nothing else. Uncaught exceptions and unhandled promise rejections never pass through `console.*` — the webview prints those itself — so they never enter the buffer.

`README.md` documents `tauri-pilot logs --level error` as step 6 of the agent workflow, "check for JS errors". Today that command cannot see a page that throws on load; it answers `No logs captured`, and an agent following the documented workflow concludes the page is fine.

I confirmed this in a clean `__PILOT__` instance (a same-origin child iframe with no app code loaded), so it is not an interaction with page scripts:

| probe | in `consoleLogs()` before this PR |
|---|---|
| `console.log(...)` | yes |
| uncaught `throw` | **no** |
| unhandled rejection | **no** |

## Change

Add `window` listeners for `error` and `unhandledrejection` that push level-`error` entries through the same buffer. Because they share the buffer they inherit `--level`, `--since-id`, `--since`, `--last`, `MAX_LOGS` trimming and `clear` for free, and the id sequence stays monotonic so `sinceId` polling cannot skip an uncaught error.

- Only script errors are recorded. Failed resource loads (`<img>`/`<script>` 404) raise a bare `Event` with no `message`; they do not bubble to `window`, but the guard is there anyway so a synthetic one cannot log an empty entry.
- `source` is the first non-bridge stack frame when the event carries an `Error`, otherwise `filename:lineno:colno`.
- Rejection entries read `Unhandled rejection: <name>: <message>`, with the stack in `source`.
- The listener registration is guarded by `typeof window.addEventListener === 'function'` so the existing dependency-free test mocks keep loading the bridge.

Entry construction moves into a shared `pushLog()`. The console wrapper still calls `extractSource()` from its own frame, since that helper skips a fixed number of stack frames to reach the caller — there is a regression test pinning that.

## Tests

New `js/bridge.errors.test.mjs`, written first (RED → GREEN), following the `bridge.network.test.mjs` pattern of eval-ing the real `bridge.js` into a minimal global mock:

- an uncaught error lands in the buffer at level `error`, with `filename:lineno:colno` as source
- an unhandled rejection lands at level `error`
- a rejection with a non-`Error` reason is still recorded
- a failed resource load is **not** reported as a JS error
- ids stay monotonic across sources, and `sinceId` does not skip an uncaught error
- the bridge still loads when `window` has no `addEventListener`
- console entries still record the calling site (guards the `pushLog` refactor)

```
node --test crates/tauri-plugin-pilot/js/*.test.mjs   # 89 pass, 0 fail
cargo test --workspace                                # 347 pass, 0 fail
cargo clippy --workspace -- -D warnings               # clean
cargo fmt --all -- --check                            # clean
```

Also verified the event shapes against the real runtime rather than only the mock — WebView2 on Windows 11, in a live app: the `error` event carries a string `message` plus `filename`/`lineno`/`colno`, and `event.error` / `event.reason` are real `Error`s with a string `stack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #188 so uncaught errors and unhandled rejections appear in `tauri-pilot logs --level error`. Previously these bypassed the console wrapper and a page that threw on load reported `No logs captured`; now they enter the same log buffer as console entries and respect `--level`, `--since-id`, `--since`, `--last`, and `clear`.

**What changed**
- Adds `window` `error` and `unhandledrejection` listeners logging at `error` level through a shared `pushLog()`.
- Ignores resource-load failures, which fire an `error` event with no message.
- Uses the first non-bridge stack frame when the event carries an `Error`, else `filename:lineno:colno`.
- Keeps uncaught errors on the same id sequence as console entries, so `sinceId` polling does not skip them.
- Records unusual rejection reasons legibly without throwing: cross-realm `Error`s, strings, symbols, functions, `NaN`/`Infinity`/`undefined`, circular and null-prototype objects, revoked proxies, and getters that throw; objects that spoof the `Error` tag keep their own fields, and non-string `Error` `name`/`message` values stay intact.
- Adds `bridge.errors.test.mjs` covering all of the above plus monotonic ids, and restores the mocked console and global state after tests.

<sup>Written for commit f397248837ad8183962045fd89287e7c553167e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Uncaught script errors and unhandled promise rejections are now captured in error logs.
  - Error details remain readable for circular, cross-context, or otherwise unusual values.
  - Logging is more resilient when error properties cannot be accessed safely.
  - Error entries now use the most relevant available stack information.
  - Console, resource, and application error entries continue to be tracked consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->