### PR TITLE
fix(bridge): keep console capture alive when page code replaces console.* (#190)

### DIFF
--- a/crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
+++ b/crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
@@ -1,0 +1,133 @@
+// Uncaught errors and unhandled rejections must reach the log buffer (#188).
+//
+// README step 6 of the AI-agent workflow is `tauri-pilot logs --level error`
+// to "check for JS errors", but the bridge only wrapped console.*. A page that
+// throws never calls console.error itself — the browser prints that — so the
+// one command documented for finding JS errors could not see them.
+//
+// bridge.js is an IIFE that attaches its API to `window.__PILOT__`. We load the
+// real file into a minimal global mock so these tests exercise the shipping
+// code, not a re-implementation.
+//
+// Run: node --test crates/tauri-plugin-pilot/js/bridge.errors.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_SRC = readFileSync(join(here, "bridge.js"), "utf8");
+
+const REAL_CONSOLE = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  info: console.info.bind(console),
+};
+
+// The bridge wraps fetch/XHR on load, so the mock has to carry both even
+// though these tests only care about the error listeners.
+function baseGlobals() {
+  Object.assign(console, REAL_CONSOLE);
+  globalThis.location = { href: "https://app.example/" };
+  globalThis.XMLHttpRequest = function () {};
+  globalThis.XMLHttpRequest.prototype.open = function () {};
+  globalThis.XMLHttpRequest.prototype.send = function () {};
+  globalThis.XMLHttpRequest.prototype.addEventListener = function () {};
+  globalThis.XMLHttpRequest.prototype.removeEventListener = function () {};
+  globalThis.document = { querySelector() { return null; } };
+  return {
+    fetch() { return Promise.resolve({ status: 200, headers: { get() { return "0"; } } }); },
+    location: globalThis.location,
+  };
+}
+
+function loadBridge() {
+  const listeners = Object.create(null);
+  globalThis.window = Object.assign(baseGlobals(), {
+    addEventListener(type, handler) {
+      (listeners[type] || (listeners[type] = [])).push(handler);
+    },
+    dispatch(type, event) {
+      for (const handler of listeners[type] || []) handler(event);
+    },
+  });
+
+  (0, eval)(BRIDGE_SRC);
+  return { pilot: globalThis.window.__PILOT__, win: globalThis.window };
+}
+
+test("an uncaught error lands in the log buffer at level error", () => {
+  const { pilot, win } = loadBridge();
+  win.dispatch("error", {
+    message: "Uncaught TypeError: x is not a function",
+    filename: "https://app.example/main.js",
+    lineno: 42,
+    colno: 7,
+  });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].args[0], "Uncaught TypeError: x is not a function");
+  assert.match(errors[0].source, /main\.js:42:7/);
+});
+
+test("an unhandled rejection lands in the log buffer at level error", () => {
+  const { pilot, win } = loadBridge();
+  const reason = new Error("boom");
+  reason.stack = "Error: boom\n    at https://app.example/main.js:9:1";
+  win.dispatch("unhandledrejection", { reason });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].args[0], /Unhandled rejection: .*boom/);
+});
+
+test("a rejection with a non-Error reason is still recorded", () => {
+  const { pilot, win } = loadBridge();
+  win.dispatch("unhandledrejection", { reason: "plain string" });
+
+  const errors = pilot.consoleLogs({ level: "error" });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].args[0], /Unhandled rejection: plain string/);
+});
+
+test("a failed resource load is not reported as a JS error", () => {
+  const { pilot, win } = loadBridge();
+  // Resource errors (img/script 404) fire the same event type on window but
+  // carry no `message`; they are not JS errors and would be noise in `logs`.
+  win.dispatch("error", { target: { tagName: "IMG" } });
+
+  assert.deepEqual(pilot.consoleLogs({ level: "error" }), []);
+});
+
+test("uncaught errors share the id sequence with console entries", () => {
+  const { pilot, win } = loadBridge();
+  console.log("first");
+  win.dispatch("error", { message: "Uncaught Error: second", filename: "a.js", lineno: 1, colno: 1 });
+
+  const all = pilot.consoleLogs({});
+  assert.equal(all.length, 2);
+  assert.ok(all[1].id > all[0].id, "ids must stay monotonic across sources");
+  // sinceId polling must not skip the uncaught error
+  assert.equal(pilot.consoleLogs({ sinceId: all[0].id }).length, 1);
+});
+
+test("the bridge still loads when window has no addEventListener", () => {
+  globalThis.window = baseGlobals();
+
+  (0, eval)(BRIDGE_SRC);
+  assert.ok(globalThis.window.__PILOT__, "bridge must not throw without addEventListener");
+});
+
+test("console entries still record the calling site", () => {
+  // pushLog() is shared with the error listeners, but extractSource() skips a
+  // fixed frame count, so the console wrapper must keep calling it directly.
+  const { pilot } = loadBridge();
+  console.log("hello");
+
+  const [entry] = pilot.consoleLogs({});
+  assert.match(entry.source, /bridge\.errors\.test\.mjs/);
+});

--- a/crates/tauri-plugin-pilot/js/bridge.js
+++ b/crates/tauri-plugin-pilot/js/bridge.js
@@ -86,20 +86,75 @@
     info: console.info.bind(console),
   };
 
+  function pushLog(level, args, source) {
+    const entry = {
+      id: ++_logIdCounter,
+      timestamp: Date.now(),
+      level: level,
+      args: args.map(serializeArg),
+      source: source || null,
+    };
+    _logs.push(entry);
+    if (_logs.length > MAX_LOGS) _logs.shift();
+    return entry;
+  }
+
   ['log', 'warn', 'error', 'info'].forEach(level => {
     console[level] = function(...args) {
-      const entry = {
-        id: ++_logIdCounter,
-        timestamp: Date.now(),
-        level: level,
-        args: args.map(serializeArg),
-        source: extractSource(),
-      };
-      _logs.push(entry);
-      if (_logs.length > MAX_LOGS) _logs.shift();
+      // extractSource() must be called from this frame: it skips a fixed
+      // number of stack frames to reach the caller.
+      pushLog(level, args, extractSource());
       _originalConsole[level].apply(console, args);
     };
   });
+
+  function describeReason(reason) {
+    if (reason instanceof Error) {
+      // The stack goes in `source`; keep the message readable in `args`.
+      return reason.name + ': ' + reason.message;
+    }
+    if (typeof reason === 'string') return reason;
+    try {
+      return JSON.stringify(reason);
+    } catch (_) {
+      return String(reason);
+    }
+  }
+
+  function stackSource(error) {
+    if (!error || typeof error.stack !== 'string') return null;
+    const lines = error.stack.split('\n');
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (line && line.trim() && !line.includes('__PILOT__')) return line.trim();
+    }
+    return null;
+  }
+
+  // Uncaught errors and unhandled rejections never pass through console.* --
+  // the browser prints those itself. Without these listeners the documented
+  // `logs --level error` workflow cannot see the failures it exists to find.
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('error', event => {
+      // Only script errors carry a message. Failed resource loads (<img>,
+      // <script> 404) raise a bare Event that does not bubble to window, but
+      // guard anyway rather than logging an empty entry.
+      if (!event || typeof event.message !== 'string') return;
+      const where = event.filename
+        ? event.filename + ':' + (event.lineno || 0) + ':' + (event.colno || 0)
+        : null;
+      pushLog('error', [event.message], stackSource(event.error) || where);
+    });
+
+    window.addEventListener('unhandledrejection', event => {
+      const reason = event && event.reason;
+      pushLog(
+        'error',
+        ['Unhandled rejection: ' + describeReason(reason)],
+        stackSource(reason)
+      );
+    });
+  }
 
   function consoleLogs(options) {
     let result = _logs.slice();


### PR DESCRIPTION
Fixes #190.

> **Stacked on #189** — both touch the same block of `bridge.js`, so this branch builds on that one to avoid a conflict. Only the second commit (`fix(bridge): keep console capture alive...`) belongs to this PR. Happy to rebase onto `main` if #189 is not going in, or to squash the two together if you would rather take them as one change.

## Problem

Capture is installed with a plain `console[level] = wrapper` at document-start. The first piece of page code that assigns `console.log` **without** chaining to what was already there removes pilot from the chain for the rest of the session.

Nothing reports it. `logs` just answers `No logs captured`, which is indistinguishable from a quiet app — so the failure mode is an agent confidently reading an empty log and concluding the page is fine.

Isolated in a clean `__PILOT__` instance (a same-origin child iframe with no app code loaded):

| probe | capture still working before this PR |
|---|---|
| later wrapper that **chains** to the previous `console.log` | yes |
| later assignment that does **not** chain | **no**, permanently |

Whether `logs` works therefore depends entirely on whether unrelated page code happens to chain. In the app I hit this on, extensions re-wrap console during startup, so `logs` was already dead before the first command ran.

## Change

Install an accessor rather than a value:

- the **getter** always returns pilot's wrapper, so it cannot be displaced;
- the **setter** treats an assignment as "call this next" and pushes it onto a chain.

Stacking is what keeps chaining wrappers working. A wrapper that calls back through the `console.*` it captured re-enters pilot's wrapper; each re-entry walks one step further down the chain, so wrappers installed earlier still run and the bottom of the chain is the real console. That same walk is what makes the common "save it and call it back" shape terminate instead of recursing forever, and the entry is recorded once per outermost call.

Edge cases: assigning a non-function is ignored; writing the wrapper back over itself is ignored, so a save-then-restore round trip changes nothing; if `console` is frozen, `defineProperty` throws and we fall back to the old plain assignment, which is still better than no capture.

## Trade-offs, so they are on the record

- Reading `console.log` after assigning to it returns pilot's wrapper, not the assigned function. Calls still reach the assigned function. Code that compares `console.log === myFn` would see `false`.
- The chain grows by one entry per assignment. Real apps assign a handful of times at startup; code that re-wraps console in a hot path would grow it without bound. Say the word if you want a cap.

## Tests

New `js/bridge.console.test.mjs`, written first (RED → GREEN). Three failed before the change and four passed — the four are the chaining behaviours that must not regress:

- capture survives a wrapper that does not chain *(was failing)*
- capture survives a wrapper that does chain, recorded exactly once
- a wrapper that calls back through console does not recurse forever, and logs once
- two stacked wrappers both run, in order, and capture still works
- restoring a saved `console.log` keeps capture alive
- assigning a non-function falls back to the original console *(was failing)*
- each level keeps its own downstream — replacing `warn` must not divert `log` *(was failing)*

```
node --test crates/tauri-plugin-pilot/js/*.test.mjs   # 96 pass, 0 fail
cargo test --workspace                                # 347 pass, 0 fail
cargo clippy --workspace -- -D warnings               # clean
cargo fmt --all -- --check                            # clean
```

Also validated against the real runtime rather than only the mock — WebView2 on Windows 11, in a live app: `defineProperty` on `console` holds, a non-chaining replacement no longer stops capture, and a wrapper stacked on top of it still reaches the one below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Console capture now survives page code that overwrites `console.*`, and uncaught errors and unhandled rejections are recorded in the log buffer at level `error`.

**Bug Fixes**
- Capture installs as an accessor: the getter always returns the wrapper, page assignments stack onto a chain, save-then-restore round trips change nothing, and a frozen console no longer aborts the bridge load.
- Each chain depth gets its own stable view, so deferred calls to a saved console reference record once instead of recursing; assigning one level over another records only on the assigned level, and two levels aliased to each other no longer recurse.
- Pilot's own views are recognized by identity, so page code cannot fake the marker.
- `error` and `unhandledrejection` listeners push through the same buffer, so they respect `--level`, `--since-id`, and `clear`; failed resource loads are skipped.
- Hostile or unusual rejection reasons — revoked proxies, cross-realm Errors, functions, symbols — are still recorded legibly, and an error's stack frame takes precedence over `filename:lineno`.

<sup>Written for commit 4e5f0cf5005975500678681ef9a5d9ad3727596e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/tauri-pilot/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

